### PR TITLE
Allow custom cms label postfixes in plots.

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -263,11 +263,14 @@ def plot_all(
             "simwip": "Simulation work in progress",
             "simpre": "Simulation preliminary",
             "simpw": "Simulation private work",
+            "od": "OpenData",
+            "odwip": "OpenData work in progress",
+            "odpw": "OpenData private work",
             "public": "",
         }
         cms_label_kwargs = {
             "ax": ax,
-            "llabel": label_options[cms_label],
+            "llabel": label_options.get(cms_label, cms_label),
             "fontsize": 22,
             "data": False,
         }

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -52,12 +52,12 @@ class PlotBase(ConfigTask):
         significant=False,
         description="when True, no legend is drawn; default: None",
     )
-    cms_label = luigi.ChoiceParameter(
-        choices=("wip", "pre", "pw", "sim", "simwip", "simpre", "simpw", "public", "skip"),
+    cms_label = luigi.Parameter(
         default="wip",
         significant=False,
-        description="Parameter to set the type of CMS logo; choices: "
-        "wip,pre,pw,sim,simwip,simpre,simpw,public,skip; default: wip",
+        description="postfix to add behind the CMS logo; when 'skip', no CMS logo is shown at all; "
+        "the following special values are expanded into the usual postfixes: wip, pre, pw, sim, "
+        "simwip, simpre, simpw, od, odwip, public; default: 'wip'",
     )
 
     @classmethod


### PR DESCRIPTION
This PR updates the variable plot task so that it is possible to pass any custom CMS label postfix that wasn't registered previously.

E.g. `law run cf.PlotVariables1D --cms-label "My custom postfix"` is supported now.