### PR TITLE
use true number of pileup interactions in pileup producer

### DIFF
--- a/columnflow/production/cms/pileup.py
+++ b/columnflow/production/cms/pileup.py
@@ -31,7 +31,7 @@ def pu_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     functions below.
     """
     # compute the indices for looking up weights
-    indices = events.Pileup.nTrueInt.to_numpy() - 1
+    indices = events.Pileup.nTrueInt.to_numpy().astype("int32") - 1
     max_bin = len(self.pu_weights) - 1
     indices[indices > max_bin] = max_bin
 

--- a/columnflow/production/cms/pileup.py
+++ b/columnflow/production/cms/pileup.py
@@ -19,7 +19,7 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 
 
 @producer(
-    uses={"PV.npvs"},
+    uses={"Pileup.nTrueInt"},
     produces={"pu_weight", "pu_weight_minbias_xs_up", "pu_weight_minbias_xs_down"},
     # only run on mc
     mc_only=True,
@@ -31,7 +31,7 @@ def pu_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     functions below.
     """
     # compute the indices for looking up weights
-    indices = events.PV.npvs.to_numpy() - 1
+    indices = events.Pileup.nTrueInt.to_numpy() - 1
     max_bin = len(self.pu_weights) - 1
     indices[indices > max_bin] = max_bin
 


### PR DESCRIPTION
It seems that in the `pu_weight` producer, the wrong column (`PV.npvs`) has been used to determine the PU event weights.

The mc_profile that is used to determine the PU weights [1] only contains values up to a number of Pileup of 73, which leads to the PU weights shown in [2].

In the PU producer, we are using these weights to determine the PU event weights based on the number of reconstructed primary vertices (`PV.npvs`) [3], however, this column takes values above 73, which leads to both large event weights of159 and event weights of 0.
Based on the information found in [4], I think that the correct column to determine the event weights would be `Pileup.nTrueInt`. I also took a look into the NanoAODs and it seems that for the UL samples, the max. value of this column seems to be around ~< 73, which would be in agreement with the mc_profile we have seen in [1].


[1] https://github.com/columnflow/columnflow/blob/3a69281abeefc614986b89f0a7601e7a45df5888/columnflow/tasks/cms/external.py#L65
(mc profile from here: https://raw.githubusercontent.com/cms-sw/cmssw/435f0b04c0e318c1036a6b95eb169181bbbe8344/SimGeneral/MixingModule/python/mix_2017_25ns_UltraLegacy_PoissonOOTPU_cfi.py)
[2] Small section of Number of Pileup vs. nominal PU weight:
```
 (66, 1.7605077201696504),
 (67, 2.4973721771534723),
 (68, 3.604846391289538),
 (69, 3.510370430997905),
 (70, 5.546157726604674),
 (71, 16.473486457289216),
 (72, 30.20828844763221),
 (73, 159.5512994439475),
 (74, 0.0),
 (75, 0.0),
 (76, 0.0),
 ```
 [3] https://github.com/columnflow/columnflow/blob/3a69281abeefc614986b89f0a7601e7a45df5888/columnflow/production/cms/pileup.py#L34
 [4] https://twiki.cern.ch/twiki/bin/viewauth/CMS/PileupJSONFileforData
 