### PR TITLE
Move from miniconda to micromamba.

### DIFF
--- a/bin/cf_make_venv_relocateable
+++ b/bin/cf_make_venv_relocateable
@@ -2,7 +2,7 @@
 
 cf_make_venv_relocateable() {
     # Traverses all executables in a virtual environment directory located in $CF_VENV_BASE and
-    # replaces absolute shebangs with relative ones using /use/bin/env.
+    # replaces absolute shebangs with relative ones using /usr/bin/env.
     #
     # Arguments:
     #   1. The name of the virtual env inside $CF_VENV_BASE.

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -43,7 +43,7 @@ bootstrap_htcondor_standalone() {
             source "${lcg_setup}" "" &&
             mkdir -p "${CF_SOFTWARE_BASE}/conda" &&
             cd "${CF_SOFTWARE_BASE}/conda" &&
-            law_wlcg_get_file '{{cf_software_uris}}' '{{cf_software_pattern}}' "software.tgz" &&
+            GFAL_PYTHONBIN="$( which python3 )" law_wlcg_get_file '{{cf_software_uris}}' '{{cf_software_pattern}}' "software.tgz" &&
             tar -xzf "software.tgz" &&
             rm "software.tgz"
         ) || return "$?"
@@ -54,7 +54,7 @@ bootstrap_htcondor_standalone() {
         source "${lcg_setup}" "" &&
         mkdir -p "${CF_REPO_BASE}" &&
         cd "${CF_REPO_BASE}" &&
-        law_wlcg_get_file '{{cf_repo_uris}}' '{{cf_repo_pattern}}' "repo.tgz" &&
+        GFAL_PYTHONBIN="$( which python3 )" law_wlcg_get_file '{{cf_repo_uris}}' '{{cf_repo_pattern}}' "repo.tgz" &&
         tar -xzf "repo.tgz" &&
         rm "repo.tgz"
     ) || return "$?"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-# version 1
+# version 2
 
 # documentation packages
 sphinx~=4.5

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,4 +1,4 @@
-# version 7
+# version 8
 
 awkward~=2.2
 uproot~=5.0

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,4 +1,4 @@
-# version 5
+# version 6
 
 awkward~=2.2
 uproot~=5.0

--- a/setup.sh
+++ b/setup.sh
@@ -45,7 +45,7 @@ setup_columnflow() {
     #      that is usually used by an upstream analysis. For instance, if the analysis base is
     #      stored in "$MY_ANALYSIS_BASE", CF_REPO_BASE_ALIAS should be "MY_ANALYSIS_BASE" (no $).
     #   CF_CONDA_BASE
-    #       The directory where conda and conda envs are installed. Might point to
+    #       The directory where conda / micromamba and conda envs are installed. Might point to
     #       $CF_SOFTWARE_BASE/conda.
     #   CF_VENV_BASE
     #       The directory where virtual envs are installed. Might point to $CF_SOFTWARE_BASE/venvs.
@@ -400,8 +400,9 @@ cf_setup_interactive() {
 }
 
 cf_setup_software_stack() {
-    # Sets up the columnflow software stack consisting of a base environment using conda,
-    # lightweight virtual environments on top and git submodule initialization / updates.
+    # Sets up the columnflow software stack as a base environment using conda (actually using the
+    # free and faster micromamba interface), lightweight virtual environments on top and git
+    # submodule initialization / updates.
     #
     # Arguments:
     #   1. setup_name
@@ -411,7 +412,7 @@ cf_setup_software_stack() {
     #   CF_BASE
     #       The columnflow base directory.
     #   CF_CONDA_BASE
-    #       The directory where conda and conda envs will be installed.
+    #       The directory where conda / micromamba and conda envs will be installed.
     #   CF_VENV_BASE
     #       The base directory were virtual envs are installed.
     #
@@ -442,7 +443,6 @@ cf_setup_software_stack() {
     local setup_name="${1}"
     local setup_is_default="false"
     [ "${setup_name}" = "default" ] && setup_is_default="true"
-    local miniconda_source="https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh"
     local pyv="3.9"
 
     # empty the PYTHONPATH
@@ -457,10 +457,12 @@ cf_setup_software_stack() {
     export PATH="${CF_PERSISTENT_PATH}:${PATH}"
     export PYTHONPATH="${CF_PERSISTENT_PYTHONPATH}:${PYTHONPATH}"
 
-    # also add the python path of the cenv to be installed to propagate changes to any outer venv
+    # also add the python path of the venv to be installed to propagate changes to any outer venv
     export PYTHONPATH="${PYTHONPATH}:${CF_CONDA_BASE}/lib/python${pyv}/site-packages"
 
     # update paths and flags
+    export MAMBA_ROOT_PREFIX="${CF_CONDA_BASE}"
+    export MAMBA_EXE="${MAMBA_ROOT_PREFIX}/bin/micromamba"
     export PYTHONWARNINGS="${PYTHONWARNINGS:-ignore}"
     export GLOBUS_THREAD_MODEL="${GLOBUS_THREAD_MODEL:-none}"
     export VIRTUAL_ENV_DISABLE_PROMPT="${VIRTUAL_ENV_DISABLE_PROMPT:-1}"
@@ -470,12 +472,12 @@ cf_setup_software_stack() {
     export VOMS_USERCONF="${VOMS_USERCONF:-${X509_VOMSES}}"
     ulimit -s unlimited
 
-    # local python stack in one conda env and two virtual envs:
+    # local python stack in one conda / micromamba env and two virtual envs:
     #   - "cf_prod": contains the minimal stack to run tasks and is sent alongside jobs
     #   - "cf_dev" : "cf_prod" + additional python tools for local development (e.g. ipython)
     if [ "${CF_REMOTE_JOB}" != "1" ]; then
         if [ "${CF_REINSTALL_SOFTWARE}" = "1" ]; then
-            echo "removing conda at $( cf_color magenta ${CF_CONDA_BASE})"
+            echo "removing conda / micromamba at $( cf_color magenta ${CF_CONDA_BASE})"
             rm -rf "${CF_CONDA_BASE}"
 
             echo "removing software virtual envs at $( cf_color magenta ${CF_VENV_BASE})"
@@ -483,39 +485,41 @@ cf_setup_software_stack() {
         fi
 
         #
-        # conda setup
+        # conda / micromamba setup
         #
 
         # not needed in CI jobs
         if [ "${CF_CI_JOB}" != "1" ]; then
-            # conda base environment
+            # base environment
             local conda_missing="$( [ -d "${CF_CONDA_BASE}" ] && echo "false" || echo "true" )"
             if ${conda_missing}; then
                 echo
-                cf_color magenta "installing conda at ${CF_CONDA_BASE}"
-                wget "${miniconda_source}" -O setup_miniconda.sh || return "$?"
-                bash setup_miniconda.sh -b -u -p "${CF_CONDA_BASE}" || return "$?"
-                rm -f setup_miniconda.sh
-                cat << EOF >> "${CF_CONDA_BASE}/.condarc"
+                cf_color magenta "installing micromamba at ${CF_CONDA_BASE}"
+                mkdir -p "${CF_CONDA_BASE}/etc/profile.d"
+                curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C "${CF_CONDA_BASE}" "bin/micromamba" > /dev/null
+                2>&1 "${CF_CONDA_BASE}/bin/micromamba" shell hook -y --prefix="$PWD" &> micromamba.sh && mv micromamba.sh "${CF_CONDA_BASE}/etc/profile.d"
+                cat << EOF > "${CF_CONDA_BASE}/.mambarc"
 changeps1: false
+always_yes: true
 channels:
   - conda-forge
 EOF
             fi
 
-            # initialize conda
-            source "${CF_CONDA_BASE}/etc/profile.d/conda.sh" "" || return "$?"
-            conda activate || return "$?"
-            echo "initialized conda with $( cf_color magenta "python ${pyv}" )"
+            # initialize micromamba
+            source "${CF_CONDA_BASE}/etc/profile.d/micromamba.sh" "" || return "$?"
+            return 123
+            micromamba activate || return "$?"
+            echo "initialized conda / micromamba with $( cf_color magenta "python ${pyv}" )"
 
             # install packages
             if ${conda_missing}; then
                 echo
                 cf_color cyan "setting up conda environment"
-                conda install --yes libgcc gfal2 gfal2-util python-gfal2 git git-lfs conda-pack || return "$?"
+                micromamba install libgcc "python=${pyv}" gfal2 gfal2-util python-gfal2 git git-lfs conda-pack || return "$?"
                 # TODO: temporary issue with numba and numpy
-                conda install --yes "numpy<1.24" || return "$?"
-                conda clean --yes --all
+                micromamba install "numpy<1.24" || return "$?"
+                micromamba clean --yes --all
 
                 # add a file to conda/activate.d that handles the gfal setup transparently with conda-pack
                 cat << EOF > "${CF_CONDA_BASE}/etc/conda/activate.d/gfal_activate.sh"
@@ -571,9 +575,11 @@ EOF
     else
         # at this point we are located in a remote job
 
+        # TODO
+
         # initialize conda
         source "${CF_CONDA_BASE}/bin/activate" "" || return "$?"
-        echo "initialized conda with $( cf_color magenta "python ${pyv}" )"
+        echo "initialized conda / micromamba with $( cf_color magenta "python ${pyv}" )"
 
         # source the prod sandbox
         source "${CF_BASE}/sandboxes/cf_prod.sh" "" "no"

--- a/setup.sh
+++ b/setup.sh
@@ -526,7 +526,6 @@ EOF
 
                 # add a file to conda/activate.d that handles the gfal setup transparently with conda-pack
                 cat << EOF > "${CF_CONDA_BASE}/etc/conda/activate.d/gfal_activate.sh"
-echo "sourcing gfal activate"
 export GFAL_CONFIG_DIR="\${CONDA_PREFIX}/etc/gfal2.d"
 export GFAL_PLUGIN_DIR="\${CONDA_PREFIX}/lib/gfal2-plugins"
 export X509_CERT_DIR="${X509_CERT_DIR}"


### PR DESCRIPTION
This PR changes the main software setup to no longer use (mini)conda but micromamba instead. There are two reasons that motivated this change:

- mamba comes with a c++ based dependency graph resolution which is notable faster that pure conda
- (ana)conda and its proprietary channels/repository seem no longer to be free of use (since a while actually) for commercial use and a large fraction of users that could potentially use cf for professional research in the future (after it's *official* v1.0.0 launch) would/could qualify as commercial users (i.e. they are "paid to do so") ([TOS, 1.1a.b\)](https://legal.anaconda.com/policies/en/#terms-of-service), [DESY IT recommendation](https://confluence.desy.de/pages/viewpage.action?pageId=242328861)). (micro)mamba and the conda-forge channel on the other hand are free to use.

Technically, both tools behave the same way except for a few caveats regarding scripts that are triggered upon `activate` and the relocatability of the env for remote jobs. Therefore, work on the PR took quite a while whereas the required changes are rather manageable :)

This PR also contains an awkward v2 post-transition change regarding a pinned numpy version which is no longer required (item 3 in https://github.com/columnflow/columnflow/issues/140).

Closes #228.