### PR TITLE
Fix software priority order

### DIFF
--- a/columnflow/tasks/cms/external.py
+++ b/columnflow/tasks/cms/external.py
@@ -42,12 +42,24 @@ class CreatePileupWeights(ConfigTask):
     def output(self):
         return self.target(f"weights_from_{self.data_mode}.json")
 
+    def sandbox_stagein(self):
+        # stagein all inputs
+        return True
+
+    def sandbox_stageout(self):
+        # stageout all outputs
+        return True
+
     @law.decorator.log
     @law.decorator.safe_output
     def run(self):
         # prepare the external files and the output weights
         externals = self.requires()
         weights = {}
+
+        # since this tasks uses stage-in into and stage-out from the sandbox,
+        # prepare external files with the staged-in inputs
+        externals.get_files(self.input())
 
         # read the mc profile
         mc_profile = self.read_mc_profile_from_cfg(externals.files.pu.mc_profile)

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -278,11 +278,11 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
 
         return self._file_names
 
-    @property
-    def files(self):
+    def get_files(self, output=None):
         if self._files is None:
             # get the output
-            output = self.output()
+            if not output:
+                output = self.output()
             if not output.exists():
                 raise Exception(
                     f"accessing external files from the bundle requires the output of {self} to "
@@ -300,6 +300,10 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
             self._files = law.util.map_struct(resolve_basename, self.file_names)
 
         return self._files
+
+    @property
+    def files(self):
+        return self.get_files()
 
     def single_output(self):
         # required by law.tasks.TransferLocalFile

--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -106,15 +106,7 @@ setup_cmssw() {
 
 
     #
-    # store variables of the encapsulating venv
-    #
-
-    local pyv="$( python3 -c "import sys; print('{0.major}.{0.minor}'.format(sys.version_info))" )"
-    local venv_site_packages="${CF_VENV_BASE}/${CF_VENV_NAME}/lib/python${pyv}/site-packages"
-
-
-    #
-    # start the setup
+    # define variables
     #
 
     local install_hash="$( cf_sandbox_file_hash "${sandbox_file}" )"
@@ -123,7 +115,13 @@ setup_cmssw() {
     local install_path="${install_base}/${CF_CMSSW_VERSION}"
     local install_path_repr="\$CF_CMSSW_BASE/${cmssw_env_name_hashed}/${CF_CMSSW_VERSION}"
     local pending_flag_file="${CF_CMSSW_BASE}/pending_${cmssw_env_name_hashed}_${CF_CMSSW_VERSION}"
+
     export CF_SANDBOX_FLAG_FILE="${install_path}/cf_flag"
+
+
+    #
+    # start the setup
+    #
 
     # ensure CF_CMSSW_BASE exists
     mkdir -p "${CF_CMSSW_BASE}"
@@ -287,14 +285,10 @@ setup_cmssw() {
     eval "$( scramv1 runtime -sh )"
     cd "${orig_dir}"
 
-    # prepend persistent path fragments again to ensure priority for local packages
+    # prepend persistent path fragments again to ensure priority for local packages and
+    # remove the conda based python fragments since there are too many overlaps between packages
+    export PYTHONPATH="${CF_PERSISTENT_PATH}:$( echo ${PYTHONPATH} | sed "s|${CF_CONDA_PYTHONPATH}||g" )"
     export PATH="${CF_PERSISTENT_PATH}:${PATH}"
-    export PYTHONPATH="${CF_PERSISTENT_PYTHONPATH}:${PYTHONPATH}"
-
-    # prepend the site-packages of the encapsulating venv for priotity over cmssw-shipped packages
-    # note: this could potentially lead to version mismatches so in case this becomes in issue,
-    # this injection needs refactoring
-    export PYTHONPATH="${venv_site_packages}:${PYTHONPATH}"
 
     # mark this as a bash sandbox for law
     export LAW_SANDBOX="bash::$( cf_sandbox_file_hash -p "${sandbox_file}" )"

--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -261,6 +261,7 @@ setup_venv() {
             cf_color magenta "updating pip"
             python -m pip install -U pip
             [ "$?" != "0" ] && clear_pending && return "27"
+            echo
 
             # install basic production requirements
             if ! ${requirement_files_contains_prod}; then

--- a/setup.sh
+++ b/setup.sh
@@ -71,11 +71,11 @@ setup_columnflow() {
     #   CF_LCG_SETUP
     #       The location of a custom LCG software setup file. See above.
     #   CF_PERSISTENT_PATH
-    #       PATH fragments that should be considered by sandboxes (bash, venv, cmssw) as having
-    #       priority, e.g. to ensure that executable of local packages in used first.
+    #       PATH fragments that should be considered by sandboxes (bash, venv, cmssw) to have
+    #       precedence, e.g. to ensure that executables of local packages are priotized.
     #   CF_PERSISTENT_PYTHONPATH
-    #       PYTHONPATH fragments that should be considered by sandboxes (bash, venv, cmssw) as
-    #       having priority, e.g. to ensure that local packages in submodules are imported first.
+    #       PYTHONPATH fragments that should be considered by sandboxes (bash, venv, cmssw) to have
+    #       precedence, e.g. to ensure that python modules of local packages are priotized.
     #   CF_ORIG_PATH
     #       Copy of the $PATH variable before ammended by the seutp.
     #   CF_ORIG_PYTHONPATH
@@ -450,7 +450,7 @@ cf_setup_software_stack() {
 
     # persistent PATH and PYTHONPATH parts that should be
     # priotized over any additions made in sandboxes
-    export CF_PERSISTENT_PATH="${CF_BASE}/bin:${CF_BASE}/modules/law/bin:${CF_SOFTWARE_BASE}/bin"
+    export CF_PERSISTENT_PATH="${CF_BASE}/bin:${CF_BASE}/modules/law/bin"
     export CF_PERSISTENT_PYTHONPATH="${CF_BASE}:${CF_BASE}/bin:${CF_BASE}/modules/law:${CF_BASE}/modules/order"
 
     # prepend them
@@ -458,7 +458,8 @@ cf_setup_software_stack() {
     export PYTHONPATH="${CF_PERSISTENT_PYTHONPATH}:${PYTHONPATH}"
 
     # also add the python path of the venv to be installed to propagate changes to any outer venv
-    export PYTHONPATH="${PYTHONPATH}:${CF_CONDA_BASE}/lib/python${pyv}/site-packages"
+    export CF_CONDA_PYTHONPATH="${CF_CONDA_BASE}/lib/python${pyv}/site-packages"
+    export PYTHONPATH="${PYTHONPATH}:${CF_CONDA_PYTHONPATH}"
 
     # update paths and flags
     export MAMBA_ROOT_PREFIX="${CF_CONDA_BASE}"
@@ -521,7 +522,6 @@ EOF
             if ${conda_missing}; then
                 echo
                 cf_color cyan "setting up conda / micromamba environment"
-                # pin numpy until https://github.com/columnflow/columnflow/issues/250 is fixed
                 micromamba install \
                     libgcc \
                     "python=${pyv}" \
@@ -531,7 +531,6 @@ EOF
                     git \
                     git-lfs \
                     conda-pack \
-                    "numpy=1.24" \
                     || return "$?"
                 micromamba clean --yes --all
 

--- a/setup.sh
+++ b/setup.sh
@@ -76,14 +76,16 @@ setup_columnflow() {
     #   CF_PERSISTENT_PYTHONPATH
     #       PYTHONPATH fragments that should be considered by sandboxes (bash, venv, cmssw) to have
     #       precedence, e.g. to ensure that python modules of local packages are priotized.
+    #   CF_CONDA_PYTHONPATH
+    #       PYTHONPATH fragments pointing to packages intalled by conda.
     #   CF_ORIG_PATH
-    #       Copy of the $PATH variable before ammended by the seutp.
+    #       Copy of the $PATH variable before ammended by the setup.
     #   CF_ORIG_PYTHONPATH
-    #       Copy of the $PYTHONPATH variable before ammended by the seutp.
+    #       Copy of the $PYTHONPATH variable before ammended by the setup.
     #   CF_ORIG_PYTHON3PATH
-    #       Copy of the $PYTHON3PATH variable before ammended by the seutp.
+    #       Copy of the $PYTHON3PATH variable before ammended by the setup.
     #   CF_ORIG_LD_LIBRARY_PATH
-    #       Copy of the $LD_LIBRARY_PATH variable before ammended by the seutp.
+    #       Copy of the $LD_LIBRARY_PATH variable before ammended by the setup.
     #   CF_WLCG_CACHE_ROOT
     #       The directory in which remote files from WLCG locations might be cached. No caching is
     #       used when empty. Queried during the interactive setup. Used in law.cfg.


### PR DESCRIPTION
This PR fixes the software priority order between the conda/micromamba base env, the main venvs, and task-level venvs, in the exact way proposed in #250.

## Implementation details

For sandboxes based on **venvs**, this is rather simple as each sandbox can control every aspect of its environment and python software stack. Here, the fix simply consists of arranging the PATH and PYTHONPATH variables in a way that reflects the desired order.

For sandboxes based on **cmssw**, however, things are much more complex as overlap between software packages of the outer env and cmssw itself must be resolved. In this PR, I went for completely disabling packages shipped with the conda base env as there is a huge clash between packages related to remote target interactions. As a result, gfal2 is not fully available within cmssw sandboxes. To **still** retrieve inputs from and move outputs to remote target locations, one can use law's target stage-in/-out feature. As an example, this PR changes the `cms.external.CreatePileupWeights` task to use this feature and it works nicely.


Close #250