### PR TITLE
Handle negative and missing values in 2d plots

### DIFF
--- a/columnflow/plotting/plot_functions_2d.py
+++ b/columnflow/plotting/plot_functions_2d.py
@@ -38,6 +38,7 @@ def plot_2d(
     density: bool | None = False,
     shape_norm: bool | None = False,
     zscale: str | None = "",
+    colormap: str | None = "",
     skip_legend: bool = False,
     cms_label: str = "wip",
     process_settings: dict | None = None,
@@ -60,6 +61,9 @@ def plot_2d(
     # how to handle yscale information from 2 variable insts?
     if not zscale:
         zscale = "log" if (variable_insts[0].log_y or variable_insts[1].log_y) else "linear"
+
+    # default color map
+    default_cmap = "viridis"
 
     # setup style config
     # TODO: some kind of z-label is still missing
@@ -84,6 +88,7 @@ def plot_2d(
         },
         "plot2d_cfg": {
             "norm": mpl.colors.LogNorm() if zscale == "log" else None,
+            "cmap": colormap or default_cmap,
             # "labels": True,  # this enables displaying numerical values for each bin, but needs some optimization
             "cmin": 0,  # display zero entries as white points
             "cbar": True,

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -227,11 +227,18 @@ class PlotBase2D(PlotBase):
         description="when True, the overall bin content is normalized on its integral; "
         "default: None",
     )
+    colormap = luigi.Parameter(
+        default=law.NO_STR,
+        significant=False,
+        description="name of the matplotlib colormap to use for the colorbar; "
+        "if not set, an appropriate colormap will be chosen by the plotting function",
+    )
 
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
         dict_add_strict(params, "zscale", None if self.zscale == law.NO_STR else self.zscale)
+        dict_add_strict(params, "colormap", None if self.colormap == law.NO_STR else self.colormap)
         dict_add_strict(params, "density", self.density)
         dict_add_strict(params, "shape_norm", self.shape_norm)
         return params

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -233,11 +233,51 @@ class PlotBase2D(PlotBase):
         description="name of the matplotlib colormap to use for the colorbar; "
         "if not set, an appropriate colormap will be chosen by the plotting function",
     )
+    zlim = law.CSVParameter(
+        default=("min", "max"),
+        significant=False,
+        min_len=2,
+        max_len=2,
+        description="the range of values covered by the colorbar; this optional CSV parameter "
+        "accepts exactly two values, indicating the lower and upper bound of the colorbar. The special "
+        "specifiers 'min' and 'max' can be used in place of floats to indicate the minimum or maximum value "
+        "of the data. Similarly, 'maxabs' and 'minabs' indicate the minimum and maximum of the absolute "
+        "value of the data. A hyphen ('-') may be prepended to any specifier to indicate the negative of the "
+        "corresponding value. If no 'zlim' is given, the limits are inferred from the data (equivalent to 'min,max').",
+    )
+    extremes = luigi.ChoiceParameter(
+        default="color",
+        choices=("color", "clip", "hide"),
+        significant=False,
+        description="how to handle extreme values outside `zlim`; valid choices are: 'color' (extreme values are "
+        "shown in a different color), 'clip' (extreme values are clipped to the closest allowed values) and 'hide' "
+        "(extreme values are treated as missing); default: 'color'",
+    )
+    extreme_colors = law.CSVParameter(
+        default=(),
+        significant=False,
+        description="the colors to use for marking extreme values; this optional CSV parameter accepts exactly two "
+        "values, indicating the color to use for values below and above the range covered by the colorbar.",
+    )
+
+    @classmethod
+    def modify_param_values(cls, params: dict) -> dict:
+        params = super().modify_param_values(params)
+
+        params["zlim"] = tuple(
+            float(v) if law.util.is_float(v) else v
+            for v in params["zlim"]
+        )
+
+        return params
 
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
         dict_add_strict(params, "zscale", None if self.zscale == law.NO_STR else self.zscale)
+        dict_add_strict(params, "zlim", None if not self.zlim else self.zlim)
+        dict_add_strict(params, "extremes", self.extremes)
+        dict_add_strict(params, "extreme_colors", None if not self.extreme_colors else self.extreme_colors)
         dict_add_strict(params, "colormap", None if self.colormap == law.NO_STR else self.colormap)
         dict_add_strict(params, "density", self.density)
         dict_add_strict(params, "shape_norm", self.shape_norm)


### PR DESCRIPTION
This PR handles several edge cases in the plotting of 2D histograms containing negative or missing values (`np.nan`).

In a previous implementation, missing values were replaced by a large negative value, `EMPTY_FLOAT = -99999.0`, and the `cmin` keyword argument passed to `mplhep` was set to `EMPTY_FLOAT + 1`. While this correctly masked missing values and included all "true" negative values, in some cases this led to the lower bound of the colorbar also starting at a large negative value, and all bins being effectively mapped to the color at the upper end of the scale.

To correct this, the implementation proposed here sets the value of bins for missing data to `np.nan`, which is also used internally by `mplhep` to mask values below `cmin`. In addition, an appropriate color bar normalization is chosen depending on the scale and the histogram content, as follows:

* ~~[`Normalize`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.Normalize.html) for linear-scale plots of histograms containing **only positive** or **only negative** values~~
* ~~[`TwoSlopeNorm`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.TwoSlopeNorm.html) (centered at zero) for linear-scale plots of histograms containing **both positive and negative** values~~
* ~~[`LogNorm`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.LogNorm.html) for log-scale plots of histograms containing **only non-negative** values~~
* ~~[`SymLogNorm`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.SymLogNorm.html) for log-scale plots of histograms containing **any negative** values~~

A new optional parameter `--colormap` is also added to the `PlotBase2D` class, allowing users to specify an alternative color scheme for 2D plots on the command line. The default color map is [`viridis`](https://matplotlib.org/stable/tutorials/colors/colormaps.html#sequential), ~~except in the case that a histogram contains both negative and positive values, in which case the cyclic/diverging color map [`twilight_r`](https://matplotlib.org/stable/tutorials/colors/colormaps.html#cyclic) centered at zero is used.~~

*Update*: the colorbar normalization choice has been simplified

* [`Normalize`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.Normalize.html) for linear-scale plots 
* [`SymLogNorm`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.SymLogNorm.html) for log-scale plots

Three new optional parameters are added to the plot task to specify the valid `z` axis range and how to handle extreme values:

* `--zlim`: CSV parameter with two entries, indicating the range of values covered by the colorbar. Special values like `min`, `max`, `minabs`, `-maxabs` are supported for setting limits based on the data. Default: `min,max`.
* `--extremes`: how to handle values lying outside the plot range indicated by `--zlim`. Can be `color` (use different colors), `hide` (mask extreme values), or `clip` (use the same color as the min/max of the colorbar). Default: `color`
* `--extreme-colors`: CSV parameter with two entries, indicating which colors to use for values below (above) the lower (upper) limit of the colorbar. Only has an effect when `--extremes` is set to `color`. Default: dark and light gray.

When the histogram contains values outside the `z` range, the colorbar is extended with triangle-shaped markers filled with the corresponding colors as a visual indicator of their presence.