### PR TITLE
allow setting default csp via function

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -270,7 +270,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
     def resolve_config_default(
         cls,
         task_params: dict[str, Any],
-        param: str,
+        param: str | tuple[str] | None,
         container: str | od.AuxDataMixin = "config_inst",
         default_str: str | None = None,
         multiple: bool = False,
@@ -372,7 +372,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             return param
 
         # expand default when param is empty
-        if param in (None, law.NO_STR):
+        print("d", default_str, param)
+        if param in (None, law.NO_STR, tuple()):
             param = container.x(default_str, None) if default_str else None
 
             # allow default to be a function, taking task parameters as input
@@ -391,7 +392,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
     def resolve_config_default_and_groups(
         cls,
         task_params: dict[str, Any],
-        param: tuple[str],
+        param: str | tuple[str] | None,
         container: str | od.AuxDataMixin = "config_inst",
         default_str: str | None = None,
         groups_str: str | None = None,
@@ -437,7 +438,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             return param
 
         # expand default when param is empty
-        if param in (None, law.NO_STR):
+        print("d+g", default_str, param)
+        if param in (None, law.NO_STR, tuple()):
             param = container.x(default_str, None) if default_str else None
 
             # allow default to be a function, taking task parameters as input

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -372,7 +372,6 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             return param
 
         # expand default when param is empty
-        print("d", default_str, param)
         if param in (None, law.NO_STR, tuple()):
             param = container.x(default_str, None) if default_str else None
 
@@ -438,7 +437,6 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             return param
 
         # expand default when param is empty
-        print("d+g", default_str, param)
         if param in (None, law.NO_STR, tuple()):
             param = container.x(default_str, None) if default_str else None
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -463,7 +463,7 @@ class ConfigTask(AnalysisTask):
 
             # allow default to be a function, taking task parameters as input
             if isinstance(param, Callable):
-                param = param(**task_params)
+                param = param(container, **task_params)
 
         # if multiple params are returned, use the first
         if param and isinstance(param, (list, tuple)):
@@ -498,7 +498,7 @@ class ConfigTask(AnalysisTask):
 
             # allow default to be a function, taking task parameters as input
             if isinstance(param, Callable):
-                param = param(**task_params)
+                param = param(container, **task_params)
 
             if not param:
                 return ()

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -366,29 +366,28 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             resolve_param_values(params)  # sets params["ml_model"] to "some_ml_model"
         """
 
-        # get the container inst
-        if isinstance(container, str):
-            container = task_params.get(container, None)
-
-        if not container:
-            return param
-
-        # expand default when param is empty
         if param in (None, law.NO_STR, tuple()):
-            param = container.x(default_str, None) if default_str else None
+            param = None
 
-            # allow default to be a function, taking task parameters as input
-            if isinstance(param, Callable):
-                param = param(container, **task_params)
+            # get the container inst
+            if isinstance(container, str):
+                container = task_params.get(container)
 
-        # return either a tuple or only the first param, based on the *multiple* parameter
+            # expand default when container is set
+            if container and default_str:
+                param = container.x(default_str, None)
+
+                # allow default to be a function, taking task parameters as input
+                if isinstance(param, Callable):
+                    param = param(container, **task_params)
+
+        # when still empty, return an empty value
         if not param:
             return () if multiple else None
-
+        
+        # return either a tuple or the first param, based on the *multiple*
         param = law.util.make_tuple(param)
         return param if multiple else param[0]
-
-        return param
 
     @classmethod
     def resolve_config_default_and_groups(

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -384,7 +384,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         # when still empty, return an empty value
         if not param:
             return () if multiple else None
-        
+
         # return either a tuple or the first param, based on the *multiple*
         param = law.util.make_tuple(param)
         return param if multiple else param[0]
@@ -447,7 +447,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             return ()
 
         # expand groups recursively
-        if default_str and (param_groups := container.x(groups_str, {})):
+        if groups_str and (param_groups := container.x(groups_str, {})):
             values = []
             lookup = law.util.make_list(param)
             handled_groups = set()

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -47,14 +47,16 @@ class CalibratorMixin(ConfigTask):
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
 
-        # add the default calibrator when empty
-        params["calibrator"] = cls.resolve_config_default(
-            params,
-            params.get("calibrator"),
-            container="config_inst",
-            default_str="default_calibrator",
-        )
-        params["calibrator_inst"] = cls.get_calibrator_inst(params["calibrator"], params)
+        if config_inst := params.get("config_inst"):
+            # add the default calibrator when empty
+            params["calibrator"] = cls.resolve_config_default(
+                params,
+                params.get("calibrator"),
+                container=config_inst,
+                default_str="default_calibrator",
+                multiple=False,
+            )
+            params["calibrator_inst"] = cls.get_calibrator_inst(params["calibrator"], params)
 
         return params
 
@@ -118,14 +120,15 @@ class CalibratorsMixin(ConfigTask):
     @classmethod
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
-
-        params["calibrators"] = cls.resolve_config_default_and_groups(
-            params,
-            params.get("calibrators"),
-            default_str="default_calibrator",
-            groups_str="calibrator_groups",
-        )
-        params["calibrator_insts"] = cls.get_calibrator_insts(params["calibrators"], params)
+        if config_inst := params.get("config_inst"):
+            params["calibrators"] = cls.resolve_config_default_and_groups(
+                params,
+                params.get("calibrators"),
+                container=config_inst,
+                default_str="default_calibrator",
+                groups_str="calibrator_groups",
+            )
+            params["calibrator_insts"] = cls.get_calibrator_insts(params["calibrators"], params)
 
         return params
 
@@ -192,11 +195,13 @@ class SelectorMixin(ConfigTask):
         params = super().resolve_param_values(params)
 
         # add the default selector when empty
-        if "config_inst" in params:
+        if config_inst := params.get("config_inst"):
             params["selector"] = cls.resolve_config_default(
                 params,
                 params.get("selector"),
+                container=config_inst,
                 default_str="default_selector",
+                multiple=False,
             )
             params["selector_inst"] = cls.get_selector_inst(params["selector"], params)
 
@@ -257,10 +262,11 @@ class SelectorStepsMixin(SelectorMixin):
         params = super().resolve_param_values(params)
 
         # apply selector_steps_groups and default_selector_steps from config
-        if "config_inst" in params:
+        if config_inst := params.get("config_inst"):
             params["selector_steps"] = cls.resolve_config_default_and_groups(
                 params,
                 params.get("selector_steps"),
+                container=config_inst,
                 default_str="default_selector_steps",
                 groups_str="selector_step_groups",
             )
@@ -304,11 +310,13 @@ class ProducerMixin(ConfigTask):
         params = super().resolve_param_values(params)
 
         # add the default producer when empty
-        if "config_inst" in params:
+        if config_inst := params.get("config_inst"):
             params["producer"] = cls.resolve_config_default(
                 params,
                 params.get("producer"),
+                container=config_inst,
                 default_str="default_producer",
+                multiple=False,
             )
             params["producer_inst"] = cls.get_producer_inst(params["producer"], params)
 
@@ -375,10 +383,11 @@ class ProducersMixin(ConfigTask):
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
 
-        if "config_inst" in params:
+        if config_inst := params.get("config_inst"):
             params["producers"] = cls.resolve_config_default_and_groups(
                 params,
                 params.get("producers"),
+                container=config_inst,
                 default_str="default_producer",
                 groups_str="producer_groups",
             )
@@ -560,6 +569,7 @@ class MLModelTrainingMixin(MLModelMixinBase):
                 selectors[i],
                 container=config_inst,
                 default_str="default_selector",
+                multiple=False,
             )
             for i, config_inst in enumerate(ml_model_inst.config_insts)
         )
@@ -636,6 +646,8 @@ class MLModelTrainingMixin(MLModelMixinBase):
 
         if "analysis_inst" in params and "ml_model" in params:
             analysis_inst = params["analysis_inst"]
+
+            # NOTE: we could try to implement resolving the default ml_model here
             ml_model_inst = cls.get_ml_model_inst(params["ml_model"], analysis_inst)
             params["ml_model_inst"] = ml_model_inst
 
@@ -734,11 +746,14 @@ class MLModelMixin(ConfigTask, MLModelMixinBase):
         if "analysis_inst" in params and "config_inst" in params:
             analysis_inst = params["analysis_inst"]
             config_inst = params["config_inst"]
-            if (
-                params.get("ml_model") in (None, law.NO_STR) and
-                config_inst.x("default_ml_model", None)
-            ):
-                params["ml_model"] = config_inst.x.default_ml_model
+
+            params["ml_model"] = cls.resolve_config_default(
+                params,
+                params.get("ml_model"),
+                container=config_inst,
+                default_str="default_ml_model",
+                multiple=False,
+            )
 
             # initialize it once to trigger its set_config hook which might, in turn,
             # add objects to the config itself
@@ -811,6 +826,7 @@ class MLModelsMixin(ConfigTask):
             params["ml_models"] = cls.resolve_config_default_and_groups(
                 params,
                 params.get("ml_models"),
+                container=config_inst,
                 default_str="default_ml_model",
                 groups_str="ml_model_groups",
             )
@@ -866,10 +882,14 @@ class InferenceModelMixin(ConfigTask):
         params = super().resolve_param_values(params)
 
         # add the default inference model when empty
-        if "config_inst" in params:
-            config_inst = params["config_inst"]
-            if params.get("inference_model") in (None, law.NO_STR) and config_inst.x("default_inference_model", None):
-                params["inference_model"] = config_inst.x.default_inference_model
+        if config_inst := params.get("config_inst"):
+            params["inference_model"] = cls.resolve_config_default(
+                params,
+                params.get("inference_model"),
+                container=config_inst,
+                default_str="default_inference_model",
+                multiple=False,
+            )
 
         return params
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -48,13 +48,13 @@ class CalibratorMixin(ConfigTask):
         params = super().resolve_param_values(params)
 
         # add the default calibrator when empty
-        if "config_inst" in params:
-            params["calibrator"] = cls.resolve_config_default(
-                params["config_inst"],
-                params.get("calibrator"),
-                default_str="default_calibrator",
-            )
-            params["calibrator_inst"] = cls.get_calibrator_inst(params["calibrator"], params)
+        params["calibrator"] = cls.resolve_config_default(
+            params,
+            params.get("calibrator"),
+            container="config_inst",
+            default_str="default_calibrator",
+        )
+        params["calibrator_inst"] = cls.get_calibrator_inst(params["calibrator"], params)
 
         return params
 
@@ -119,14 +119,13 @@ class CalibratorsMixin(ConfigTask):
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
 
-        if "config_inst" in params:
-            params["calibrators"] = cls.resolve_config_default_and_groups(
-                params["config_inst"],
-                params.get("calibrators"),
-                default_str="default_calibrator",
-                groups_str="calibrator_groups",
-            )
-            params["calibrator_insts"] = cls.get_calibrator_insts(params["calibrators"], params)
+        params["calibrators"] = cls.resolve_config_default_and_groups(
+            params,
+            params.get("calibrators"),
+            default_str="default_calibrator",
+            groups_str="calibrator_groups",
+        )
+        params["calibrator_insts"] = cls.get_calibrator_insts(params["calibrators"], params)
 
         return params
 
@@ -195,7 +194,7 @@ class SelectorMixin(ConfigTask):
         # add the default selector when empty
         if "config_inst" in params:
             params["selector"] = cls.resolve_config_default(
-                params["config_inst"],
+                params,
                 params.get("selector"),
                 default_str="default_selector",
             )
@@ -260,7 +259,7 @@ class SelectorStepsMixin(SelectorMixin):
         # apply selector_steps_groups and default_selector_steps from config
         if "config_inst" in params:
             params["selector_steps"] = cls.resolve_config_default_and_groups(
-                params["config_inst"],
+                params,
                 params.get("selector_steps"),
                 default_str="default_selector_steps",
                 groups_str="selector_step_groups",
@@ -307,7 +306,7 @@ class ProducerMixin(ConfigTask):
         # add the default producer when empty
         if "config_inst" in params:
             params["producer"] = cls.resolve_config_default(
-                params["config_inst"],
+                params,
                 params.get("producer"),
                 default_str="default_producer",
             )
@@ -378,7 +377,7 @@ class ProducersMixin(ConfigTask):
 
         if "config_inst" in params:
             params["producers"] = cls.resolve_config_default_and_groups(
-                params["config_inst"],
+                params,
                 params.get("producers"),
                 default_str="default_producer",
                 groups_str="producer_groups",
@@ -511,8 +510,9 @@ class MLModelTrainingMixin(MLModelMixinBase):
         # apply calibrators_groups and default_calibrator from the config
         calibrators = tuple(
             ConfigTask.resolve_config_default_and_groups(
-                config_inst,
+                params,
                 calibrators[i],
+                container=config_inst,
                 default_str="default_calibrator",
                 groups_str="calibrator_groups",
             )
@@ -556,9 +556,10 @@ class MLModelTrainingMixin(MLModelMixinBase):
         # use config defaults
         selectors = tuple(
             ConfigTask.resolve_config_default(
-                config_inst,
+                params,
                 selectors[i],
-                "default_selector",
+                container=config_inst,
+                default_str="default_selector",
             )
             for i, config_inst in enumerate(ml_model_inst.config_insts)
         )
@@ -599,8 +600,9 @@ class MLModelTrainingMixin(MLModelMixinBase):
         # apply producers_groups and default_producer from the config
         producers = tuple(
             ConfigTask.resolve_config_default_and_groups(
-                config_inst,
+                params,
                 producers[i],
+                container=config_inst,
                 default_str="default_producer",
                 groups_str="producer_groups",
             )
@@ -807,7 +809,7 @@ class MLModelsMixin(ConfigTask):
 
             # apply ml_model_groups and default_ml_model from the config
             params["ml_models"] = cls.resolve_config_default_and_groups(
-                params["config_inst"],
+                params,
                 params.get("ml_models"),
                 default_str="default_ml_model",
                 groups_str="ml_model_groups",


### PR DESCRIPTION
This PR allows defining your default_{calibrator,selector,producer,ml_model} as a function that takes all task parameters as inputs.

This PR also allows setting multiple CSPs as your default_csp. For tasks that can only use one CSP, the first one is used.

Example 1: choosing the ml_model based on some default that is set in the inference_model
```python
from columnflow.inference import InferenceModel

def default_ml_model(container, **task_params):
    """ Function that chooses the default_ml_model based on the inference_model if given """
    default_ml_model = None

    # check if task is using an inference model
    if "inference_model" in task_params.keys():
        inference_model = task_params.get("inference_model", None)

        # if inference model is not set, assume it's the container default
        if inference_model in (None, "NO_STR"):
            inference_model = container.x.default_inference_model

        # get the default_ml_model from the inference_model_inst
        inference_model_inst = InferenceModel._subclasses[inference_model]
        default_ml_model = getattr(inference_model_inst, "ml_model_name", default_ml_model)

        return default_ml_model

    return default_ml_model

config_inst.x.default_ml_model = default_ml_model
```

Example 2: extend your default_producers based on which ML Model is used (using Example 1)
```python
def default_producers(container, **task_params):
    """ Default producers chosen based on the Inference model and the ML Model """

    # per default, use the ml_inputs and event_weights
    default_producers = ["ml_inputs", "event_weights"]

    # check if a ml_model has been set
    ml_model = task_params.get("mlmodel", None) or task_params.get("mlmodels", None)

    # only consider 1 ml_model
    if isinstance(ml_model, (list, tuple)):
        ml_model = ml_model[0]

    # try and get the default ml model if not set
    if ml_model in (None, "NO_STR"):
        ml_model = default_ml_model(container, **task_params)

    # if a ML model is set, add some producer that depends on the ML Model (e.g. for categorising based on ML outputs)
    if ml_model not in (None, "NO_STR"):
        default_producers.insert(0, f"ml_{ml_model}")

    return default_producers

config_inst.x.default_producer = default_producer
```