### PR TITLE
add calib/sel/prod in MLTraining output parts

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -712,7 +712,7 @@ class MLModelTrainingMixin(MLModelMixinBase):
             else:
                 # when functions differ between configs, flatten
                 n_fct_per_config = "".join(str(len(x)) for x in fct_names)
-                fct_names = sum(fct_names[1:], fct_names[0])
+                fct_names = tuple(fct_name for fct_names_cfg in fct_names for fct_name in fct_names_cfg)
 
             part = "_".join(fct_names[:2])
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -714,7 +714,7 @@ class MLModelTrainingMixin(MLModelMixinBase):
                 n_fct_per_config = "".join(str(len(x)) for x in fct_names)
                 fct_names = tuple(fct_name for fct_names_cfg in fct_names for fct_name in fct_names_cfg)
 
-            part = "_".join(fct_names[:2])
+            part = "__".join(fct_names[:2])
 
             if len(fct_names) > 2:
                 part += f"_{n_fct_per_config}_{law.util.create_hash(fct_names[2:])}"

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -691,10 +691,35 @@ class MLModelTrainingMixin(MLModelMixinBase):
         # since MLTraining is no CalibratorsMixin, SelectorMixin, ProducerMixin, ConfigTask,
         # all these parts are missing in the `store_parts`
 
-        configs_repr = "__".join(self.configs)
+        configs_repr = "__".join(self.configs[:5])
+
+        if len(self.configs) > 5:
+            configs_repr += f"_{law.util.create_hash(self.configs[5:])}"
+
         parts.insert_after("task_family", "configs", configs_repr)
 
-        # TODO: parts for calib, sel, prod
+        task_array_functions = {
+            "calib": self.calibrators,
+            "sel": tuple((sel,) for sel in self.selectors),
+            "prod": self.producers,
+        }
+
+        for label, fct_names in task_array_functions.items():
+            if all(map(lambda x: x == fct_names[0], fct_names)):
+                # when functions are the same per config, only use them once
+                fct_names = fct_names[0]
+                n_fct_per_config = str(len(fct_names))
+            else:
+                # when functions differ between configs, flatten
+                n_fct_per_config = "".join(str(len(x)) for x in fct_names)
+                fct_names = sum(fct_names[1:], fct_names[0])
+
+            part = "_".join(fct_names[:2])
+
+            if len(fct_names) > 2:
+                part += f"_{n_fct_per_config}_{law.util.create_hash(fct_names[2:])}"
+
+            parts.insert_before("version", label, f"{label}__{part}")
 
         if self.ml_model_inst:
             parts.insert_before("version", "ml_model", f"ml__{self.ml_model_inst.cls_name}")

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -703,7 +703,9 @@ class MLModelTrainingMixin(MLModelMixinBase):
             ("sel", tuple((sel,) for sel in self.selectors)),
             ("prod", self.producers),
         ]:
-            if len(set(fct_names)) == 1:
+            if not fct_names or not any(fct_names):
+                fct_names = ["none"]
+            elif len(set(fct_names)) == 1:
                 # when functions are the same per config, only use them once
                 fct_names = fct_names[0]
                 n_fct_per_config = str(len(fct_names))

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -698,14 +698,12 @@ class MLModelTrainingMixin(MLModelMixinBase):
 
         parts.insert_after("task_family", "configs", configs_repr)
 
-        task_array_functions = {
-            "calib": self.calibrators,
-            "sel": tuple((sel,) for sel in self.selectors),
-            "prod": self.producers,
-        }
-
-        for label, fct_names in task_array_functions.items():
-            if all(map(lambda x: x == fct_names[0], fct_names)):
+        for label, fct_names in [
+            ("calib", self.calibrators),
+            ("sel", tuple((sel,) for sel in self.selectors)),
+            ("prod", self.producers),
+        ]:
+            if len(set(fct_names)) == 1:
                 # when functions are the same per config, only use them once
                 fct_names = fct_names[0]
                 n_fct_per_config = str(len(fct_names))


### PR DESCRIPTION
This PR adds Calibrators, Selectors and Producers to the MLTraining output paths, always adding at least the first two producers (etc.) to the output path. If the producers are the same for all configs, the duplicates are removed. If there are different producers per config, the number of producers per config is also added to the string.

closes #234 