### PR TITLE
Add process scale attribute to inference model

### DIFF
--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -126,6 +126,7 @@ class InferenceModel(Derivable):
                 config_process: hh
                 is_signal: True
                 config_mc_datasets: [hh_ggf]
+                scale: 1.0
                 parameters:
                   - name: lumi
                     type: rate_gauss
@@ -143,6 +144,7 @@ class InferenceModel(Derivable):
                 is_signal: False
                 config_process: ttbar
                 config_mc_datasets: [tt_sl, tt_dl, tt_fh]
+                scale: 1.0
                 parameters:
                   - name: lumi
                     type: rate_gauss
@@ -280,6 +282,7 @@ class InferenceModel(Derivable):
         config_process: str | None = None,
         is_signal: bool = False,
         config_mc_datasets: Sequence[str] | None = None,
+        scale: float | int = 1.0,
     ) -> DotDict:
         """
         Returns a dictionary representing a process, forwarding all arguments.
@@ -288,12 +291,14 @@ class InferenceModel(Derivable):
             - *is_signal*: A boolean flag deciding whether this process describes signal.
             - *config_process*: The name of the source process in the config to use.
             - *config_mc_datasets*: List of names of MC datasets in the config to use.
+            - *scale*: A float value to scale the process, defaulting to 1.0.
         """
         return DotDict([
             ("name", str(name)),
             ("is_signal", bool(is_signal)),
             ("config_process", str(config_process) if config_process else None),
             ("config_mc_datasets", list(map(str, config_mc_datasets or []))),
+            ("scale", float(scale)),
             ("parameters", []),
         ])
 
@@ -1308,6 +1313,27 @@ class InferenceModel(Derivable):
             for process_name, parameters in parameters.items():
                 for parameter in parameters:
                     yield (category_name, process_name, parameter)
+
+    #
+    # other helpers
+    #
+
+    def scale_process(
+        self,
+        scale: int | float,
+        process: str | Sequence[str] | None = None,
+        category: str | Sequence[str] | None = None,
+    ) -> bool:
+        """
+        Sets the scale attribute of all processes whose names match *process*, optionally in all
+        categories whose names match *category*, to *scale*. Returns *True* if at least one process
+        was found and scale, and *False* otherwise.
+        """
+        found = False
+        for _, process in self.iter_processes(process=process, category=category):
+            process.scale = float(scale)
+            found = True
+        return found
 
 
 # shorthand

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -375,8 +375,7 @@ class DatacardWriter(object):
                 scale = proc_obj.scale
 
                 # nominal shape
-                h_nom = _hists["nominal"].copy()
-                from IPython import embed; embed()
+                h_nom = _hists["nominal"].copy() * scale
                 if fill_empty_bins:
                     fill_empty(h_nom)
                 nom_name = nom_pattern.format(category=cat_name, process=proc_name)
@@ -391,7 +390,7 @@ class DatacardWriter(object):
                             f"shapes of parameter '{param_name}' for process '{proc_name}' "
                             f"in category '{cat_name}' misconfigured: {__hists}",
                         )
-                    return __hists["down"], __hists["up"]
+                    return __hists["down"] * scale, __hists["up"] * scale
 
                 # go through all parameters and check if varied shapes need to be processed
                 for _, _, param_obj in self.inference_model_inst.iter_parameters(category=cat_name, process=proc_name):

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -370,8 +370,13 @@ class DatacardWriter(object):
                 if proc_name == "data":
                     continue
 
+                # get the process scale (usually 1)
+                proc_obj = self.inference_model_inst.get_process(proc_name, category=cat_name)
+                scale = proc_obj.scale
+
                 # nominal shape
                 h_nom = _hists["nominal"].copy()
+                from IPython import embed; embed()
                 if fill_empty_bins:
                     fill_empty(h_nom)
                 nom_name = nom_pattern.format(category=cat_name, process=proc_name)


### PR DESCRIPTION
This PR adds an additional `scale` field to process objects in the inference model.
The datacard writer uses this value to scale shapes and integrals with that factor.

This can be helpful in cases where artificial effects of different signal or background contributions should be estimated.