### PR TITLE
Fix hiding of error bars.

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -85,7 +85,7 @@ def draw_hist(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> None:
 
 def draw_errorbars(ax: plt.Axes, h: hist.Hist, norm: float = 1.0, **kwargs) -> None:
     values = h.values() / norm
-    variances = np.sqrt(h.variances()) / norm
+    variances = h.variances() / norm**2
     # compute asymmetric poisson errors for data
     # TODO: passing the output of poisson_interval as yerr to mpl.plothist leads to
     #       buggy error bars and the documentation is clearly wrong (mplhep 0.3.12,

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -102,19 +102,21 @@ def plot_variable_variants(
     # add hists
     for label, h in hists.items():
         norm = sum(h.values()) if shape_norm else 1
-        plot_config[f"hist_{label}"] = {
+        plot_config[f"hist_{label}"] = plot_cfg = {
             "method": "draw_hist",
             "hist": h,
             "kwargs": {
                 "norm": norm,
                 "label": selector_step_labels.get(label, label),
-                "yerr": False if hide_errors else None,
             },
             "ratio_kwargs": {
                 "norm": hists["Initial"].values(),
-                "yerr": False if hide_errors else None,
             },
         }
+        if hide_errors:
+            for key in ("kwargs", "ratio_kwargs"):
+                if key in plot_cfg:
+                    plot_cfg[key]["yerr"] = None
 
     # setup style config
     default_style_config = prepare_style_config(
@@ -176,21 +178,23 @@ def plot_shifted_variable(
         if not shift_inst.is_nominal:
             label += " ({0:+.2f}%)".format(diff * 100)
 
-        plot_config[shift_inst.name] = {
+        plot_config[shift_inst.name] = plot_cfg = {
             "method": "draw_hist",
             "hist": h,
             "kwargs": {
                 "norm": sum(h.values()) if shape_norm else 1,
                 "label": label,
                 "color": colors[shift_inst.direction],
-                "yerr": False if hide_errors else None,
             },
             "ratio_kwargs": {
                 "norm": ratio_norm,
                 "color": colors[shift_inst.direction],
-                "yerr": False if hide_errors else None,
             },
         }
+        if hide_errors:
+            for key in ("kwargs", "ratio_kwargs"):
+                if key in plot_cfg:
+                    plot_cfg[key]["yerr"] = None
 
     # legend title setting
     if not legend_title:

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -254,42 +254,52 @@ def prepare_plot_config(
                 "kwargs": {"norm": mc_norm, "label": "MC stat. unc."},
                 "ratio_kwargs": {"norm": h_mc.values()},
             }
+
     # draw lines
     for i, h in enumerate(line_hists):
         line_norm = sum(h.values()) if shape_norm else 1
-        plot_config[f"line_{i}"] = {
+        plot_config[f"line_{i}"] = plot_cfg = {
             "method": "draw_hist",
             "hist": h,
             "kwargs": {
                 "norm": line_norm,
                 "label": line_labels[i],
                 "color": line_colors[i],
-                "yerr": False if line_hide_errors[i] else None,
             },
             # "ratio_kwargs": {
             #     "norm": h.values(),
             #     "color": line_colors[i],
-            #     "yerr": False if line_hide_errors[i] else None,
             # },
         }
+
+        # suppress error bars by overriding `yerr`
+        if line_hide_errors[i]:
+            for key in ("kwargs", "ratio_kwargs"):
+                if key in plot_cfg:
+                    plot_cfg[key]["yerr"] = False
 
     # draw data
     if data_hists:
         data_norm = sum(h_data.values()) if shape_norm else 1
-        plot_config["data"] = {
+        plot_config["data"] = plot_cfg = {
             "method": "draw_errorbars",
             "hist": h_data,
             "kwargs": {
                 "norm": data_norm,
                 "label": "Data",
-                "yerr": False if any(data_hide_errors) else None,
             },
         }
+
         if h_mc is not None:
             plot_config["data"]["ratio_kwargs"] = {
                 "norm": h_mc.values() * data_norm / mc_norm,
-                "yerr": False if any(data_hide_errors) else None,
             }
+
+        # suppress error bars by overriding `yerr`
+        if any(data_hide_errors):
+            for key in ("kwargs", "ratio_kwargs"):
+                if key in plot_cfg:
+                    plot_cfg[key]["yerr"] = False
 
     return plot_config
 


### PR DESCRIPTION
This PR fixes a plotting issue that prevented error bars from being shown. 

Prior to this fix, the `yerr` parameter passed to the drawing function (which takes precedence over the error bar calculation) was erroneously being set to either `False` or `None`, leading to the error bars being not being plotted. It is now omitted from the `plot_config` entirely and only set to `False` when error hiding is requested.

I also noticed that the variance passed to the Poisson error interval is calculated as the square root of the bin variance, i.e. it is actually the standard deviation. Judging by the [`hist` documentation](https://hist.readthedocs.io/en/latest/reference/hist.intervals.html#hist.intervals.poisson_interval), this seems incorrect, as the `poisson_interval` function expects the sum of squared weights, i.e. the full variance. I therefore removed the square root.