### PR TITLE
Add checks for overlapping input columns.

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -52,10 +52,12 @@ chunked_io_pool_size: 2
 chunked_io_debug: False
 
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
-# checked for non-finite values before saving them to disk (right now, supported tasks are
-# cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation,
-# cf.UniteColumns)
+# checked (raising an exception) for non-finite values before saving them to disk
 check_finite_output: cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns
+
+# csv list of task families that inherit from ChunkedReaderMixin and whose input columns should be
+# checked (raising an exception) for overlaps between fields when created a merged input array
+check_overlapping_inputs: None
 
 # whether to log runtimes of array functions by default
 log_array_function_runtime: False

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -135,7 +135,7 @@ class CalibrateEvents(
             events = route_filter(events)
 
             # optional check for finite values
-            if self.check_finite:
+            if self.check_finite_output:
                 self.raise_if_not_finite(events)
 
             # save as parquet via a thread in the same pool
@@ -151,7 +151,7 @@ class CalibrateEvents(
 
 # overwrite class defaults
 check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
-CalibrateEvents.check_finite = ChunkedIOMixin.check_finite.copy(
+CalibrateEvents.check_finite_output = ChunkedIOMixin.check_finite_output.copy(
     default=CalibrateEvents.task_family in check_finite_tasks,
     add_default_to_description=True,
 )

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import gc
 import time
 import itertools
+from collections import Counter
 from typing import Sequence, Any
 
 import luigi
@@ -1323,14 +1324,19 @@ class EventWeightMixin(ConfigTask):
 
 class ChunkedIOMixin(AnalysisTask):
 
-    check_finite = luigi.BoolParameter(
+    check_finite_output = luigi.BoolParameter(
         default=False,
         significant=False,
         description="when True, checks whether output arrays only contain finite values before "
         "writing to them to file",
     )
+    check_overlapping_inputs = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, checks whether columns if input arrays overlap in at least one field",
+    )
 
-    exclude_params_req = {"check_finite"}
+    exclude_params_req = {"check_finite_output", "check_overlapping_inputs"}
 
     def iter_chunked_io(self, *args, **kwargs):
         from columnflow.columnar_util import ChunkedIOHandler
@@ -1373,15 +1379,14 @@ class ChunkedIOMixin(AnalysisTask):
     @classmethod
     def raise_if_not_finite(cls, ak_array: ak.Array) -> None:
         """
-        Perform explicit check whether all values in array *ak_array* are finite.
+        Checks whether all values in array *ak_array* are finite.
 
-        The check is performed using the :external+numpy:py:func:`numpy.isfinite` function
+        The check is performed using the :external+numpy:py:func:`numpy.isfinite` function.
 
         :param ak_array: Array with events to check.
         :raises ValueError: If any value in *ak_array* is not finite.
         """
         import numpy as np
-        import awkward as ak
         from columnflow.columnar_util import get_ak_routes
 
         for route in get_ak_routes(ak_array):
@@ -1390,3 +1395,28 @@ class ChunkedIOMixin(AnalysisTask):
                     f"found one or more non-finite values in column '{route.column}' "
                     f"of array {ak_array}",
                 )
+
+    @classmethod
+    def raise_if_overlapping(cls, ak_arrays: Sequence[ak.Array]) -> None:
+        """
+        Checks whether fields of *ak_arrays* overlap.
+
+        :param ak_arrays: Arrays with fields to check.
+        :raises ValueError: If at least one overlap is found.
+        """
+        from columnflow.columnar_util import get_ak_routes
+
+        # when less than two arrays are given, there cannot be any overlap
+        if len(ak_arrays) < 2:
+            return
+
+        # determine overlapping routes
+        counts = Counter(sum(map(get_ak_routes, ak_arrays), []))
+        overlapping_routes = [r for r, c in counts.items() if c > 1]
+
+        # raise
+        if overlapping_routes:
+            raise ValueError(
+                f"found {len(overlapping_routes)} overlapping columns across {len(ak_arrays)} "
+                f"arrays: {','.join(overlapping_routes)}",
+            )

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -144,6 +144,10 @@ class PrepareMLEvents(
         ):
             n_events += len(events)
 
+            # optional check for overlapping inputs
+            if self.check_overlapping_inputs:
+                self.raise_if_overlapping([events] + list(columns))
+
             # add additional columns
             events = update_ak_array(events, *columns)
 
@@ -162,7 +166,7 @@ class PrepareMLEvents(
             events = route_filter(events)
 
             # optional check for finite values
-            if self.check_finite:
+            if self.check_finite_output:
                 self.raise_if_not_finite(events)
 
             # loop over folds, use indices to generate masks and project into files
@@ -189,11 +193,16 @@ class PrepareMLEvents(
 
 # overwrite class defaults
 check_finite_tasks = law.config.get_expanded("analysis", "check_finite_output", [], split_csv=True)
-PrepareMLEvents.check_finite = ChunkedIOMixin.check_finite.copy(
+PrepareMLEvents.check_finite_output = ChunkedIOMixin.check_finite_output.copy(
     default=PrepareMLEvents.task_family in check_finite_tasks,
     add_default_to_description=True,
 )
 
+check_overlap_tasks = law.config.get_expanded("analysis", "check_overlapping_inputs", [], split_csv=True)
+PrepareMLEvents.check_overlapping_inputs = ChunkedIOMixin.check_overlapping_inputs.copy(
+    default=PrepareMLEvents.task_family in check_overlap_tasks,
+    add_default_to_description=True,
+)
 
 PrepareMLEventsWrapper = wrapper_factory(
     base_cls=AnalysisTask,
@@ -537,6 +546,10 @@ class MLEvaluation(
             source_type=len(files) * ["awkward_parquet"],
             read_columns=len(files) * [read_columns],
         ):
+            # optional check for overlapping inputs
+            if self.check_overlapping_inputs:
+                self.raise_if_overlapping([events] + list(columns))
+
             # add additional columns
             events = update_ak_array(events, *columns)
 
@@ -564,7 +577,7 @@ class MLEvaluation(
             events = route_filter(events)
 
             # optional check for finite values
-            if self.check_finite:
+            if self.check_finite_output:
                 self.raise_if_not_finite(events)
 
             # save as parquet via a thread in the same pool
@@ -578,8 +591,14 @@ class MLEvaluation(
 
 
 # overwrite class defaults
-MLEvaluation.check_finite = ChunkedIOMixin.check_finite.copy(
+MLEvaluation.check_finite_output = ChunkedIOMixin.check_finite_output.copy(
     default=MLEvaluation.task_family in check_finite_tasks,
+    add_default_to_description=True,
+)
+
+check_overlap_tasks = law.config.get_expanded("analysis", "check_overlapping_inputs", [], split_csv=True)
+MLEvaluation.check_overlapping_inputs = ChunkedIOMixin.check_overlapping_inputs.copy(
+    default=MLEvaluation.task_family in check_overlap_tasks,
     add_default_to_description=True,
 )
 

--- a/law.cfg
+++ b/law.cfg
@@ -47,10 +47,12 @@ chunked_io_pool_size: 2
 chunked_io_debug: False
 
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
-# checked for non-finite values before saving them to disk (right now, supported tasks are
-# cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns, cf.PrepareMLEvents, cf.MLEvaluation,
-# cf.UniteColumns)
+# checked (raising an exception) for non-finite values before saving them to disk
 check_finite_output: None
+
+# csv list of task families that inherit from ChunkedReaderMixin and whose input columns should be
+# checked (raising an exception) for overlaps between fields when created a merged input array
+check_overlapping_inputs: None
 
 # whether to log runtimes of array functions by default
 log_array_function_runtime: False


### PR DESCRIPTION
This PR adds checks for overlapping input columns in several tasks that read more than one input file (as suggested by @jolange).

The check can be enabled / disabled by adding the respective task family to the `check_overlapping_inputs` config value, similar to the `check_finite_output` mechanism. When one or more overlapping columns are detected across at least two arrays, a `ValueError` is raised. In some cases a warning could be a better choice but this should be done in a future PR.

The checks in all tasks work similar in that overlapping columns are detected across all input files, i.e., original events and addition columns. Two exceptions are `SelectEvents` and `ReduceEvents` which do not consider the original events but only additional columns as the latter are meant to overwrite columns existing in nano input files.

Closes #283.