### PR TITLE
Read inputs for lambda-valued variable expressions.

### DIFF
--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -114,7 +114,9 @@ class CreateCutflowHistograms(
                     route = Route(expr)
                     expr = functools.partial(route.apply, null_value=variable_inst.null_value)
                     read_columns.add(route)
-                # TODO: handle variable_inst with custom expressions, can they declare columns?
+                else:
+                    # for variable_inst with custom expressions, read columns declared via aux key
+                    read_columns |= {inp for inp in variable_inst.x("inputs", [])}
                 expressions[variable_inst.name] = expr
 
         # prepare columns to load

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -116,20 +116,17 @@ class CreateHistograms(
         # define columns that need to be read
         read_columns = {"category_ids", "process_id"} | set(aliases.values())
         read_columns |= {
-            Route(variable_inst.expression)
-            for variable_inst in (
-                self.config_inst.get_variable(var_name)
-                for var_name in law.util.flatten(self.variable_tuples.values())
-            )
-            if isinstance(variable_inst.expression, str)
-        } | {
-            # for variable_inst with custom expressions, read columns declared via aux key
             Route(inp)
             for variable_inst in (
                 self.config_inst.get_variable(var_name)
                 for var_name in law.util.flatten(self.variable_tuples.values())
             )
-            for inp in variable_inst.x("inputs", [])
+            for inp in (
+                [variable_inst.expression]
+                if isinstance(variable_inst.expression, str)
+                # for variable_inst with custom expressions, read columns declared via aux key
+                else variable_inst.x("inputs", [])
+            )
         }
         if self.dataset_inst.is_mc:
             read_columns |= {Route(column) for column in self.config_inst.x.event_weights}

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -117,12 +117,19 @@ class CreateHistograms(
         read_columns = {"category_ids", "process_id"} | set(aliases.values())
         read_columns |= {
             Route(variable_inst.expression)
-            if isinstance(variable_inst.expression, str) else
-            None  # TODO: handle variable_inst with custom expressions, can they declare columns?
             for variable_inst in (
                 self.config_inst.get_variable(var_name)
                 for var_name in law.util.flatten(self.variable_tuples.values())
             )
+            if isinstance(variable_inst.expression, str)
+        } | {
+            # for variable_inst with custom expressions, read columns declared via aux key
+            Route(inp)
+            for variable_inst in (
+                self.config_inst.get_variable(var_name)
+                for var_name in law.util.flatten(self.variable_tuples.values())
+            )
+            for inp in variable_inst.x("inputs", [])
         }
         if self.dataset_inst.is_mc:
             read_columns |= {Route(column) for column in self.config_inst.x.event_weights}


### PR DESCRIPTION
This PR adds a way for variables to declare input columns in case their `expression` is not a string-valued column specifier but a callable/lambda which calculates the variable value on the fly from the event array.

In such cases, the list of columns that are actually needed by the expression must be specified in a different way. The approach chosen here requires that these are given via an optional `inputs` key in the `aux` field of the variable, for instance:
```python
config.add_variable(
    name="ht",
    expression=lambda events: ak.sum(events.Jet.pt, axis=1),
    binning=(40, 0.0, 800.0),
    unit="GeV",
    x_title="$H_{T}$",
    aux={
        "inputs": {"Jet.pt"},
    },
)
```

This is intended as more of a workaround, so we can also discuss a more definitive fix. An alternative approach would be to wrap the bare `lambda` with something that allows specifying input columns, as it's being done for the CSP decorators via the `uses` keyword. However, it might take longer to understand what a better solution could be, so for the time being we should consider merging this workaround to provide early support for analyses relying on lambda-valued variable expressions.