### PR TITLE
Catch unkown process ids.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -15,6 +15,7 @@ from columnflow.util import DotDict, maybe_import
 from columnflow.columnar_util import EMPTY_FLOAT
 from columnflow.config_util import (
     get_root_processes_from_campaign, add_shift_aliases, get_shifts_from_sources, add_category,
+    verify_config_processes,
 )
 
 ak = maybe_import("awkward")
@@ -107,6 +108,9 @@ for dataset_name in dataset_names:
     # for testing purposes, limit the number of files to 2
     for info in dataset.info.values():
         info.n_files = min(info.n_files, 2)
+
+# verify that the root process of all datasets is part of any of the registered processes
+verify_config_processes(cfg, warn=True)
 
 # default objects, such as calibrator, selector, producer, ml model, inference model, etc
 cfg.x.default_calibrator = "example"

--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -239,14 +239,15 @@ def create_category_combinations(
 
 def verify_config_processes(config: od.Config, warn: bool = False) -> None:
     """
-    Verifies for all datasets contained in a *config* object that the linked process is covered by
-    any process object registered in *config* and raises an exception if not. If *warn* is *True*,
-    a warning is printed instead.
+    Verifies for all datasets contained in a *config* object that the linked processes are covered
+    by any process object registered in *config* and raises an exception if not. If *warn* is
+    *True*, a warning is printed instead.
     """
     missing_pairs = []
     for dataset in config.datasets:
-        if not config.has_process(process := dataset.processes.get_first()):
-            missing_pairs.append((dataset, process))
+        for process in dataset.processes:
+            if not config.has_process(process):
+                missing_pairs.append((dataset, process))
 
     # nothing to do when nothing is missing
     if not missing_pairs:
@@ -258,7 +259,7 @@ def verify_config_processes(config: od.Config, warn: bool = False) -> None:
         msg += f"\n  dataset '{dataset.name}' -> process '{process.name}'"
 
     # warn or raise
-    if warn:
-        print(f"{law.util.colored('WARNING:', 'red')} {msg}")
-    else:
+    if not warn:
         raise Exception(msg)
+
+    print(f"{law.util.colored('WARNING', 'red')}: {msg}")

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -89,6 +89,18 @@ def normalization_weights_setup(self: Producer, reqs: dict, inputs: dict, reader
     ]
     max_id = max(process_inst.id for process_inst in process_insts)
 
+    # ensure that the selection stats do not contain any process that was not previously registered
+    unregistered_process_ids = [
+        int(process_id) for process_id in selection_stats["sum_mc_weight_per_process"]
+        if int(process_id) > max_id
+    ]
+    if unregistered_process_ids:
+        id_str = ",".join(map(str, unregistered_process_ids))
+        raise Exception(
+            f"selection stats contain ids ({id_str}) of processes that were not previously " +
+            f"registered to the config '{self.config_inst.name}'",
+        )
+
     # create a event weight sum lookup table with all known processes
     sum_weights_table = sp.sparse.lil_matrix((1, max_id + 1), dtype=np.float32)
     for process_id, sum_weights in selection_stats["sum_mc_weight_per_process"].items():


### PR DESCRIPTION
This PR adds a check to the config_utils verifying that the linked processes to every dataset are actually known by the config itself. The check is rather trivial and should be used in all analysis configs as a safety measure, which is why I also injected it into the template analysis.

In addition, the PR contains an additional check in the normalization weight producer as mentioned in #235.

Closes #235.