### PR TITLE
Improve version lookup in version map

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -31,6 +31,7 @@ analysis___cf_short_name_lc__ = ana = od.Analysis(
 )
 
 # analysis-global versions
+# (see cfg.x.versions below for more info)
 ana.x.versions = {}
 
 # files of bash sandboxes that might be required by remote tasks
@@ -239,10 +240,11 @@ cfg.x.event_weights = DotDict({
     "muon_weight": get_shifts("mu"),
 })
 
-# versions per task family and optionally also dataset and shift
-# None can be used as a key to define a default value
+# versions per task family, either referring to strings or to callables receving the invoking
+# task instance and parameters to be passed to the task family
 cfg.x.versions = {
     # "cf.CalibrateEvents": "prod1",
+    # "cf.SelectEvents": (lambda task_inst, params: "prod1" if params.get("selector") == "default" else "dev1"),
     # ...
 }
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -158,7 +158,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         # when version is a callable, invoke it
         if callable(version):
-            version = version(cls, inst, params)
+            version = version(inst, params)
 
         # at this point, version must be a string
         if not isinstance(version, str):

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -64,7 +64,9 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         default=default_analysis,
         description=f"name of the analysis; default: '{default_analysis}'",
     )
-    version = luigi.Parameter(description="mandatory version that is encoded into output paths")
+    version = luigi.Parameter(
+        description="mandatory version that is encoded into output paths",
+    )
 
     allow_empty_sandbox = True
     sandbox = None
@@ -93,7 +95,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         return params
 
     @classmethod
-    def get_analysis_inst(cls, analysis):
+    def get_analysis_inst(cls, analysis: str) -> od.Analysis:
         # prepare names
         if "." not in analysis:
             raise ValueError(f"invalid analysis format: {analysis}")
@@ -113,7 +115,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         return analysis_inst
 
     @classmethod
-    def req_params(cls, inst, **kwargs):
+    def req_params(cls, inst: AnalysisTask, **kwargs) -> dict:
         """
         Returns parameters that are jointly defined in this class and another task instance of some
         other class. The parameters are used when calling ``Task.req(self)``.
@@ -180,7 +182,11 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         return set(), upstream_shifts
 
     @classmethod
-    def get_array_function_kwargs(cls, task=None, **params):
+    def get_array_function_kwargs(
+        cls,
+        task: AnalysisTask | None = None,
+        **params,
+    ) -> dict[str, Any]:
         if task:
             analysis_inst = task.analysis_inst
         elif "analysis_inst" in params:
@@ -194,17 +200,17 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         }
 
     @classmethod
-    def get_calibrator_kwargs(cls, *args, **kwargs):
+    def get_calibrator_kwargs(cls, *args, **kwargs) -> dict[str, Any]:
         # implemented here only for simplified mro control
         return cls.get_array_function_kwargs(*args, **kwargs)
 
     @classmethod
-    def get_selector_kwargs(cls, *args, **kwargs):
+    def get_selector_kwargs(cls, *args, **kwargs) -> dict[str, Any]:
         # implemented here only for simplified mro control
         return cls.get_array_function_kwargs(*args, **kwargs)
 
     @classmethod
-    def get_producer_kwargs(cls, *args, **kwargs):
+    def get_producer_kwargs(cls, *args, **kwargs) -> dict[str, Any]:
         # implemented here only for simplified mro control
         return cls.get_array_function_kwargs(*args, **kwargs)
 


### PR DESCRIPTION
This PR improves the lookup of version in the version map defined in either the config or the analysis itself. With the new additions, the version map can look like (e.g.)

```python
cfg.x.versions = {
    "cf.CalibrateEvents": "prod1",
    "cf.SelectEvents": (lambda task_inst, params: "prod1" if params.get("selector") == "default" else "dev1"),
}
```

The overall structure is a flat dictionary mapping task families to either

- strings, to refer to a fixed version, or
- callables, to make a dynamic decision, receiving
  - `task_inst`, the task instance that requested the version for that task class (i.e. the object that invoked `task_cls.req(self)`, `self` being the `task_inst`, and `task_cls` being `cf.SelectEvents` in the example above), and
  - `params`, the other parameters determined by `req()`.