### PR TITLE
Add Categorizer object.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/categorization/__init__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/categorization/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/analysis_templates/cms_minimal/__cf_module_name__/categorization/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/categorization/example.py
@@ -1,0 +1,27 @@
+# coding: utf-8
+
+"""
+Exemplary selection methods.
+"""
+
+from columnflow.categorization import Categorizer, categorizer
+from columnflow.util import maybe_import
+
+
+ak = maybe_import("awkward")
+
+
+#
+# categorizer functions used by categories definitions
+#
+
+@categorizer(uses={"event"})
+def cat_incl(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    # fully inclusive selection
+    return events, ak.ones_like(events.event) == 1
+
+
+@categorizer(uses={"Jet.pt"})
+def cat_2j(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    # two or more jets
+    return events, ak.num(events.Jet.pt, axis=1) >= 2

--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -257,13 +257,13 @@ cfg.add_channel(name="mutau", id=1)
 add_category(
     cfg,
     name="incl",
-    selection="sel_incl",
+    selection="cat_incl",
     label="inclusive",
 )
 add_category(
     cfg,
     name="2j",
-    selection="sel_2j",
+    selection="cat_2j",
     label="2 jets",
 )
 

--- a/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
@@ -21,23 +21,6 @@ ak = maybe_import("awkward")
 
 
 #
-# selectors used by categories definitions
-# (not "exposed" to be used from the command line)
-#
-
-@selector(uses={"event"})
-def sel_incl(self: Selector, events: ak.Array, **kwargs) -> ak.Array:
-    # fully inclusive selection
-    return ak.ones_like(events.event) == 1
-
-
-@selector(uses={"Jet.pt"})
-def sel_2j(self: Selector, events: ak.Array, **kwargs) -> ak.Array:
-    # two or more jets
-    return ak.num(events.Jet.pt, axis=1) >= 2
-
-
-#
 # other unexposed selectors
 # (not selectable from the command line but used by other, exposed selectors)
 #
@@ -161,12 +144,18 @@ def example(
             "sum_mc_weight_selected": (events.mc_weight, results.main.event),
         }
         group_map = {
+            # per process
+            "process": {
+                "values": events.process_id,
+                "mask_fn": (lambda v: events.process_id == v),
+            },
+            # per jet multiplicity
             "njet": {
                 "values": results.x.n_jets,
                 "mask_fn": (lambda v: results.x.n_jets == v),
             },
         }
-    events = self[increment_stats](
+    events, results = self[increment_stats](
         events,
         results,
         stats,

--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -28,6 +28,7 @@ default_dataset: st_tchannel_t_powheg
 calibration_modules: columnflow.calibration.cms.{jets,met}, __cf_module_name__.calibration.example
 selection_modules: columnflow.selection.cms.{json_filter, met_filters}, __cf_module_name__.selection.example
 production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds}, __cf_module_name__.production.example
+categorization_modules: __cf_module_name__.categorization.example
 ml_modules: columnflow.ml, __cf_module_name__.ml.example
 inference_modules: columnflow.inference, __cf_module_name__.inference.example
 

--- a/columnflow/__init__.py
+++ b/columnflow/__init__.py
@@ -38,7 +38,7 @@ if law.config.has_option("outputs", "wlcg_file_systems"):
     ]
 
 
-# initialize producers, calibrators, selectors, ml and stat models
+# initialize producers, calibrators, selectors, categorizers, ml models and stat models
 from columnflow.util import maybe_import
 
 import columnflow.production  # noqa
@@ -57,6 +57,12 @@ import columnflow.selection  # noqa
 if law.config.has_option("analysis", "selection_modules"):
     for m in law.config.get_expanded("analysis", "selection_modules", split_csv=True):
         logger.debug(f"loading selection module '{m}'")
+        maybe_import(m.strip())
+
+import columnflow.categorization  # noqa
+if law.config.has_option("analysis", "categorization_modules"):
+    for m in law.config.get_expanded("analysis", "categorization_modules", split_csv=True):
+        logger.debug(f"loading categorization module '{m}'")
         maybe_import(m.strip())
 
 import columnflow.ml  # noqa

--- a/columnflow/calibration/__init__.py
+++ b/columnflow/calibration/__init__.py
@@ -19,6 +19,8 @@ class Calibrator(TaskArrayFunction):
     Base class for all calibrators.
     """
 
+    exposed = True
+
     @classmethod
     def calibrator(
         cls,

--- a/columnflow/categorization/__init__.py
+++ b/columnflow/categorization/__init__.py
@@ -7,11 +7,10 @@ Event categorization tools.
 from __future__ import annotations
 
 import inspect
-from typing import Callable, Sequence
+from typing import Callable
 
 from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
-from columnflow.config_util import expand_shift_sources
 
 
 class Categorizer(TaskArrayFunction):

--- a/columnflow/categorization/__init__.py
+++ b/columnflow/categorization/__init__.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+"""
+Event categorization tools.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Callable, Sequence
+
+from columnflow.util import DerivableMeta
+from columnflow.columnar_util import TaskArrayFunction
+from columnflow.config_util import expand_shift_sources
+
+
+class Categorizer(TaskArrayFunction):
+    """
+    Base class for all categorizers.
+    """
+
+    exposed = True
+
+    @classmethod
+    def categorizer(
+        cls,
+        func: Callable | None = None,
+        bases: tuple = (),
+        **kwargs,
+    ) -> DerivableMeta | Callable:
+        """
+        Decorator for creating a new :py:class:`~.Categorizer` subclass with additional, optional
+        *bases* and attaching the decorated function to it as ``call_func``.
+
+        All additional *kwargs* are added as class members of the new subclasses.
+
+        :param func: Function to be wrapped and integrated into new :py:class:`Categorizer`
+            instance.
+        :param bases: Additional base classes for new :py:class:`Categorizer`.
+        :return: The new :py:class:`Categorizer` instance.
+        """
+        def decorator(func: Callable) -> DerivableMeta:
+            # create the class dict
+            cls_dict = {
+                "call_func": func,
+            }
+            cls_dict.update(kwargs)
+
+            # get the module name
+            frame = inspect.stack()[1]
+            module = inspect.getmodule(frame[0])
+
+            # get the categorizer name
+            cls_name = cls_dict.pop("cls_name", func.__name__)
+
+            # create the subclass
+            subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
+
+            return subclass
+
+        return decorator(func) if func else decorator
+
+
+# shorthand
+categorizer = Categorizer.categorizer

--- a/columnflow/production/__init__.py
+++ b/columnflow/production/__init__.py
@@ -19,6 +19,8 @@ class Producer(TaskArrayFunction):
     Base class for all producers.
     """
 
+    exposed = True
+
     @classmethod
     def producer(
         cls,

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -67,7 +67,12 @@ def normalization_weights_requires(self: Producer, reqs: dict) -> None:
 
 
 @normalization_weights.setup
-def normalization_weights_setup(self: Producer, reqs: dict, inputs: dict, reader_targets: InsertableDict) -> None:
+def normalization_weights_setup(
+    self: Producer,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: InsertableDict,
+) -> None:
     """
     Sets up objects required by the computation of normalization weights and stores them as instance
     attributes:

--- a/columnflow/selection/cms/json_filter.py
+++ b/columnflow/selection/cms/json_filter.py
@@ -67,7 +67,9 @@ def json_filter(
     :param events: Array containing events in the NanoAOD format
     :param data_only: boolean flag to indicate that this selector should only run on observed data,
         defaults to True
-    :return: Array containing boolean masks to accept or reject given events
+    :return: Tuple containing the events array and a
+        :py:class:`~columnflow.selection.SelectionResult` with a "json" field in its "steps" data
+        representing a boolean mask to accept or reject given events
     """
     # handle out-of-bounds values
     run_out_of_bounds = (events.run >= self.run_ls_lookup.shape[0])
@@ -86,7 +88,7 @@ def json_filter(
     # reject out-ouf-bounds entries
     lookup_result = ak.where(out_of_bounds, False, lookup_result)
 
-    return lookup_result, SelectionResult()
+    return events, SelectionResult(steps={"json": lookup_result})
 
 
 @json_filter.requires

--- a/columnflow/selection/cms/json_filter.py
+++ b/columnflow/selection/cms/json_filter.py
@@ -6,7 +6,7 @@ Selectors for applying golden JSON in data.
 
 from __future__ import annotations
 
-from columnflow.selection import Selector, selector
+from columnflow.selection import Selector, selector, SelectionResult
 from columnflow.util import maybe_import, InsertableDict, DotDict
 
 
@@ -43,9 +43,9 @@ def get_lumi_file_default(self, external_files: DotDict) -> str:
 def json_filter(
     self: Selector,
     events: ak.Array,
-    data_only=True,
+    data_only: bool = True,
     **kwargs,
-) -> ak.Array:
+) -> tuple[ak.Array, SelectionResult]:
     """
     Select only events from certified luminosity blocks included in the "golden" JSON. This filter
     can only be applied in recorded data.
@@ -86,7 +86,7 @@ def json_filter(
     # reject out-ouf-bounds entries
     lookup_result = ak.where(out_of_bounds, False, lookup_result)
 
-    return lookup_result
+    return lookup_result, SelectionResult()
 
 
 @json_filter.requires

--- a/columnflow/selection/cms/met_filters.py
+++ b/columnflow/selection/cms/met_filters.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from columnflow.selection import Selector, selector
+from columnflow.selection import Selector, selector, SelectionResult
 from columnflow.util import maybe_import
 from columnflow.columnar_util import Route
 
@@ -40,7 +40,7 @@ def met_filters(
     self: Selector,
     events: ak.Array,
     **kwargs,
-) -> ak.Array:
+) -> tuple[ak.Array, SelectionResult]:
     """
     Compute a selection mask to filter out noisy/anomalous high-MET events
     (MET filters).
@@ -83,7 +83,7 @@ def met_filters(
         # append to the result
         result = (result & vals)
 
-    return result
+    return result, SelectionResult()
 
 
 @met_filters.init

--- a/columnflow/selection/cms/met_filters.py
+++ b/columnflow/selection/cms/met_filters.py
@@ -70,7 +70,9 @@ def met_filters(
     Returns a bool array containing the logical ``AND`` of all input columns.
 
     :param events: Array containing events in the NanoAOD format
-    :return: Array containing logical ``AND`` of all input filter columns
+    :return: Tuple containing the events array and a
+        :py:class:`~columnflow.selection.SelectionResult` with a "met_filter" field in its "steps"
+        data representing the logical ``AND`` of all input filter columns
     """
     result = ak.ones_like(events.event, dtype=bool)
 
@@ -83,7 +85,7 @@ def met_filters(
         # append to the result
         result = (result & vals)
 
-    return result, SelectionResult()
+    return events, SelectionResult(steps={"met_filter": result})
 
 
 @met_filters.init

--- a/columnflow/selection/matching.py
+++ b/columnflow/selection/matching.py
@@ -165,4 +165,4 @@ def jet_lepton_delta_r_cleaning(
     clean_jet_indices = self[delta_r_jet_lepton](events, "Jet", ["Muon", "Electron"], threshold=threshold)
 
     # TODO: should not return a new object collection but an array with masks
-    return SelectionResult(objects={"Jet": clean_jet_indices})
+    return events, SelectionResult(objects={"Jet": clean_jet_indices})

--- a/columnflow/selection/matching.py
+++ b/columnflow/selection/matching.py
@@ -150,7 +150,7 @@ def jet_lepton_delta_r_cleaning(
     stats: dict[str, Union[int, float]],
     threshold: float = 0.4,
     **kwargs,
-) -> SelectionResult:
+) -> tuple[ak.Array, SelectionResult]:
     """
     Function to apply the selection requirements necessary for a cleaning of jets against leptons.
 
@@ -160,7 +160,10 @@ def jet_lepton_delta_r_cleaning(
     :param events: Array containing events in the NanoAOD format
     :param stats: :py:class:`dictionary <dict>` containing selection stats (not used here).
     :param threshold: Threshold value for decision which objects to keep and which to reject.
-    :return: :py:class:`~columnflow.selection.SelectionResult` with indices of cleaned jets.
+
+    :return: Tuple containing the events array and a
+        :py:class:`~columnflow.selection.SelectionResult` with indices of cleaned jets in the
+        "Jet" object field.
     """
     clean_jet_indices = self[delta_r_jet_lepton](events, "Jet", ["Muon", "Electron"], threshold=threshold)
 

--- a/columnflow/selection/stats.py
+++ b/columnflow/selection/stats.py
@@ -33,7 +33,7 @@ def increment_stats(
     group_map: dict[str, dict[str, ak.Array | Callable]] | None = None,
     group_combinations: Sequence[tuple[str]] | None = None,
     **kwargs,
-) -> ak.Array:
+) -> tuple[ak.Array, SelectionResult]:
     """
     Unexposed selector that does not actually select objects but that instead increments selection
     metrics in a given dictionary *stats* given a chunk of *events* and the corresponding selection
@@ -193,7 +193,7 @@ def increment_stats(
                 else:  # SUM
                     innermost_dict[str_values[-1]] += float(ak.sum(weights[weight_mask & group_mask]))
 
-    return events
+    return events, results
 
 
 @increment_stats.setup
@@ -228,7 +228,7 @@ def increment_event_stats(
     results: SelectionResult,
     stats: dict,
     **kwargs,
-) -> ak.Array:
+) -> tuple[ak.Array, SelectionResult]:
     """
     Simplified version of :py:class:`increment_stats` that only increments the number of events and
     the number of selected events.

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -40,8 +40,12 @@ class CalibratorMixin(ConfigTask):
 
     @classmethod
     def get_calibrator_inst(cls, calibrator, kwargs=None):
+        calibrator_cls = Calibrator.get_cls(calibrator)
+        if not calibrator_cls.exposed:
+            raise RuntimeError(f"cannot use unexposed calibrator '{calibrator}' in {cls.__name__}")
+
         inst_dict = cls.get_calibrator_kwargs(**kwargs) if kwargs else None
-        return Calibrator.get_cls(calibrator)(inst_dict=inst_dict)
+        return calibrator_cls(inst_dict=inst_dict)
 
     @classmethod
     def resolve_param_values(cls, params):
@@ -118,10 +122,17 @@ class CalibratorsMixin(ConfigTask):
     @classmethod
     def get_calibrator_insts(cls, calibrators, kwargs=None):
         inst_dict = cls.get_calibrator_kwargs(**kwargs) if kwargs else None
-        return [
-            Calibrator.get_cls(calibrator)(inst_dict=inst_dict)
-            for calibrator in calibrators
-        ]
+
+        insts = []
+        for calibrator in calibrators:
+            calibrator_cls = Calibrator.get_cls(calibrator)
+            if not calibrator_cls.exposed:
+                raise RuntimeError(
+                    f"cannot use unexposed calibrator '{calibrator}' in {cls.__name__}",
+                )
+            insts.append(calibrator_cls(inst_dict=inst_dict))
+
+        return insts
 
     @classmethod
     def resolve_param_values(cls, params):
@@ -196,7 +207,6 @@ class SelectorMixin(ConfigTask):
     @classmethod
     def get_selector_inst(cls, selector, kwargs=None):
         selector_cls = Selector.get_cls(selector)
-
         if not selector_cls.exposed:
             raise RuntimeError(f"cannot use unexposed selector '{selector}' in {cls.__name__}")
 
@@ -328,8 +338,12 @@ class ProducerMixin(ConfigTask):
 
     @classmethod
     def get_producer_inst(cls, producer, kwargs=None):
+        producer_cls = Producer.get_cls(producer)
+        if not producer_cls.exposed:
+            raise RuntimeError(f"cannot use unexposed producer '{producer}' in {cls.__name__}")
+
         inst_dict = cls.get_producer_kwargs(**kwargs) if kwargs else None
-        return Producer.get_cls(producer)(inst_dict=inst_dict)
+        return producer_cls(inst_dict=inst_dict)
 
     @classmethod
     def resolve_param_values(cls, params):
@@ -406,10 +420,15 @@ class ProducersMixin(ConfigTask):
     @classmethod
     def get_producer_insts(cls, producers, kwargs=None):
         inst_dict = cls.get_producer_kwargs(**kwargs) if kwargs else None
-        return [
-            Producer.get_cls(producer)(inst_dict=inst_dict)
-            for producer in producers
-        ]
+
+        insts = []
+        for producer in producers:
+            producer_cls = Producer.get_cls(producer)
+            if not producer_cls.exposed:
+                raise RuntimeError(f"cannot use unexposed producer '{producer}' in {cls.__name__}")
+            insts.append(producer_cls(inst_dict=inst_dict))
+
+        return insts
 
     @classmethod
     def resolve_param_values(cls, params):

--- a/create_analysis.sh
+++ b/create_analysis.sh
@@ -19,7 +19,7 @@ create_analysis() {
     local exec_dir="$( pwd )"
     local fetch_cf_branch="master"
     local fetch_cmsdb_branch="master"
-    local debug="false"
+    local debug="${CF_CREATE_ANALYSIS_DEBUG:-false}"
 
     # zsh options
     if ${shell_is_zsh}; then
@@ -242,18 +242,20 @@ create_analysis() {
     echo
 
     echo_color cyan "setup submodules"
+
+    local gh_prefix="https://github.com/"
+    ${cf_use_ssh,,} && gh_prefix="git@github.com:"
+
     mkdir -p modules
-    if [ "${cf_use_ssh}" ]; then
-        git submodule add -b "${fetch_cf_branch}" git@github.com:columnflow/columnflow.git modules/columnflow
-        if [ "${cf_analysis_flavor}" = "cms_minimal" ]; then
-            git submodule add -b "${fetch_cmsdb_branch}" git@github.com:uhh-cms/cmsdb.git modules/cmsdb
-        fi
+    if ${debug}; then
+        ln -s "${this_dir}" modules/columnflow
     else
-        git submodule add -b "${fetch_cf_branch}" https://github.com/columnflow/columnflow.git modules/columnflow
-        if [ "${cf_analysis_flavor}" = "cms_minimal" ]; then
-            git submodule add "${fetch_cmsdb_branch}" https://github.com/uhh-cms/cmsdb.git modules/cmsdb
-        fi
+        git submodule add -b "${fetch_cf_branch}" "${gh_prefix}columnflow/columnflow.git" modules/columnflow
     fi
+    if [ "${cf_analysis_flavor}" = "cms_minimal" ]; then
+        git submodule add -b "${fetch_cmsdb_branch}" "${gh_prefix}uhh-cms/cmsdb.git" modules/cmsdb
+    fi
+
     git submodule update --init --recursive
     echo_color green "done"
 

--- a/law.cfg
+++ b/law.cfg
@@ -23,6 +23,7 @@ default_dataset: st_tchannel_t
 production_modules: columnflow.production.{categories,processes,normalization}
 calibration_modules: columnflow.calibration
 selection_modules: columnflow.selection
+categorization_modules: columnflow.categorization
 ml_modules: columnflow.ml
 inference_modules: columnflow.inference
 


### PR DESCRIPTION
This PR adds a dedicated `Categorizer` object that is meant to produce masks for defining categories. In particular, the changes are:

- Added the new `Categorizer` as a `TaskArrayFunction` subclass.
- Added the `exposed` attribute to all CSPs and added exceptions to the mixins in case they unexposed CSPs are requested from the CLI. This was only done for selectors before but is a good generic approach.
- Categorizers are supposed to return `(events, mask)`.
- All existing core selectors now return `(events, results)`.
- In the `category_ids` producer the new categorizer object is used instead of selectors.
- Template analysis:
  - Use categorizes in category definitions.
  - Updated the example selectors to always return `(events, results)`.
- Updated the `create_analysis.sh` script for easier local debugging.