### PR TITLE
Pilot parameter to MergeHistograms and MergeShiftedHistograms

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -124,7 +124,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         _prefer_cli = law.util.make_set(kwargs.get("_prefer_cli", [])) | {
             "version", "workflow", "job_workers", "poll_interval", "walltime", "max_runtime",
             "retries", "acceptance", "tolerance", "parallel_jobs", "shuffle_jobs", "htcondor_cpus",
-            "htcondor_gpus", "htcondor_pool",
+            "htcondor_gpus", "htcondor_pool", "pilot",
         }
         kwargs["_prefer_cli"] = _prefer_cli
 

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -265,7 +265,8 @@ class MergeHistograms(
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        reqs["hists"] = self.as_branch().requires()
+        if not self.pilot:
+            reqs["hists"] = self.as_branch().requires()
 
         return reqs
 
@@ -361,9 +362,10 @@ class MergeShiftedHistograms(
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        # add nominal and both directions per shift source
-        for shift in ["nominal"] + self.shifts:
-            reqs[shift] = self.reqs.MergeHistograms.req(self, shift=shift, _prefer_cli={"variables"})
+        if not self.pilot:
+            # add nominal and both directions per shift source
+            for shift in ["nominal"] + self.shifts:
+                reqs[shift] = self.reqs.MergeHistograms.req(self, shift=shift, _prefer_cli={"variables"})
 
         return reqs
 


### PR DESCRIPTION
The "pilot" parameter is also added to "prefer_cli", allowing to set the pilot e.g. when creating datacards:

```law run cf.CreateDatacards --version v1 --workflow htcondor --workers 4 --cf.MergeShiftedHistograms-pilot```

With this minor change, the time spent to build the dependency tree when creating datacards is reduced to a few seconds and the number of workflows that needs to be submitted is reduced significantly.
(If you prefer to submit a workflow for each systematic uncertainty, you can use the `--cf.MergeHistograms-pilot` instead)