### PR TITLE
Uncomment uncertainty combination.

### DIFF
--- a/columnflow/tasks/yields.py
+++ b/columnflow/tasks/yields.py
@@ -230,7 +230,7 @@ class CreateYieldTable(
 
                     # format yields into strings
                     yields_str[category].append((value / norm_factor).str(
-                        # combine_uncs="all",  # TODO
+                        combine_uncs="all",
                         format=self.number_format,
                         style="latex" if "latex" in self.table_format else "plain",
                     ))


### PR DESCRIPTION
This PR just uncomments a single line in the yields task which instructs the `Number` object to combine all uncertainties.

For this line to work, the sandbox needs to be updated since the `combine_uncs` feature was added to scinum only recently.

E.g.

```bash
source $CF_BASE/sandboxes/venv_columnar_dev.sh reinstall
```

Closes #229.