### PR TITLE
Propagate local and global shift correctly to CSPs

### DIFF
--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -108,9 +108,9 @@ def btag_weights(
         # save the new column
         return set_ak_column(events, column_name, weight, value_type=np.float32)
 
-    # when the globally requested uncertainty is a known jec shift, obtain the propagated effect and
+    # when the requested uncertainty is a known jec shift, obtain the propagated effect and
     # do not produce additional systematics
-    shift_inst = self.global_shift_inst
+    shift_inst = self.local_shift_inst
     if shift_inst.is_nominal:
         # nominal weight and those of all method intrinsic uncertainties
         events = add_weight("central", None, "btag_weight")
@@ -144,7 +144,7 @@ def btag_weights_init(self: Producer) -> None:
     #   2. when the nominal shift is requested, the central weight and all variations related to the
     #      method-intrinsic shifts are produced
     #   3. when any other shift is requested, only create the central weight column
-    shift_inst = getattr(self, "global_shift_inst", None)
+    shift_inst = getattr(self, "local_shift_inst", None)
     if not shift_inst:
         return
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -601,7 +601,7 @@ class ShiftTask(ConfigTask):
 
         if task:
             if task.local_shift_inst:
-                kwargs["shift_inst"] = task.local_shift_inst
+                kwargs["local_shift_inst"] = task.local_shift_inst
             if task.global_shift_inst:
                 kwargs["global_shift_inst"] = task.global_shift_inst
         else:


### PR DESCRIPTION
A while ago when we added the concept of local and global shifts, we decided to only pass the `local_shift_inst` to CSPs (calibrators, selectors, producers) and simply name it `shift_inst` in their instance attributes.

However, after working with some less standard CSPs for the first AGC implementation, I ran into situations where it comes in handy to know the difference between global and local shifts.

In this PR, the above simplification is removed and both shifts are propagated to CSPs using their actual names. We need to document this properly in a future sprint to finalize the first draft of docs.