### PR TITLE
Add functionality to mark `used` and `produced` columns as optional.

### DIFF
--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -11,7 +11,7 @@ from columnflow.calibration import Calibrator, calibrator
 from columnflow.calibration.util import ak_random, propagate_met
 from columnflow.production.util import attach_coffea_behavior
 from columnflow.util import maybe_import, InsertableDict, DotDict
-from columnflow.columnar_util import set_ak_column, layout_ak_array
+from columnflow.columnar_util import set_ak_column, layout_ak_array, optional_column as optional
 
 
 np = maybe_import("numpy")
@@ -150,13 +150,14 @@ def get_jec_config_default(self) -> DotDict:
 @calibrator(
     uses={
         "Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass", "Jet.area", "Jet.rawFactor",
-        "Jet.jetId", "fixedGridRhoFastjetAll", "Rho.fixedGridRhoFastjetAll",
+        "Jet.jetId",
+        optional("fixedGridRhoFastjetAll"),
+        optional("Rho.fixedGridRhoFastjetAll"),
         attach_coffea_behavior,
     },
     produces={
         "Jet.pt", "Jet.mass", "Jet.rawFactor",
     },
-    check_columns_present={"produces"},  # some used columns optional
     # custom uncertainty sources, defaults to config when empty
     uncertainty_sources=None,
     # toggle for propagation to MET
@@ -542,7 +543,8 @@ def get_jer_config(self) -> DotDict:
 @calibrator(
     uses={
         "Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass", "Jet.genJetIdx",
-        "Rho.fixedGridRhoFastjetAll", "fixedGridRhoFastjetAll",
+        optional("Rho.fixedGridRhoFastjetAll"),
+        optional("fixedGridRhoFastjetAll"),
         "GenJet.pt", "GenJet.eta", "GenJet.phi",
         "MET.pt", "MET.phi",
         attach_coffea_behavior,
@@ -554,7 +556,6 @@ def get_jer_config(self) -> DotDict:
         "MET.pt", "MET.phi",
         "MET.pt_jer_up", "MET.pt_jer_down", "MET.phi_jer_up", "MET.phi_jer_down",
     },
-    check_columns_present={"produces"},  # some used columns optional
     # toggle for propagation to MET
     propagate_met=True,
     # only run on mc

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -345,7 +345,10 @@ class Route(od.TagMixin):
         return self.join(self._fields)
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} '{self}' at {hex(id(self))}>"
+        tags = ""
+        if self.tags:
+            tags = f" (tags={','.join(sorted(self.tags))})"
+        return f"<{self.__class__.__name__} '{self}'{tags} at {hex(id(self))}>"
 
     def __hash__(self) -> int:
         return hash(str(self.fields))

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -20,7 +20,6 @@ import re
 import math
 import time
 import enum
-import fnmatch
 import threading
 import multiprocessing
 import multiprocessing.pool
@@ -34,7 +33,7 @@ from law.util import InsertableDict
 
 from columnflow.util import (
     UNSET, maybe_import, classproperty, DotDict, DerivableMeta, Derivable, pattern_matcher,
-    get_source_code, is_pattern,
+    get_source_code,
 )
 
 

--- a/columnflow/production/cms/mc_weight.py
+++ b/columnflow/production/cms/mc_weight.py
@@ -6,7 +6,7 @@ Methods for dealing with MC weights.
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
-from columnflow.columnar_util import set_ak_column, has_ak_column
+from columnflow.columnar_util import set_ak_column, has_ak_column, optional_column as optional
 
 
 np = maybe_import("numpy")
@@ -14,11 +14,10 @@ ak = maybe_import("awkward")
 
 
 @producer(
-    uses={"genWeight", "LHEWeight.originalXWGTUP"},
+    uses={"genWeight", optional("LHEWeight.originalXWGTUP")},
     produces={"mc_weight"},
     # only run on mc
     mc_only=True,
-    check_columns_present={"produces"},  # some used columns optional
 )
 def mc_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """

--- a/columnflow/production/cms/seeds.py
+++ b/columnflow/production/cms/seeds.py
@@ -8,7 +8,12 @@ import hashlib
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import, primes, InsertableDict
-from columnflow.columnar_util import Route, set_ak_column, has_ak_column
+from columnflow.columnar_util import (
+    Route,
+    set_ak_column,
+    has_ak_column,
+    optional_column as optional,
+)
 
 
 np = maybe_import("numpy")
@@ -19,11 +24,11 @@ ak = maybe_import("awkward")
     uses={
         # global columns for event seed
         "run", "luminosityBlock", "event",
-        "Photon.pt", "SV.pt",
+        optional("Photon.pt"), optional("SV.pt"),
         # first-object columns for event seed
-        "Tau.jetIdx", "Tau.decayMode",
-        "Muon.jetIdx", "Muon.nStations",
-        "Jet.nConstituents", "Jet.nElectrons", "Jet.nMuons",
+        optional("Tau.jetIdx"), optional("Tau.decayMode"),
+        optional("Muon.jetIdx"), optional("Muon.nStations"),
+        optional("Jet.nConstituents"), optional("Jet.nElectrons"), optional("Jet.nMuons"),
     },
     produces={"deterministic_seed"},
 )

--- a/tests/run_test
+++ b/tests/run_test
@@ -11,6 +11,7 @@ action() {
     # get and check arguments
     local mod="$1"
     local sandbox="$2"
+
     if [ -z "${mod}" ]; then
         2>&1 echo "missing module to test (argument 1)"
         return "1"
@@ -24,10 +25,10 @@ action() {
             python -m unittest "tests.${mod}"
         )
     else
-        echo "testing ${mod} in sandbox ${sandbox} ..."
+        echo "testing ${mod} ..."
         (
             cd "${cf_dir}" && \
-            bash -c "source \"sandboxes/${sandbox}\" \"\" yes && python -m unittest \"tests.${mod}\""
+            cf_sandbox "${sandbox}" "python -m unittest tests.${mod}"
         )
     fi
 }

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -6,6 +6,7 @@ action() {
     local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
+    local cf_dir="$( dirname "${this_dir}" )"
 
     # dev flag for sandboxes
     local dev="$( [ "${CF_DEV}" = "1" ] && echo "_dev" || echo "" )"
@@ -21,7 +22,7 @@ action() {
 
     # test_columnar_util
     echo
-    bash "${this_dir}/run_test" test_columnar_util "venv_columnar${dev}.sh"
+    bash "${this_dir}/run_test" test_columnar_util "${cf_dir}/sandboxes/venv_columnar${dev}.sh"
     ret="$?"
     [ "${gret}" = "0" ] && gret="${ret}"
 


### PR DESCRIPTION
This PR introduces a mechanism for more fine-grained control over which input/output columns of array functions should be covered by the checks introduced in PR #240. In the current implementation, these checks can only be turned on or off for all columns simultaneously, which limits the usability of this feature for functions that only read/produce certain columns under specific circumstances.

By default, columns given  in the `uses` (`produces`) keywords of `ArrayFunction`s are assumed to be required and their presence in the input (output) arrays will be checked . To mark optional columns, an `optional_column` function is provided in `columnar_util`, which can be used as follows:
```python
from columnflow.production import producer
from columnflow.columnar_util import optional_column

@producer(
    uses={
        "required_column",
        optional_column("my_optional_column"),
    },
    produces={
        "always_produced_column",
        optional_column("maybe_produced_column"),
    },
)
def my_producer(...):
    ...
```