### PR TITLE
Feature/allow histogramming jagged variables

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -11,11 +11,13 @@ import law
 import order as od
 from scinum import Number
 
-from columnflow.util import DotDict
+from columnflow.util import DotDict, maybe_import
 from columnflow.columnar_util import EMPTY_FLOAT
 from columnflow.config_util import (
     get_root_processes_from_campaign, add_shift_aliases, get_shifts_from_sources, add_category,
 )
+
+ak = maybe_import("awkward")
 
 
 #
@@ -290,6 +292,13 @@ cfg.add_variable(
     x_title="Number of jets",
 )
 cfg.add_variable(
+    name="jets_pt",
+    expression="Jet.pt",
+    binning=(40, 0.0, 400.0),
+    unit="GeV",
+    x_title=r"$p_{T} of all jets$",
+)
+cfg.add_variable(
     name="jet1_pt",
     expression="Jet.pt[:,0]",
     null_value=EMPTY_FLOAT,
@@ -303,6 +312,13 @@ cfg.add_variable(
     null_value=EMPTY_FLOAT,
     binning=(30, -3.0, 3.0),
     x_title=r"Jet 1 $\eta$",
+)
+cfg.add_variable(
+    name="ht",
+    expression=lambda events: ak.sum(events.Jet.pt, axis=1),
+    binning=(40, 0.0, 800.0),
+    unit="GeV",
+    x_title="HT",
 )
 # weights
 cfg.add_variable(

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -185,7 +185,7 @@ class CreateHistograms(
                 fill_kwargs = {
                     "category": events.category_ids,
                     "process": events.process_id,
-                    "shift": self.global_shift_inst.id,
+                    "shift": ak.Array(np.zeros(len(events)) + self.global_shift_inst.id),
                     "weight": weight,
                 }
                 for variable_inst in variable_insts:
@@ -199,9 +199,10 @@ class CreateHistograms(
                             return route.apply(events, null_value=variable_inst.null_value)
                     # apply it
                     fill_kwargs[variable_inst.name] = expr(events)
+
                 # broadcast and fill
-                arrays = (ak.flatten(a) for a in ak.broadcast_arrays(*fill_kwargs.values()))
-                histograms[var_key].fill(**dict(zip(fill_kwargs, arrays)))
+                arrays = ak.flatten(ak.cartesian(fill_kwargs))
+                histograms[var_key].fill(**{field: arrays[field] for field in arrays.fields})
 
         # merge output files
         self.output()["hists"].dump(histograms, formatter="pickle")

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -185,7 +185,7 @@ class CreateHistograms(
                 fill_kwargs = {
                     "category": events.category_ids,
                     "process": events.process_id,
-                    "shift": ak.Array(np.zeros(len(events)) + self.global_shift_inst.id),
+                    "shift": np.ones(len(events), dtype=np.int32) * self.global_shift_inst.id,
                     "weight": weight,
                 }
                 for variable_inst in variable_insts:


### PR DESCRIPTION
This PR allows creating histograms with jagged variables, e.g.
```
cfg.add_variable(
    name="jets_pt",
    expression="Jet.pt",
    binning=(40, 0.0, 400.0),
    unit="GeV",
    x_title=r"$p_{T} of all jets$",
)
```
creates a single histogram that contains the pt of all jets.