### PR TITLE
Cache bundle repo requirement in HTCondorWorkflow.

### DIFF
--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -343,11 +343,18 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow):
         BundleCMSSWSandbox=BundleCMSSWSandbox,
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # cached BundleRepo requirement to avoid race conditions during checksum calculation
+        self.bundle_repo_req = self.reqs.BundleRepo.req(self)
+
     def htcondor_workflow_requires(self):
         reqs = law.htcondor.HTCondorWorkflow.htcondor_workflow_requires(self)
 
-        # add the repository bundle
-        reqs["repo"] = self.reqs.BundleRepo.req(self)
+        # add the repository bundle and trigger the checksum calculation
+        reqs["repo"] = self.bundle_repo_req
+        self.bundle_repo_req.checksum
 
         # main software stack
         if not self.htcondor_share_software:


### PR DESCRIPTION
This PR adds a small adjustment to the base `HTCondorWorkflow` to avoid race conditions regarding the checksum calculation of the `BundleRepo` task, as reported in #279.

The issue appears when, during the processing of tasks required to submit jobs via htcondor,  the `BundleRepo` requirement is run way before the actual `HTCondorWorkflow` is triggered. So far, the latter created an instance of `BundleRepo` every time the workflow requirements were created, i.e., during dependency tree building and then again within the workflow run method itself to access the repo checksum to be sent with jobs, 

https://github.com/columnflow/columnflow/blob/a812d032db9e753de886e92e86d34baed7eec341/columnflow/tasks/framework/remote.py#L449

When a change to the repository happens between these to instants, the checksum will be different, and a wrong (i.e., not actually provided by `BundleRepo`) checksum will be sent with jobs, which fail to find the bundle.

The fix simply consists of a cached `BundleRepo` instance that is used in both cases.

Fixes #279.