### PR TITLE
Skip calibration outputs and requirements dynamically.

### DIFF
--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -56,7 +56,7 @@ class CalibrateEvents(
     def output(self):
         outputs = {}
 
-        # only declare the output in case the producer actually creates columns
+        # only declare the output in case the calibrator actually creates columns
         if self.calibrator_inst.produced_columns:
             outputs["columns"] = self.target(f"calib_{self.branch}.parquet")
 

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -54,7 +54,13 @@ class CalibrateEvents(
         return reqs
 
     def output(self):
-        return {"columns": self.target(f"calib_{self.branch}.parquet")}
+        outputs = {}
+
+        # only declare the output in case the producer actually creates columns
+        if self.calibrator_inst.produced_columns:
+            outputs["columns"] = self.target(f"calib_{self.branch}.parquet")
+
+        return outputs
 
     @law.decorator.log
     @ensure_proxy

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -54,8 +54,9 @@ class CreateHistograms(
         if not self.pilot:
             if self.producers:
                 reqs["producers"] = [
-                    self.reqs.ProduceColumns.req(self, producer=p)
-                    for p in self.producers
+                    self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                    for producer_inst in self.producer_insts
+                    if producer_inst.produced_columns
                 ]
             if self.ml_models:
                 reqs["ml"] = [
@@ -72,8 +73,9 @@ class CreateHistograms(
 
         if self.producers:
             reqs["producers"] = [
-                self.reqs.ProduceColumns.req(self, producer=p)
-                for p in self.producers
+                self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                for producer_inst in self.producer_insts
+                if producer_inst.produced_columns
             ]
         if self.ml_models:
             reqs["ml"] = [

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -72,19 +72,25 @@ class PrepareMLEvents(
 
         if not self.pilot and self.producers:
             reqs["producers"] = [
-                self.reqs.ProduceColumns.req(self, producer=p)
-                for p in self.producers
+                self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                for producer_inst in self.producer_insts
+                if producer_inst.produced_columns
             ]
 
         return reqs
 
     def requires(self):
-        reqs = {"events": self.reqs.MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"})}
+        reqs = {
+            "events": self.reqs.MergeReducedEvents.req(self, tree_index=self.branch, _exclude={"branch"}),
+        }
+
         if self.producers:
             reqs["producers"] = [
-                self.reqs.ProduceColumns.req(self, producer=p)
-                for p in self.producers
+                self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                for producer_inst in self.producer_insts
+                if producer_inst.produced_columns
             ]
+
         return reqs
 
     @MergeReducedEventsUser.maybe_dummy
@@ -443,8 +449,9 @@ class MLEvaluation(
 
         if not self.pilot and self.producers:
             reqs["producers"] = [
-                self.reqs.ProduceColumns.req(self, producer=p)
-                for p in self.producers
+                self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                for producer_inst in self.producer_insts
+                if producer_inst.produced_columns
             ]
 
         return reqs
@@ -468,8 +475,9 @@ class MLEvaluation(
 
         if self.producers:
             reqs["producers"] = [
-                self.reqs.ProduceColumns.req(self, producer=p)
-                for p in self.producers
+                self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                for producer_inst in self.producer_insts
+                if producer_inst.produced_columns
             ]
 
         return reqs

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -59,15 +59,21 @@ class ProduceColumns(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return {"columns": self.target(f"columns_{self.branch}.parquet")}
+        outputs = {}
+
+        # only declare the output in case the producer actually creates columns
+        if self.producer_inst.produced_columns:
+            outputs["columns"] = self.target(f"columns_{self.branch}.parquet")
+
+        return outputs
 
     @law.decorator.log
     @law.decorator.localize(input=False)
     @law.decorator.safe_output
     def run(self):
         from columnflow.columnar_util import (
-            Route, RouteFilter, mandatory_coffea_columns, update_ak_array,
-            add_ak_aliases, sorted_ak_to_parquet,
+            Route, RouteFilter, mandatory_coffea_columns, update_ak_array, add_ak_aliases,
+            sorted_ak_to_parquet,
         )
 
         # prepare inputs and outputs

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -53,7 +53,8 @@ class ReduceEvents(
         if not self.pilot:
             reqs["calibrations"] = [
                 self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c in self.calibrators
+                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                if calibrator_inst.produced_columns
             ]
             reqs["selection"] = self.reqs.SelectEvents.req(self)
         else:
@@ -68,7 +69,8 @@ class ReduceEvents(
             "lfns": self.reqs.GetDatasetLFNs.req(self),
             "calibrations": [
                 self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c in self.calibrators
+                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                if calibrator_inst.produced_columns
             ],
             "selection": self.reqs.SelectEvents.req(self),
         }

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -52,8 +52,8 @@ class ReduceEvents(
 
         if not self.pilot:
             reqs["calibrations"] = [
-                self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                self.reqs.CalibrateEvents.req(self, calibrator=calibrator_inst.cls_name)
+                for calibrator_inst in self.calibrator_insts
                 if calibrator_inst.produced_columns
             ]
             reqs["selection"] = self.reqs.SelectEvents.req(self)
@@ -68,8 +68,8 @@ class ReduceEvents(
         return {
             "lfns": self.reqs.GetDatasetLFNs.req(self),
             "calibrations": [
-                self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                self.reqs.CalibrateEvents.req(self, calibrator=calibrator_inst.cls_name)
+                for calibrator_inst in self.calibrator_insts
                 if calibrator_inst.produced_columns
             ],
             "selection": self.reqs.SelectEvents.req(self),

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -52,8 +52,8 @@ class SelectEvents(
 
         if not self.pilot:
             reqs["calib"] = [
-                self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                self.reqs.CalibrateEvents.req(self, calibrator=calibrator_inst.cls_name)
+                for calibrator_inst in self.calibrator_insts
                 if calibrator_inst.produced_columns
             ]
         else:
@@ -70,8 +70,8 @@ class SelectEvents(
         reqs = {
             "lfns": self.reqs.GetDatasetLFNs.req(self),
             "calibrations": [
-                self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                self.reqs.CalibrateEvents.req(self, calibrator=calibrator_inst.cls_name)
+                for calibrator_inst in self.calibrator_insts
                 if calibrator_inst.produced_columns
             ],
         }

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -53,7 +53,8 @@ class SelectEvents(
         if not self.pilot:
             reqs["calib"] = [
                 self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c in self.calibrators
+                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                if calibrator_inst.produced_columns
             ]
         else:
             # pass-through pilot workflow requirements of upstream task
@@ -70,7 +71,8 @@ class SelectEvents(
             "lfns": self.reqs.GetDatasetLFNs.req(self),
             "calibrations": [
                 self.reqs.CalibrateEvents.req(self, calibrator=c)
-                for c in self.calibrators
+                for c, calibrator_inst in zip(self.calibrators, self.calibrator_insts)
+                if calibrator_inst.produced_columns
             ],
         }
 

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -47,8 +47,9 @@ class UniteColumns(
         if not self.pilot:
             if self.producers:
                 reqs["producers"] = [
-                    self.reqs.ProduceColumns.req(self, producer=p)
-                    for p in self.producers
+                    self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                    for producer_inst in self.producer_insts
+                    if producer_inst.produced_columns
                 ]
             if self.ml_models:
                 reqs["ml"] = [
@@ -65,8 +66,9 @@ class UniteColumns(
 
         if self.producers:
             reqs["producers"] = [
-                self.reqs.ProduceColumns.req(self, producer=p)
-                for p in self.producers
+                self.reqs.ProduceColumns.req(self, producer=producer_inst.cls_name)
+                for producer_inst in self.producer_insts
+                if producer_inst.produced_columns
             ]
         if self.ml_models:
             reqs["ml"] = [


### PR DESCRIPTION
Calibrators and producers, similar to selectors, can produce columns very dynamically, i.e., under certain circumstances, some columns might be added or not.

Using the fact that we can predict this dynamic behavior, this PR adds some features to make the task structure more dynamic as well.

In case a calibrator does not produce any column at all:

- `CalibratorEvents` has no outputs and is considered complete instantly. So far, the task ran, required IO and produced an empty array.
- `SelectEvents` and `ReduceEvents` do not require `CalibrateEvents`.

In case a producer does not produce any column at all:

- `ProduceColumns` has no outputs and is considered complete instantly. So far, the task ran, required IO and produced an empty array.
- `CreateHistograms`, `UniteColumns`, `PrepareMLEvents` and `MLEvaluation` do not require `ProduceColumns`.

The changes required for this are minimal :)