### PR TITLE
Class aware decorators for task array functions

### DIFF
--- a/columnflow/calibration/__init__.py
+++ b/columnflow/calibration/__init__.py
@@ -13,56 +13,63 @@ from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
 
 
-Calibrator = TaskArrayFunction.derive("Calibrator")
+class Calibrator(TaskArrayFunction):
+
+    @classmethod
+    def calibrator(
+        cls,
+        func: Callable | None = None,
+        bases=(),
+        mc_only: bool = False,
+        data_only: bool = False,
+        **kwargs,
+    ) -> DerivableMeta | Callable:
+        """
+        Decorator for creating a new :py:class:`Calibrator` subclass with additional, optional
+        *bases* and attaching the decorated function to it as ``call_func``. When *mc_only*
+        (*data_only*) is *True*, the calibrator is skipped and not considered by other calibrators,
+        selectors and producers in case they are evalauted on an :py:class:`order.Dataset` whose
+        ``is_mc`` attribute is *False* (*True*).
+
+        All additional *kwargs* are added as class members of the new subclasses.
+        """
+        def decorator(func: Callable) -> DerivableMeta:
+            # create the class dict
+            cls_dict = {"call_func": func}
+            cls_dict.update(kwargs)
+
+            # get the module name
+            frame = inspect.stack()[1]
+            module = inspect.getmodule(frame[0])
+
+            # get the calibrator name
+            cls_name = cls_dict.pop("cls_name", func.__name__)
+
+            # optionally add skip function
+            if mc_only and data_only:
+                raise Exception(f"calibrator {cls_name} received both mc_only and data_only")
+            if mc_only or data_only:
+                if cls_dict.get("skip_func"):
+                    raise Exception(
+                        f"calibrator {cls_name} received custom skip_func, but mc_only or data_only are set",
+                    )
+
+                def skip_func(self):
+                    # never skip when there is not dataset
+                    if not getattr(self, "dataset_inst", None):
+                        return False
+
+                    return self.dataset_inst.is_mc != bool(mc_only)
+
+                cls_dict["skip_func"] = skip_func
+
+            # create the subclass
+            subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
+
+            return subclass
+
+        return decorator(func) if func else decorator
 
 
-def calibrator(
-    func: Callable | None = None,
-    bases=(),
-    mc_only: bool = False,
-    data_only: bool = False,
-    **kwargs,
-) -> DerivableMeta | Callable:
-    """
-    Decorator for creating a new :py:class:`Calibrator` subclass with additional, optional *bases*
-    and attaching the decorated function to it as ``call_func``. When *mc_only* (*data_only*) is
-    *True*, the calibrator is skipped and not considered by other calibrators, selectors and
-    producers in case they are evalauted on an :py:class:`order.Dataset` whose ``is_mc`` attribute
-    is *False* (*True*).
-
-    All additional *kwargs* are added as class members of the new subclasses.
-    """
-    def decorator(func: Callable) -> DerivableMeta:
-        # create the class dict
-        cls_dict = {"call_func": func}
-        cls_dict.update(kwargs)
-
-        # get the module name
-        frame = inspect.stack()[1]
-        module = inspect.getmodule(frame[0])
-
-        # get the calibrator name
-        cls_name = cls_dict.pop("cls_name", func.__name__)
-
-        # optionally add skip function
-        if mc_only and data_only:
-            raise Exception(f"calibrator {cls_name} received both mc_only and data_only")
-        if mc_only or data_only:
-            if cls_dict.get("skip_func"):
-                raise Exception(f"calibrator {cls_name} received custom skip_func, but mc_only or data_only are set")
-
-            def skip_func(self):
-                # never skip when there is not dataset
-                if not getattr(self, "dataset_inst", None):
-                    return False
-
-                return self.dataset_inst.is_mc != bool(mc_only)
-
-            cls_dict["skip_func"] = skip_func
-
-        # create the subclass
-        subclass = Calibrator.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
-
-        return subclass
-
-    return decorator(func) if func else decorator
+# shorthand
+calibrator = Calibrator.calibrator

--- a/columnflow/production/__init__.py
+++ b/columnflow/production/__init__.py
@@ -13,56 +13,63 @@ from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
 
 
-Producer = TaskArrayFunction.derive("Producer")
+class Producer(TaskArrayFunction):
+
+    @classmethod
+    def producer(
+        cls,
+        func: Callable | None = None,
+        bases=(),
+        mc_only: bool = False,
+        data_only: bool = False,
+        **kwargs,
+    ) -> DerivableMeta | Callable:
+        """
+        Decorator for creating a new :py:class:`Producer` subclass with additional, optional *bases*
+        and attaching the decorated function to it as ``call_func``. When *mc_only* (*data_only*) is
+        *True*, the producer is skipped and not considered by other calibrators, selectors and
+        producers in case they are evalauted on an :py:class:`order.Dataset` whose ``is_mc``
+        attribute is *False* (*True*).
+
+        All additional *kwargs* are added as class members of the new subclasses.
+        """
+        def decorator(func: Callable) -> DerivableMeta:
+            # create the class dict
+            cls_dict = {"call_func": func}
+            cls_dict.update(kwargs)
+
+            # get the module name
+            frame = inspect.stack()[1]
+            module = inspect.getmodule(frame[0])
+
+            # get the producer name
+            cls_name = cls_dict.pop("cls_name", func.__name__)
+
+            # optionally add skip function
+            if mc_only and data_only:
+                raise Exception(f"producer {cls_name} received both mc_only and data_only")
+            if mc_only or data_only:
+                if cls_dict.get("skip_func"):
+                    raise Exception(
+                        f"producer {cls_name} received custom skip_func, but mc_only or data_only are set",
+                    )
+
+                def skip_func(self):
+                    # never skip when there is not dataset
+                    if not getattr(self, "dataset_inst", None):
+                        return False
+
+                    return self.dataset_inst.is_mc != bool(mc_only)
+
+                cls_dict["skip_func"] = skip_func
+
+            # create the subclass
+            subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
+
+            return subclass
+
+        return decorator(func) if func else decorator
 
 
-def producer(
-    func: Callable | None = None,
-    bases=(),
-    mc_only: bool = False,
-    data_only: bool = False,
-    **kwargs,
-) -> DerivableMeta | Callable:
-    """
-    Decorator for creating a new :py:class:`Producer` subclass with additional, optional *bases* and
-    attaching the decorated function to it as ``call_func``. When *mc_only* (*data_only*) is *True*,
-    the producer is skipped and not considered by other calibrators, selectors and producers in case
-    they are evalauted on an :py:class:`order.Dataset` whose ``is_mc`` attribute is *False*
-    (*True*).
-
-    All additional *kwargs* are added as class members of the new subclasses.
-    """
-    def decorator(func: Callable) -> DerivableMeta:
-        # create the class dict
-        cls_dict = {"call_func": func}
-        cls_dict.update(kwargs)
-
-        # get the module name
-        frame = inspect.stack()[1]
-        module = inspect.getmodule(frame[0])
-
-        # get the producer name
-        cls_name = cls_dict.pop("cls_name", func.__name__)
-
-        # optionally add skip function
-        if mc_only and data_only:
-            raise Exception(f"producer {cls_name} received both mc_only and data_only")
-        if mc_only or data_only:
-            if cls_dict.get("skip_func"):
-                raise Exception(f"producer {cls_name} received custom skip_func, but mc_only or data_only are set")
-
-            def skip_func(self):
-                # never skip when there is not dataset
-                if not getattr(self, "dataset_inst", None):
-                    return False
-
-                return self.dataset_inst.is_mc != bool(mc_only)
-
-            cls_dict["skip_func"] = skip_func
-
-        # create the subclass
-        subclass = Producer.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
-
-        return subclass
-
-    return decorator(func) if func else decorator
+# shorthand
+producer = Producer.producer

--- a/columnflow/production/cms/scale.py
+++ b/columnflow/production/cms/scale.py
@@ -65,7 +65,9 @@ class _ScaleWeightBase(Producer):
 
 
 @_ScaleWeightBase.producer(
-    uses={"LHEScaleWeight"},
+    uses={
+        "nLHEScaleWeight", "LHEScaleWeight",
+    },
     produces={
         "mur_weight", "mur_weight_up", "mur_weight_down",
         "muf_weight", "muf_weight_up", "muf_weight_down",
@@ -162,8 +164,12 @@ def murmuf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 
 
 @_ScaleWeightBase.producer(
-    uses={"LHEScaleWeight"},
-    produces={"murf_envelope_weight", "murf_envelope_weight_up", "murf_envelope_weight_down"},
+    uses={
+        "nLHEScaleWeight", "LHEScaleWeight",
+    },
+    produces={
+        "murf_envelope_weight", "murf_envelope_weight_up", "murf_envelope_weight_down",
+    },
     # only run on mc
     mc_only=True,
 )

--- a/columnflow/production/cms/scale.py
+++ b/columnflow/production/cms/scale.py
@@ -8,7 +8,7 @@ import functools
 
 import law
 
-from columnflow.production import Producer, producer
+from columnflow.production import Producer
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column
 from columnflow.columnar_util import DotDict
@@ -23,7 +23,48 @@ logger = law.logger.get_logger(__name__)
 set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 
 
-@producer(
+class _ScaleWeightBase(Producer):
+    """
+    Common base class for the scale weight producers below that join a setup function.
+    """
+
+    def setup_func(self, reqs: dict, inputs: dict) -> None:
+        # named weight indices
+        self.indices_9 = DotDict(
+            mur_down_muf_down=0,
+            mur_down_muf_nom=1,
+            mur_down_muf_up=2,
+            mur_nom_muf_down=3,
+            mur_nom_muf_nom=4,
+            mur_nom_muf_up=5,
+            mur_up_muf_down=6,
+            mur_up_muf_nom=7,
+            mur_up_muf_up=8,
+        )
+
+        # named weight indices for cases where only 8 of the exist
+        # (expecting no nominal value and all above being shifted down by one)
+        self.indices_8 = DotDict({
+            key: index if index <= self.indices_9.mur_nom_muf_nom else index - 1
+            for key, index in self.indices_9.items()
+            if key != "mur_nom_muf_nom"
+        })
+
+        # for convenience, declare some meaningful clear names for the weights
+        # here instead of the very technical names like mur_nom_muf_up
+        self.clearnames = DotDict(
+            # decorrelated weights
+            mur_weight_up="mur_up_muf_nom",
+            mur_weight_down="mur_down_muf_nom",
+            muf_weight_up="mur_nom_muf_up",
+            muf_weight_down="mur_nom_muf_down",
+            # fully-correlated names
+            murmuf_weight_up="mur_up_muf_up",
+            murmuf_weight_down="mur_down_muf_down",
+        )
+
+
+@_ScaleWeightBase.producer(
     uses={"LHEScaleWeight"},
     produces={
         "mur_weight", "mur_weight_up", "mur_weight_down",
@@ -120,45 +161,7 @@ def murmuf_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     return events
 
 
-@murmuf_weights.setup
-def murmuf_weights_setup(self: Producer, reqs: dict, inputs: dict) -> None:
-    # define indices in case there are 9 LHEScaleWeights in total
-    self.indices_9 = DotDict(
-        mur_down_muf_down=0,
-        mur_down_muf_nom=1,
-        mur_down_muf_up=2,
-        mur_nom_muf_down=3,
-        mur_nom_muf_nom=4,
-        mur_nom_muf_up=5,
-        mur_up_muf_down=6,
-        mur_up_muf_nom=7,
-        mur_up_muf_up=8,
-    )
-
-    # if there are only 8, the nominal weight at index 4 is missing
-    # in this case, initialize an index where all indices > 4 are shifted
-    # down by one
-    self.indices_8 = DotDict({
-        key: index if index <= 4 else index - 1
-        for key, index in self.indices_9.items()
-        if key != "mur_nom_muf_nom"
-    })
-
-    # for convenience, declare some meaningful clear names for the weights
-    # here instead of the very technical names like mur_nom_muf_up
-    self.clearnames = DotDict(
-        # decorrelated weights
-        mur_weight_up="mur_up_muf_nom",
-        mur_weight_down="mur_down_muf_nom",
-        muf_weight_up="mur_nom_muf_up",
-        muf_weight_down="mur_nom_muf_down",
-        # fully-correlated names
-        murmuf_weight_up="mur_up_muf_up",
-        murmuf_weight_down="mur_down_muf_down",
-    )
-
-
-@producer(
+@_ScaleWeightBase.producer(
     uses={"LHEScaleWeight"},
     produces={"murf_envelope_weight", "murf_envelope_weight_up", "murf_envelope_weight_down"},
     # only run on mc
@@ -219,18 +222,8 @@ def murmuf_envelope_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Ar
 
 @murmuf_envelope_weights.setup
 def murmuf_envelope_weights_setup(self: Producer, reqs: dict, inputs: dict) -> None:
-    # define the indices of weights to consider for the envelope construction
-    self.indices_9 = DotDict(
-        mur_down_muf_down=0,
-        mur_down_muf_nom=1,
-        mur_down_muf_up=2,
-        mur_nom_muf_down=3,
-        mur_nom_muf_nom=4,
-        mur_nom_muf_up=5,
-        mur_up_muf_down=6,
-        mur_up_muf_nom=7,
-        mur_up_muf_up=8,
-    )
+    # call the super func
+    super(murmuf_envelope_weights, self).setup_func(reqs, inputs)
 
     # create a flat list if indices, skipping those for crossed variations
     self.envelope_indices_9 = [

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -31,57 +31,64 @@ class Selector(TaskArrayFunction):
         if self.call_force is None and not self.exposed:
             self.call_force = True
 
+    @classmethod
+    def selector(
+        cls,
+        func: Callable | None = None,
+        bases=(),
+        mc_only: bool = False,
+        data_only: bool = False,
+        **kwargs,
+    ) -> DerivableMeta | Callable:
+        """
+        Decorator for creating a new :py:class:`Selector` subclass with additional, optional *bases*
+        and attaching the decorated function to it as ``call_func``. When *mc_only* (*data_only*) is
+        *True*, the selector is skipped and not considered by other calibrators, selectors and
+        producers in case they are evalauted on an :py:class:`order.Dataset` whose ``is_mc``
+        attribute is *False* (*True*).
 
-def selector(
-    func: Callable | None = None,
-    bases=(),
-    mc_only: bool = False,
-    data_only: bool = False,
-    **kwargs,
-) -> DerivableMeta | Callable:
-    """
-    Decorator for creating a new :py:class:`Selector` subclass with additional, optional *bases* and
-    attaching the decorated function to it as ``call_func``. When *mc_only* (*data_only*) is *True*,
-    the selector is skipped and not considered by other calibrators, selectors and producers in case
-    they are evalauted on an :py:class:`order.Dataset` whose ``is_mc`` attribute is *False*
-    (*True*).
+        All additional *kwargs* are added as class members of the new subclasses.
+        """
+        def decorator(func: Callable) -> DerivableMeta:
+            # create the class dict
+            cls_dict = {"call_func": func}
+            cls_dict.update(kwargs)
 
-    All additional *kwargs* are added as class members of the new subclasses.
-    """
-    def decorator(func: Callable) -> DerivableMeta:
-        # create the class dict
-        cls_dict = {"call_func": func}
-        cls_dict.update(kwargs)
+            # get the module name
+            frame = inspect.stack()[1]
+            module = inspect.getmodule(frame[0])
 
-        # get the module name
-        frame = inspect.stack()[1]
-        module = inspect.getmodule(frame[0])
+            # get the selector name
+            cls_name = cls_dict.pop("cls_name", func.__name__)
 
-        # get the selector name
-        cls_name = cls_dict.pop("cls_name", func.__name__)
+            # optionally add skip function
+            if mc_only and data_only:
+                raise Exception(f"selector {cls_name} received both mc_only and data_only")
+            if mc_only or data_only:
+                if cls_dict.get("skip_func"):
+                    raise Exception(
+                        f"selector {cls_name} received custom skip_func, but mc_only or data_only are set",
+                    )
 
-        # optionally add skip function
-        if mc_only and data_only:
-            raise Exception(f"selector {cls_name} received both mc_only and data_only")
-        if mc_only or data_only:
-            if cls_dict.get("skip_func"):
-                raise Exception(f"selector {cls_name} received custom skip_func, but mc_only or data_only are set")
+                def skip_func(self):
+                    # never skip when there is not dataset
+                    if not getattr(self, "dataset_inst", None):
+                        return False
 
-            def skip_func(self):
-                # never skip when there is not dataset
-                if not getattr(self, "dataset_inst", None):
-                    return False
+                    return self.dataset_inst.is_mc != bool(mc_only)
 
-                return self.dataset_inst.is_mc != bool(mc_only)
+                cls_dict["skip_func"] = skip_func
 
-            cls_dict["skip_func"] = skip_func
+            # create the subclass
+            subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
 
-        # create the subclass
-        subclass = Selector.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
+            return subclass
 
-        return subclass
+        return decorator(func) if func else decorator
 
-    return decorator(func) if func else decorator
+
+# shorthand
+selector = Selector.selector
 
 
 class SelectionResult(od.AuxDataMixin):


### PR DESCRIPTION
This PR makes the calibrator / selector / producer (CSP) decorators classmethods of the respective `Calibrator`, `Selector` and `Producer` base classes.

This does not change existing code and forces to updates to analyses, but it allows transparent subclassing. The PR also changes the two cms-related scale weight producers which actually share some attributes (i.e. the named indices of the weights). This is done by defining a common, unexposed subclass `_ScaleWeightBase` and then dynamically created subclasses via (e.g.)

```python
@_ScaleWeightBase.producer()
def ...
```

Closes #230.