### PR TITLE
Support for crab job submission.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -44,12 +44,8 @@ ana.x.bash_sandboxes = [
 # files of cmssw sandboxes that might be required by remote tasks
 # (used in cf.HTCondorWorkflow)
 ana.x.cmssw_sandboxes = [
-    # "$CF_BASE/sandboxes/cmssw_default.sh",
+    "$CF_BASE/sandboxes/cmssw_default.sh",
 ]
-
-# clear the list when cmssw bundling is disabled
-if not law.util.flag_to_bool(os.getenv("__cf_short_name_uc___BUNDLE_CMSSW", "1")):
-    del ana.x.cmssw_sandboxes[:]
 
 # config groups for conveniently looping over certain configs
 # (used in wrapper_factory)

--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -87,6 +87,14 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 job_file_dir: $CF_JOB_BASE
 job_file_dir_cleanup: False
 
+# storage element (SE) and output directory on that SE for crab's internal output
+# (crab might not even move files there, but it is strictly required for crab's job submission)
+crab_storage_element: $CF_CRAB_STORAGE_ELEMENT
+crab_base_directory: $CF_CRAB_BASE_DIRECTORY
+
+# lcg setup file sourced in remote jobs to access gfal tools
+remote_lcg_setup: /cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh
+
 
 [local_fs]
 

--- a/analysis_templates/cms_minimal/setup.sh
+++ b/analysis_templates/cms_minimal/setup.sh
@@ -72,26 +72,14 @@ setup___cf_short_name_lc__() {
     # interactive setup
     if [ "${CF_REMOTE_JOB}" != "1" ]; then
         cf_setup_interactive_body() {
-            # start querying for variables
-            query CF_CERN_USER "CERN username" "$( whoami )"
-            export_and_save CF_CERN_USER_FIRSTCHAR "\${CF_CERN_USER:0:1}"
-            query CF_DATA "Local data directory" "\$__cf_short_name_uc___BASE/data" "./data"
-            query CF_STORE_NAME "Relative path used in store paths (see next queries)" "__cf_short_name_lc___store"
-            query CF_STORE_LOCAL "Default local output store" "\$CF_DATA/\$CF_STORE_NAME"
-            query CF_WLCG_CACHE_ROOT "Local directory for caching remote files" "\$CF_DATA/__cf_short_name_lc___cache"
-            export_and_save CF_WLCG_USE_CACHE "$( [ -z "${CF_WLCG_CACHE_ROOT}" ] && echo false || echo true )"
-            export_and_save CF_WLCG_CACHE_CLEANUP "${CF_WLCG_CACHE_CLEANUP:-false}"
-            query CF_SOFTWARE_BASE "Local directory for installing software" "\$CF_DATA/software"
-            query CF_JOB_BASE "Local directory for storing job files" "\$CF_DATA/jobs"
-            query CF_LOCAL_SCHEDULER "Use a local scheduler for law tasks" "True"
-            if [ "${CF_LOCAL_SCHEDULER}" != "True" ]; then
-                query CF_SCHEDULER_HOST "Address of a central scheduler for law tasks" "naf-cms15.desy.de"
-                query CF_SCHEDULER_PORT "Port of a central scheduler for law tasks" "8082"
-            else
-                export_and_save CF_SCHEDULER_HOST "127.0.0.1"
-                export_and_save CF_SCHEDULER_PORT "8082"
-            fi
-            query __cf_short_name_uc___BUNDLE_CMSSW "Install and bundle CMSSW sandboxes for job submission?" "True"
+            # pre-export the CF_FLAVOR which will be cms
+            export CF_FLAVOR="cms"
+
+            # query common variables
+            cf_setup_interactive_common_variables
+
+            # query specific variables
+            # nothing yet ...
         }
         cf_setup_interactive "${CF_SETUP_NAME}" "${__cf_short_name_uc___BASE}/.setups/${CF_SETUP_NAME}.sh" || return "$?"
     fi

--- a/columnflow/__init__.py
+++ b/columnflow/__init__.py
@@ -4,6 +4,7 @@
 Main entry point for top-level settings and fixes before anything else is imported.
 """
 
+import os
 import re
 import logging
 
@@ -26,9 +27,13 @@ version = tuple(map(int, m.groups()[:3])) + (m.group(4),)
 
 # load contrib packages
 law.contrib.load(
-    "arc", "awkward", "cms", "git", "htcondor", "numpy", "pyarrow", "telegram", "root", "slurm",
-    "tasks", "wlcg", "matplotlib",
+    "arc", "awkward", "git", "htcondor", "numpy", "pyarrow", "telegram", "root", "slurm", "tasks",
+    "wlcg", "matplotlib",
 )
+
+# load flavor specific contrib packages
+if os.getenv("CF_FLAVOR") == "cms":
+    law.contrib.load("cms")
 
 # initialize wlcg file systems once so that their cache cleanup is triggered if configured
 if law.config.has_option("outputs", "wlcg_file_systems"):

--- a/columnflow/__init__.py
+++ b/columnflow/__init__.py
@@ -37,8 +37,11 @@ law.contrib.load(
 )
 
 # load flavor specific contrib packages
-if flavor == "cms":
-    law.contrib.load("cms")
+# if flavor == "cms":
+#     law.contrib.load("cms")
+# some core tasks (BundleCMSSW) need the cms contrib package, to be refactored, see #155
+law.contrib.load("cms")
+
 
 # initialize wlcg file systems once so that their cache cleanup is triggered if configured
 if law.config.has_option("outputs", "wlcg_file_systems"):

--- a/columnflow/__init__.py
+++ b/columnflow/__init__.py
@@ -25,6 +25,11 @@ from columnflow.__version__ import (  # noqa
 m = re.match(r"^(\d+)\.(\d+)\.(\d+)(-.+)?$", __version__)
 version = tuple(map(int, m.groups()[:3])) + (m.group(4),)
 
+# cf flavor
+flavor = os.getenv("CF_FLAVOR")
+if isinstance(flavor, str):
+    flavor = flavor.lower()
+
 # load contrib packages
 law.contrib.load(
     "arc", "awkward", "git", "htcondor", "numpy", "pyarrow", "telegram", "root", "slurm", "tasks",
@@ -32,7 +37,7 @@ law.contrib.load(
 )
 
 # load flavor specific contrib packages
-if os.getenv("CF_FLAVOR") == "cms":
+if flavor == "cms":
     law.contrib.load("cms")
 
 # initialize wlcg file systems once so that their cache cleanup is triggered if configured

--- a/columnflow/tasks/cms/base.py
+++ b/columnflow/tasks/cms/base.py
@@ -1,0 +1,110 @@
+# coding: utf-8
+
+"""
+CMS related base tasks.
+"""
+
+import os
+
+import law
+
+from columnflow.tasks.framework.base import Requirements, AnalysisTask
+from columnflow.tasks.framework.remote import (
+    RemoteWorkflowMixin, BundleRepo, BundleSoftware, BundleBashSandbox, BundleCMSSWSandbox,
+)
+
+
+class CrabWorkflow(AnalysisTask, law.cms.CrabWorkflow, RemoteWorkflowMixin):
+
+    # example for a parameter whose value is propagated to the crab job configuration
+    crab_memory = law.BytesParameter(
+        default=law.NO_FLOAT,
+        unit="MB",
+        significant=False,
+        description="requested memory in MB; empty value leads to crab's default setting; "
+        "empty default",
+    )
+
+    exclude_params_branch = {"crab_memory"}
+
+    # mapping of environment variables to render variables that are forwarded
+    crab_forward_env_variables = {
+        "CF_CERN_USER": "cf_cern_user",
+        "CF_STORE_NAME": "cf_store_name",
+    }
+
+    # upstream requirements
+    reqs = Requirements(
+        BundleRepo=BundleRepo,
+        BundleSoftware=BundleSoftware,
+        BundleBashSandbox=BundleBashSandbox,
+        BundleCMSSWSandbox=BundleCMSSWSandbox,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # cached BundleRepo requirement to avoid race conditions during checksum calculation
+        self.bundle_repo_req = self.reqs.BundleRepo.req(self)
+
+    def crab_stageout_location(self):
+        # the storage site and base directory on it for crab specific outputs
+        return (
+            law.config.get_expanded("job", "crab_storage_element"),
+            law.config.get_expanded("job", "crab_base_directory"),
+        )
+
+    def crab_output_directory(self):
+        # the directory where submission meta data and logs should be stored
+        return self.local_target(dir=True)
+
+    def crab_bootstrap_file(self):
+        # each job can define a bootstrap file that is executed prior to the actual job
+        # in order to setup software and environment variables
+        bootstrap_file = os.path.expandvars("$CF_BASE/columnflow/tasks/framework/remote_bootstrap.sh")
+        if "CF_REMOTE_BOOTSTRAP_FILE" in os.environ:
+            bootstrap_file = os.environ["CF_REMOTE_BOOTSTRAP_FILE"]
+
+        # copy the file only once into the submission directory (sharing between jobs)
+        # and allow rendering inside the job
+        return law.JobInputFile(bootstrap_file, share=True, render_job=True)
+
+    def crab_workflow_requires(self):
+        reqs = law.cms.CrabWorkflow.crab_workflow_requires(self)
+
+        # add requirements dealing with software bundling
+        self.add_bundle_requirements(reqs)
+
+        return reqs
+
+    def crab_job_config(self, config, submit_jobs):
+        # include the wlcg specific tools script in the input sandbox
+        config.input_files["wlcg_tools"] = law.JobInputFile(
+            law.util.law_src_path("contrib/wlcg/scripts/law_wlcg_tools.sh"),
+            share=True,
+            render=False,
+        )
+
+        # customize memory
+        if self.crab_memory > 0:
+            config.crab.JobType.maxMemoryMB = int(round(self.crab_memory))
+
+        # render variables
+        config.render_variables["cf_bootstrap_name"] = "crab"
+        config.render_variables.setdefault("cf_pre_setup_command", "")
+        config.render_variables.setdefault("cf_post_setup_command", "")
+        config.render_variables.setdefault("cf_remote_lcg_setup", law.config.get_expanded("job", "remote_lcg_setup"))
+
+        # add variables related to software bundles
+        self.add_bundle_render_variables(self.crab_workflow_requires(), config)
+
+        # forward env variables
+        for ev, rv in self.crab_forward_env_variables.items():
+            config.render_variables[rv] = os.environ[ev]
+
+        return config
+
+    def crab_destination_info(self, info: dict[str, str]) -> dict[str, str]:
+        info = super().crab_destination_info(info)
+        info = self.common_destination_info(info)
+        return info

--- a/columnflow/tasks/cms/base.py
+++ b/columnflow/tasks/cms/base.py
@@ -4,6 +4,8 @@
 CMS related base tasks.
 """
 
+from __future__ import annotations
+
 import os
 
 import law
@@ -47,18 +49,18 @@ class CrabWorkflow(AnalysisTask, law.cms.CrabWorkflow, RemoteWorkflowMixin):
         # cached BundleRepo requirement to avoid race conditions during checksum calculation
         self.bundle_repo_req = self.reqs.BundleRepo.req(self)
 
-    def crab_stageout_location(self):
+    def crab_stageout_location(self) -> tuple[str, str]:
         # the storage site and base directory on it for crab specific outputs
         return (
             law.config.get_expanded("job", "crab_storage_element"),
             law.config.get_expanded("job", "crab_base_directory"),
         )
 
-    def crab_output_directory(self):
+    def crab_output_directory(self) -> law.FileSystemDirectoryTarget:
         # the directory where submission meta data and logs should be stored
         return self.local_target(dir=True)
 
-    def crab_bootstrap_file(self):
+    def crab_bootstrap_file(self) -> law.JobInputFile:
         # each job can define a bootstrap file that is executed prior to the actual job
         # in order to setup software and environment variables
         bootstrap_file = os.path.expandvars("$CF_BASE/columnflow/tasks/framework/remote_bootstrap.sh")
@@ -69,7 +71,7 @@ class CrabWorkflow(AnalysisTask, law.cms.CrabWorkflow, RemoteWorkflowMixin):
         # and allow rendering inside the job
         return law.JobInputFile(bootstrap_file, share=True, render_job=True)
 
-    def crab_workflow_requires(self):
+    def crab_workflow_requires(self) -> dict[str, AnalysisTask]:
         reqs = law.cms.CrabWorkflow.crab_workflow_requires(self)
 
         # add requirements dealing with software bundling
@@ -77,7 +79,11 @@ class CrabWorkflow(AnalysisTask, law.cms.CrabWorkflow, RemoteWorkflowMixin):
 
         return reqs
 
-    def crab_job_config(self, config, submit_jobs):
+    def crab_job_config(
+        self,
+        config: law.BaseJobFileFactory.Config,
+        submit_jobs: dict[int, list[int]],
+    ) -> law.BaseJobFileFactory.Config:
         # include the wlcg specific tools script in the input sandbox
         config.input_files["wlcg_tools"] = law.JobInputFile(
             law.util.law_src_path("contrib/wlcg/scripts/law_wlcg_tools.sh"),

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -11,6 +11,7 @@ import math
 import luigi
 import law
 
+from columnflow import flavor as cf_flavor
 from columnflow.tasks.framework.base import Requirements, AnalysisTask
 from columnflow.util import real_path
 
@@ -724,7 +725,7 @@ class SlurmWorkflow(AnalysisTask, law.slurm.SlurmWorkflow, RemoteWorkflowMixin):
 # prepare bases of the RemoteWorkflow container class
 remote_workflow_bases = (HTCondorWorkflow, SlurmWorkflow)
 
-if os.getenv("CF_FLAVOR") == "cms":
+if cf_flavor == "cms":
     from columnflow.tasks.cms.base import CrabWorkflow
     remote_workflow_bases += (CrabWorkflow,)
 

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -268,11 +268,135 @@ class BundleCMSSWSandbox(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLo
         self.transfer(bundle)
 
 
+class RemoteWorkflowMixin(object):
+    """
+    Mixin class for custom remote workflows adding common functionality.
+    """
+
+    skip_destination_info: bool = False
+
+    def add_bundle_requirements(
+        self,
+        reqs: dict[str, AnalysisTask],
+    ) -> None:
+        """
+        Adds requirements related to bundles of the repository, conda environment, bash and cmssw
+        sandboxes to *reqs*.
+
+        :param reqs: Dictionary of workflow requirements to be extended.
+        """
+        # add the repository bundle and trigger the checksum calculation
+        if getattr(self, "bundle_repo_req", None) is not None:
+            reqs["repo"] = self.bundle_repo_req
+        elif "BundleRepo" in self.reqs:
+            reqs["repo"] = self.reqs.BundleRepo.req(self)
+        if "rep" in reqs:
+            self.bundle_repo_req.checksum
+
+        # main software stack
+        if "BundleSoftware" in self.reqs:
+            reqs["software"] = self.reqs.BundleSoftware.req(self)
+
+        # get names of bash and cmssw sandboxes
+        bash_sandboxes = set()
+        cmssw_sandboxes = set()
+        if getattr(self, "analysis_inst", None) is not None:
+            bash_sandboxes |= set(self.analysis_inst.x("bash_sandboxes", []))
+            cmssw_sandboxes |= set(self.analysis_inst.x("cmssw_sandboxes", []))
+        if getattr(self, "config_inst", None) is not None:
+            bash_sandboxes |= set(self.config_inst.x("bash_sandboxes", []))
+            cmssw_sandboxes |= set(self.config_inst.x("cmssw_sandboxes", []))
+
+        # bash-based sandboxes
+        if bash_sandboxes and "BundleBashSandbox" in self.reqs:
+            reqs["bash_sandboxes"] = [
+                self.reqs.BundleBashSandbox.req(self, sandbox_file=sandbox_file)
+                for sandbox_file in sorted(bash_sandboxes)
+            ]
+
+        # optional cmssw sandboxes
+        if cmssw_sandboxes and "BundleCMSSWSandbox" in self.reqs:
+            reqs["cmssw_sandboxes"] = [
+                self.reqs.BundleCMSSWSandbox.req(self, sandbox_file=sandbox_file)
+                for sandbox_file in sorted(cmssw_sandboxes)
+            ]
+
+    def add_bundle_render_variables(
+        self,
+        reqs: dict[str, AnalysisTask],
+        config: law.BaseJobFileFactory.Config,
+    ) -> None:
+        """
+        Adds render variables to the job *config* related to repository, conda environment, bash and
+        cmssw sandboxes, depending on which requirements are present in *reqs*.
+
+        :param reqs: Dictionary of workflow requirements.
+        :param config: The job :py:class:`law.BaseJobFileFactory.Config` whose render variables
+            should be set.
+        """
+        join_bash = lambda seq: " ".join(map('"{}"'.format, seq))
+
+        def get_bundle_info(task):
+            uris = task.output().dir.uri(base_name="filecopy", return_all=True)
+            pattern = os.path.basename(task.get_file_pattern())
+            return ",".join(uris), pattern
+
+        # add repo variables
+        if "repo" in reqs:
+            uris, pattern = get_bundle_info(reqs["repo"])
+            config.render_variables["cf_repo_uris"] = uris
+            config.render_variables["cf_repo_pattern"] = pattern
+
+        # add software variables
+        if "software" in reqs:
+            uris, pattern = get_bundle_info(reqs["software"])
+            config.render_variables["cf_software_uris"] = uris
+            config.render_variables["cf_software_pattern"] = pattern
+
+        # add bash sandbox variables
+        if "bash_sandboxes" in reqs:
+            uris, patterns = law.util.unzip([get_bundle_info(t) for t in reqs["bash_sandboxes"]])
+            names = [
+                os.path.splitext(os.path.basename(t.sandbox_file))[0]
+                for t in reqs["bash_sandboxes"]
+            ]
+            config.render_variables["cf_bash_sandbox_uris"] = join_bash(uris)
+            config.render_variables["cf_bash_sandbox_patterns"] = join_bash(patterns)
+            config.render_variables["cf_bash_sandbox_names"] = join_bash(names)
+
+        # add cmssw sandbox variables
+        if "cmssw_sandboxes" in reqs:
+            uris, patterns = law.util.unzip([get_bundle_info(t) for t in reqs["cmssw_sandboxes"]])
+            names = [
+                os.path.splitext(os.path.basename(t.sandbox_file))[0]
+                for t in reqs["cmssw_sandboxes"]
+            ]
+            config.render_variables["cf_cmssw_sandbox_uris"] = join_bash(uris)
+            config.render_variables["cf_cmssw_sandbox_patterns"] = join_bash(patterns)
+            config.render_variables["cf_cmssw_sandbox_names"] = join_bash(names)
+
+    def common_destination_info(self, info: dict[str, str]) -> dict[str, str]:
+        """
+        Hook to modify the additional info printed along logs of the workflow.
+        """
+        if self.skip_destination_info:
+            return info
+
+        if getattr(self, "config_inst", None) is not None:
+            info["config"] = self.config_inst.name
+        if getattr(self, "dataset_inst", None) is not None:
+            info["dataset"] = self.dataset_inst.name
+        if getattr(self, "global_shift_inst", None) not in (None, law.NO_STR, "nominal"):
+            info["shift"] = self.global_shift_inst.name
+
+        return info
+
+
 _default_htcondor_flavor = law.config.get_expanded("analysis", "htcondor_flavor", "cern")
 _default_htcondor_share_software = law.config.get_expanded_boolean("analysis", "htcondor_share_software", False)
 
 
-class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow):
+class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkflowMixin):
 
     transfer_logs = luigi.BoolParameter(
         default=True,
@@ -352,38 +476,8 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow):
     def htcondor_workflow_requires(self):
         reqs = law.htcondor.HTCondorWorkflow.htcondor_workflow_requires(self)
 
-        # add the repository bundle and trigger the checksum calculation
-        reqs["repo"] = self.bundle_repo_req
-        self.bundle_repo_req.checksum
-
-        # main software stack
-        if not self.htcondor_share_software:
-            reqs["software"] = self.reqs.BundleSoftware.req(self)
-
-        # get names of pure bash and cmssw sandboxes
-        bash_sandboxes = None
-        cmssw_sandboxes = None
-        if getattr(self, "analysis_inst", None):
-            bash_sandboxes = self.analysis_inst.x("bash_sandboxes", [])
-            cmssw_sandboxes = self.analysis_inst.x("cmssw_sandboxes", [])
-        if getattr(self, "config_inst", None):
-            bash_sandboxes = self.config_inst.x("bash_sandboxes", bash_sandboxes)
-            cmssw_sandboxes = self.config_inst.x("cmssw_sandboxes", cmssw_sandboxes)
-
-        # bash-based sandboxes
-        cls = self.reqs.BuildBashSandbox if self.htcondor_share_software else self.reqs.BundleBashSandbox
-        reqs["bash_sandboxes"] = [
-            cls.req(self, sandbox_file=sandbox_file)
-            for sandbox_file in bash_sandboxes
-        ]
-
-        # optional cmssw sandboxes
-        if cmssw_sandboxes:
-            cls = self.reqs.BuildBashSandbox if self.htcondor_share_software else self.reqs.BundleCMSSWSandbox
-            reqs["cmssw_sandboxes"] = [
-                cls.req(self, sandbox_file=sandbox_file)
-                for sandbox_file in cmssw_sandboxes
-            ]
+        # add requirements dealing with software bundling
+        self.add_bundle_requirements(reqs)
 
         return reqs
 
@@ -452,56 +546,15 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow):
         if self.htcondor_memory > 0:
             config.custom_content.append(("Request_Memory", self.htcondor_memory))
 
-        # helper to return uris and a file pattern for replicated bundles
-        reqs = self.htcondor_workflow_requires()
-        join_bash = lambda seq: " ".join(map('"{}"'.format, seq))
-        def get_bundle_info(task):
-            uris = task.output().dir.uri(base_name="filecopy", return_all=True)
-            pattern = os.path.basename(task.get_file_pattern())
-            return ",".join(uris), pattern
-
-        # add repo variables
-        uris, pattern = get_bundle_info(reqs["repo"])
-        config.render_variables["cf_repo_uris"] = uris
-        config.render_variables["cf_repo_pattern"] = pattern
-
-        if self.htcondor_share_software:
-            config.render_variables["cf_software_base"] = os.environ["CF_SOFTWARE_BASE"]
-        else:
-            # add software variables
-            uris, pattern = get_bundle_info(reqs["software"])
-            config.render_variables["cf_software_uris"] = uris
-            config.render_variables["cf_software_pattern"] = pattern
-
-            # add bash sandbox variables
-            uris, patterns = law.util.unzip([get_bundle_info(t) for t in reqs["bash_sandboxes"]])
-            names = [
-                os.path.splitext(os.path.basename(t.sandbox_file))[0]
-                for t in reqs["bash_sandboxes"]
-            ]
-            config.render_variables["cf_bash_sandbox_uris"] = join_bash(uris)
-            config.render_variables["cf_bash_sandbox_patterns"] = join_bash(patterns)
-            config.render_variables["cf_bash_sandbox_names"] = join_bash(names)
-
-            # add cmssw sandbox variables
-            config.render_variables["cf_cmssw_sandbox_uris"] = ""
-            config.render_variables["cf_cmssw_sandbox_patterns"] = ""
-            config.render_variables["cf_cmssw_sandbox_names"] = ""
-            if "cmssw_sandboxes" in reqs:
-                uris, patterns = law.util.unzip([get_bundle_info(t) for t in reqs["cmssw_sandboxes"]])
-                names = [
-                    os.path.splitext(os.path.basename(t.sandbox_file))[0]
-                    for t in reqs["cmssw_sandboxes"]
-                ]
-                config.render_variables["cf_cmssw_sandbox_uris"] = join_bash(uris)
-                config.render_variables["cf_cmssw_sandbox_patterns"] = join_bash(patterns)
-                config.render_variables["cf_cmssw_sandbox_names"] = join_bash(names)
-
-        # other render variables
+        # render variables
         config.render_variables["cf_bootstrap_name"] = "htcondor_standalone"
         config.render_variables["cf_htcondor_flavor"] = self.htcondor_flavor
         config.render_variables.setdefault("cf_pre_setup_command", "")
         config.render_variables.setdefault("cf_post_setup_command", "")
+        config.render_variables.setdefault("cf_remote_lcg_setup", law.config.get_expanded("job", "remote_lcg_setup"))
+
+        # add variables related to software bundles
+        self.add_bundle_render_variables(self.htcondor_workflow_requires(), config)
 
         # forward env variables
         for ev, rv in self.htcondor_forward_env_variables.items():
@@ -513,12 +566,17 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow):
         # remote jobs should not communicate with ther central scheduler but with a local one
         return True
 
+    def htcondor_destination_info(self, info: dict[str, str]) -> dict[str, str]:
+        info = super().htcondor_destination_info(info)
+        info = self.common_destination_info(info)
+        return info
+
 
 _default_slurm_flavor = law.config.get_expanded("analysis", "slurm_flavor", "maxwell")
 _default_slurm_partition = law.config.get_expanded("analysis", "slurm_partition", "cms-uhh")
 
 
-class SlurmWorkflow(AnalysisTask, law.slurm.SlurmWorkflow):
+class SlurmWorkflow(AnalysisTask, law.slurm.SlurmWorkflow, RemoteWorkflowMixin):
 
     transfer_logs = luigi.BoolParameter(
         default=True,
@@ -657,11 +715,21 @@ class SlurmWorkflow(AnalysisTask, law.slurm.SlurmWorkflow):
 
         return config
 
+    def slurm_destination_info(self, info: dict[str, str]) -> dict[str, str]:
+        info = super().slurm_destination_info(info)
+        info = self.common_destination_info(info)
+        return info
 
-class RemoteWorkflow(HTCondorWorkflow, SlurmWorkflow):
+
+# prepare bases of the RemoteWorkflow container class
+remote_workflow_bases = (HTCondorWorkflow, SlurmWorkflow)
+
+if os.getenv("CF_FLAVOR") == "cms":
+    from columnflow.tasks.cms.base import CrabWorkflow
+    remote_workflow_bases += (CrabWorkflow,)
+
+
+class RemoteWorkflow(*remote_workflow_bases):
 
     # upstream requirements
-    reqs = Requirements(
-        HTCondorWorkflow.reqs,
-        SlurmWorkflow.reqs,
-    )
+    reqs = Requirements(*(cls.reqs for cls in remote_workflow_bases))

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -291,7 +291,7 @@ class RemoteWorkflowMixin(object):
             reqs["repo"] = self.bundle_repo_req
         elif "BundleRepo" in self.reqs:
             reqs["repo"] = self.reqs.BundleRepo.req(self)
-        if "rep" in reqs:
+        if "repo" in reqs:
             self.bundle_repo_req.checksum
 
         # main software stack

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -17,7 +17,11 @@ bootstrap_htcondor_standalone() {
     export CF_STORE_LOCAL="{{cf_store_local}}"
     export CF_LOCAL_SCHEDULER="{{cf_local_scheduler}}"
     export CF_WLCG_CACHE_ROOT="${LAW_JOB_HOME}/cf_wlcg_cache"
+    export CF_WLCG_TOOLS="{{wlcg_tools}}"
     [ ! -z "{{vomsproxy_file}}" ] && export X509_USER_PROXY="${PWD}/{{vomsproxy_file}}"
+    local sharing_software="$( [ -z "{{cf_software_base}}" ] && echo "false" || echo "true" )"
+    local lcg_setup="{{cf_remote_lcg_setup}}"
+    lcg_setup="${lcg_setup:-/cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh}"
 
     # fallback to a default path when the externally given software base is empty or inaccessible
     local fetch_software="true"
@@ -32,14 +36,24 @@ bootstrap_htcondor_standalone() {
         echo "found existing software at ${CF_SOFTWARE_BASE}"
     fi
 
+    # when gfal is not available, check that the lcg_setup file exists
+    local skip_lcg_setup="true"
+    if ! type gfal-ls &> /dev/null; then
+        ls "$( dirname "${lcg_setup}" )" &> /dev/null
+        if [ ! -f "${lcg_setup}" ]; then
+            2>&1 echo "lcg setup file ${lcg_setup} not existing"
+            return "1"
+        fi
+        skip_lcg_setup="false"
+    fi
+
     # source the law wlcg tools, mainly for law_wlcg_get_file
-    local lcg_setup="/cvmfs/grid.cern.ch/centos7-ui-160522/etc/profile.d/setup-c7-ui-python3-example.sh"
-    source "{{wlcg_tools}}" "" || return "$?"
+    source "${CF_WLCG_TOOLS}" "" || return "$?"
 
     # load and unpack the software bundle, then source it
     if ${fetch_software}; then
         (
-            source "${lcg_setup}" "" &&
+            { ${skip_lcg_setup} || source "${lcg_setup}" ""; } &&
             mkdir -p "${CF_SOFTWARE_BASE}/conda" &&
             cd "${CF_SOFTWARE_BASE}/conda" &&
             GFAL_PYTHONBIN="$( which python3 )" law_wlcg_get_file '{{cf_software_uris}}' '{{cf_software_pattern}}' "software.tgz" &&
@@ -50,7 +64,7 @@ bootstrap_htcondor_standalone() {
 
     # load the repo bundle
     (
-        source "${lcg_setup}" "" &&
+        { ${skip_lcg_setup} || source "${lcg_setup}" ""; } &&
         mkdir -p "${CF_REPO_BASE}" &&
         cd "${CF_REPO_BASE}" &&
         GFAL_PYTHONBIN="$( which python3 )" law_wlcg_get_file '{{cf_repo_uris}}' '{{cf_repo_pattern}}' "repo.tgz" &&
@@ -59,12 +73,14 @@ bootstrap_htcondor_standalone() {
     ) || return "$?"
 
     # export variables used in cf setup script on-the-fly to load sandboxes
-    export CF_JOB_BASH_SANDBOX_URIS="{{cf_bash_sandbox_uris}}"
-    export CF_JOB_BASH_SANDBOX_PATTERNS="{{cf_bash_sandbox_patterns}}"
-    export CF_JOB_BASH_SANDBOX_NAMES="{{cf_bash_sandbox_names}}"
-    export CF_JOB_CMSSW_SANDBOX_URIS="{{cf_cmssw_sandbox_uris}}"
-    export CF_JOB_CMSSW_SANDBOX_PATTERNS="{{cf_cmssw_sandbox_patterns}}"
-    export CF_JOB_CMSSW_SANDBOX_NAMES="{{cf_cmssw_sandbox_names}}"
+    if ! ${sharing_software}; then
+        export CF_JOB_BASH_SANDBOX_URIS="{{cf_bash_sandbox_uris}}"
+        export CF_JOB_BASH_SANDBOX_PATTERNS="{{cf_bash_sandbox_patterns}}"
+        export CF_JOB_BASH_SANDBOX_NAMES="{{cf_bash_sandbox_names}}"
+        export CF_JOB_CMSSW_SANDBOX_URIS="{{cf_cmssw_sandbox_uris}}"
+        export CF_JOB_CMSSW_SANDBOX_PATTERNS="{{cf_cmssw_sandbox_patterns}}"
+        export CF_JOB_CMSSW_SANDBOX_NAMES="{{cf_cmssw_sandbox_names}}"
+    fi
 
     # optional custom command before the setup is sourced
     {{cf_pre_setup_command}}
@@ -99,6 +115,75 @@ bootstrap_slurm() {
     {{cf_post_setup_command}}
 }
 
+
+# Bootstrap function for crab jobs.
+bootstrap_crab() {
+    # set env variables
+    export CF_ON_CRAB="1"
+    export CF_REMOTE_JOB="1"
+    export CF_CERN_USER="{{cf_cern_user}}"
+    export CF_REPO_BASE="${LAW_JOB_HOME}/repo"
+    export CF_DATA="${LAW_JOB_HOME}/cf_data"
+    export CF_SOFTWARE_BASE="${CF_DATA}/software"
+    export CF_STORE_NAME="{{cf_store_name}}"
+    export CF_WLCG_CACHE_ROOT="${LAW_JOB_HOME}/cf_wlcg_cache"
+    export CF_WLCG_TOOLS="{{wlcg_tools}}"
+    local lcg_setup="{{cf_remote_lcg_setup}}"
+    lcg_setup="${lcg_setup:-/cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh}"
+
+    # when gfal is not available, check that the lcg_setup file exists
+    local skip_lcg_setup="true"
+    if ! type gfal-ls &> /dev/null; then
+        ls "$( dirname "${lcg_setup}" )" &> /dev/null
+        if [ ! -f "${lcg_setup}" ]; then
+            2>&1 echo "lcg setup file ${lcg_setup} not existing"
+            return "1"
+        fi
+        skip_lcg_setup="false"
+    fi
+
+    # source the law wlcg tools, mainly for law_wlcg_get_file
+    source "${CF_WLCG_TOOLS}" "" || return "$?"
+
+    # load and unpack the software bundle, then source it
+    (
+        { ${skip_lcg_setup} || source "${lcg_setup}" ""; } &&
+        mkdir -p "${CF_SOFTWARE_BASE}/conda" &&
+        cd "${CF_SOFTWARE_BASE}/conda" &&
+        GFAL_PYTHONBIN="$( which python3 )" law_wlcg_get_file '{{cf_software_uris}}' '{{cf_software_pattern}}' "software.tgz" &&
+        tar -xzf "software.tgz" &&
+        rm "software.tgz"
+    ) || return "$?"
+
+    # load the repo bundle
+    (
+        { ${skip_lcg_setup} || source "${lcg_setup}" ""; } &&
+        mkdir -p "${CF_REPO_BASE}" &&
+        cd "${CF_REPO_BASE}" &&
+        GFAL_PYTHONBIN="$( which python3 )" law_wlcg_get_file '{{cf_repo_uris}}' '{{cf_repo_pattern}}' "repo.tgz" &&
+        tar -xzf "repo.tgz" &&
+        rm "repo.tgz"
+    ) || return "$?"
+
+    # export variables used in cf setup script on-the-fly to load sandboxes
+    export CF_JOB_BASH_SANDBOX_URIS="{{cf_bash_sandbox_uris}}"
+    export CF_JOB_BASH_SANDBOX_PATTERNS="{{cf_bash_sandbox_patterns}}"
+    export CF_JOB_BASH_SANDBOX_NAMES="{{cf_bash_sandbox_names}}"
+    export CF_JOB_CMSSW_SANDBOX_URIS="{{cf_cmssw_sandbox_uris}}"
+    export CF_JOB_CMSSW_SANDBOX_PATTERNS="{{cf_cmssw_sandbox_patterns}}"
+    export CF_JOB_CMSSW_SANDBOX_NAMES="{{cf_cmssw_sandbox_names}}"
+
+    # optional custom command before the setup is sourced
+    {{cf_pre_setup_command}}
+
+    # source the default repo setup
+    source "${CF_REPO_BASE}/setup.sh" "" || return "$?"
+
+    # optional custom command after the setup is sourced
+    {{cf_post_setup_command}}
+
+    return "0"
+}
 
 # job entry point
 bootstrap_{{cf_bootstrap_name}} "$@"

--- a/law.cfg
+++ b/law.cfg
@@ -84,6 +84,14 @@ lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirec
 job_file_dir: $CF_JOB_BASE
 job_file_dir_cleanup: False
 
+# storage element (SE) and output directory on that SE for crab's internal output
+# (crab might not even move files there, but it is strictly required for crab's job submission)
+crab_storage_element: $CF_CRAB_STORAGE_ELEMENT
+crab_base_directory: $CF_CRAB_BASE_DIRECTORY
+
+# lcg setup file sourced in remote jobs to access gfal tools
+remote_lcg_setup: /cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh
+
 
 [logging]
 

--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -234,16 +234,22 @@ setup_cmssw() {
     if [ "${CF_REMOTE_JOB}" = "1" ]; then
         # fetch, unpack and setup the bundle
         if [ ! -d "${install_path}" ]; then
+            if [ -z "${CF_WLCG_TOOLS}" ] || [ ! -f "${CF_WLCG_TOOLS}" ]; then
+                2>&1 echo "CF_WLCG_TOOLS (${CF_WLCG_TOOLS}) files is empty or does not exist"
+                return "30"
+            fi
+
             # fetch the bundle and unpack it
             echo "looking for cmssw sandbox bundle for${CF_CMSSW_ENV_NAME}"
-            local sandbox_names=(${CF_JOB_CMSSW_SANDBOX_NAMES})
-            local sandbox_uris=(${CF_JOB_CMSSW_SANDBOX_URIS})
-            local sandbox_patterns=(${CF_JOB_CMSSW_SANDBOX_PATTERNS})
+            local sandbox_names=( ${CF_JOB_CMSSW_SANDBOX_NAMES} )
+            local sandbox_uris=( ${CF_JOB_CMSSW_SANDBOX_URIS} )
+            local sandbox_patterns=( ${CF_JOB_CMSSW_SANDBOX_PATTERNS} )
             local found_sandbox="false"
             for (( i=0; i<${#sandbox_names[@]}; i+=1 )); do
                 if [ "${sandbox_names[i]}" = "${CF_CMSSW_ENV_NAME}" ]; then
                     echo "found bundle ${CF_CMSSW_ENV_NAME}, index ${i}, pattern ${sandbox_patterns[i]}, uri ${sandbox_uris[i]}"
                     (
+                        source "${CF_WLCG_TOOLS}" "" &&
                         mkdir -p "${install_base}" &&
                         cd "${install_base}" &&
                         law_wlcg_get_file "${sandbox_uris[i]}" "${sandbox_patterns[i]}" "cmssw.tgz"
@@ -259,10 +265,12 @@ setup_cmssw() {
 
             # create a new cmssw checkout, unpack the bundle on top and rebuild python symlinks
             (
-                echo "unpacking bundle to ${install_path}"
+                echo "unpacking bundle to ${install_path}" &&
                 cd "${install_base}" &&
-                source "/cvmfs/cms.cern.ch/cmsset_default.sh" "" &&
                 export SCRAM_ARCH="${CF_SCRAM_ARCH}" &&
+                export PATH="${LAW_CRAB_ORIGINAL_PATH:-${PATH}}" &&
+                export LD_LIBRARY_PATH="${LAW_CRAB_ORIGINAL_LD_LIBRARY_PATH:-${LD_LIBRARY_PATH}}" &&
+                source "/cvmfs/cms.cern.ch/cmsset_default.sh" "" &&
                 scramv1 project CMSSW "${CF_CMSSW_VERSION}" &&
                 cd "${CF_CMSSW_VERSION}" &&
                 tar -xzf "../cmssw.tgz" &&

--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -305,16 +305,22 @@ setup_venv() {
         # in this case, the environment is inside a remote job, i.e., these variables are present:
         # CF_JOB_BASH_SANDBOX_URIS, CF_JOB_BASH_SANDBOX_PATTERNS and CF_JOB_BASH_SANDBOX_NAMES
         if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
+            if [ -z "${CF_WLCG_TOOLS}" ] || [ ! -f "${CF_WLCG_TOOLS}" ]; then
+                2>&1 echo "CF_WLCG_TOOLS (${CF_WLCG_TOOLS}) files is empty or does not exist"
+                return "30"
+            fi
+
             # fetch the bundle and unpack it
             echo "looking for bash sandbox bundle for venv ${CF_VENV_NAME}"
-            local sandbox_names=(${CF_JOB_BASH_SANDBOX_NAMES})
-            local sandbox_uris=(${CF_JOB_BASH_SANDBOX_URIS})
-            local sandbox_patterns=(${CF_JOB_BASH_SANDBOX_PATTERNS})
+            local sandbox_names=( ${CF_JOB_BASH_SANDBOX_NAMES} )
+            local sandbox_uris=( ${CF_JOB_BASH_SANDBOX_URIS} )
+            local sandbox_patterns=( ${CF_JOB_BASH_SANDBOX_PATTERNS} )
             local found_sandbox="false"
             for (( i=0; i<${#sandbox_names[@]}; i+=1 )); do
                 if [ "${sandbox_names[i]}" = "${CF_VENV_NAME}" ]; then
                     echo "found bundle ${CF_VENV_NAME}, index ${i}, pattern ${sandbox_patterns[i]}, uri ${sandbox_uris[i]}"
                     (
+                        source "${CF_WLCG_TOOLS}" "" &&
                         mkdir -p "${install_path}" &&
                         cd "${install_path}" &&
                         law_wlcg_get_file "${sandbox_uris[i]}" "${sandbox_patterns[i]}" "bundle.tgz" &&

--- a/setup.sh
+++ b/setup.sh
@@ -120,6 +120,10 @@ setup_columnflow() {
     #       The default slurm flavor setting for the SlurmWorkflow task.
     #   CF_SLURM_PARTITION
     #       The default slurm partition setting for the SlurmWorkflow task.
+    #   CF_CRAB_STORAGE_ELEMENT
+    #       The storage element for storing crab job related outputs.
+    #   CF_CRAB_BASE_DIRECTORY
+    #       The base directory where to store crab job related outputs on CF_CRAB_STORAGE_ELEMENT.
     #   CF_SETUP
     #       A flag that is set to 1 after the setup was successful.
     #   PATH
@@ -179,28 +183,8 @@ setup_columnflow() {
     # interactive setup
     if [ "${CF_REMOTE_JOB}" != "1" ]; then
         cf_setup_interactive_body() {
-            # start querying for variables
-            query CF_CERN_USER "CERN username" "$( whoami )"
-            export_and_save CF_CERN_USER_FIRSTCHAR "\${CF_CERN_USER:0:1}"
-            query CF_DATA "Local data directory" "\$CF_BASE/data" "./data"
-            query CF_STORE_NAME "Relative path used in store paths (see next queries)" "cf_store"
-            query CF_STORE_LOCAL "Default local output store" "\$CF_DATA/\$CF_STORE_NAME"
-            query CF_WLCG_CACHE_ROOT "Local directory for caching remote files" "" "''"
-            export_and_save CF_WLCG_USE_CACHE "$( [ -z "${CF_WLCG_CACHE_ROOT}" ] && echo false || echo true )"
-            export_and_save CF_WLCG_CACHE_CLEANUP "${CF_WLCG_CACHE_CLEANUP:-false}"
-            query CF_SOFTWARE_BASE "Local directory for installing software" "\$CF_DATA/software"
-            query CF_JOB_BASE "Local directory for storing job files" "\$CF_DATA/jobs"
-            query CF_VENV_SETUP_MODE_UPDATE "Automatically update virtual envs if needed" "False"
-            [ "${CF_VENV_SETUP_MODE_UPDATE}" != "True" ] && export_and_save CF_VENV_SETUP_MODE "update"
-            unset CF_VENV_SETUP_MODE_UPDATE
-            query CF_LOCAL_SCHEDULER "Use a local scheduler for law tasks" "True"
-            if [ "${CF_LOCAL_SCHEDULER}" != "True" ]; then
-                query CF_SCHEDULER_HOST "Address of a central scheduler for law tasks" "127.0.0.1"
-                query CF_SCHEDULER_PORT "Port of a central scheduler for law tasks" "8082"
-            else
-                export_and_save CF_SCHEDULER_HOST "127.0.0.1"
-                export_and_save CF_SCHEDULER_PORT "8082"
-            fi
+            # query common variables
+            cf_setup_interactive_common_variables
         }
         cf_setup_interactive "${CF_SETUP_NAME}" "${CF_BASE}/.setups/${CF_SETUP_NAME}.sh" || return "$?"
     fi
@@ -307,6 +291,44 @@ cf_setup_common_variables() {
     export CF_SLURM_PARTITION="${CF_SLURM_PARTITION:-${cf_slurm_partition_default}}"
 }
 
+cf_setup_interactive_common_variables() {
+    # Queries for common variables which should be called from called inside custom
+    # cf_setup_interactive_body funtions, which in turn is called by cf_setup_interactive.
+
+    query CF_CERN_USER "CERN username" "$( whoami )"
+    export_and_save CF_CERN_USER_FIRSTCHAR "\${CF_CERN_USER:0:1}"
+
+    query CF_DATA "Local data directory" "\$CF_BASE/data" "./data"
+    query CF_SOFTWARE_BASE "Local directory for installing software" "\$CF_DATA/software"
+    query CF_JOB_BASE "Local directory for storing job files" "\$CF_DATA/jobs"
+
+    query CF_STORE_NAME "Relative path used in store paths (see next queries)" "cf_store"
+    query CF_STORE_LOCAL "Default local output store" "\$CF_DATA/\$CF_STORE_NAME"
+    query CF_WLCG_CACHE_ROOT "Local directory for caching remote files" "" "''"
+    export_and_save CF_WLCG_USE_CACHE "$( [ -z "${CF_WLCG_CACHE_ROOT}" ] && echo false || echo true )"
+    export_and_save CF_WLCG_CACHE_CLEANUP "${CF_WLCG_CACHE_CLEANUP:-false}"
+
+    query CF_VENV_SETUP_MODE_UPDATE "Automatically update virtual envs if needed" "False"
+    [ "${CF_VENV_SETUP_MODE_UPDATE}" != "True" ] && export_and_save CF_VENV_SETUP_MODE "update"
+    unset CF_VENV_SETUP_MODE_UPDATE
+
+    query CF_LOCAL_SCHEDULER "Use a local scheduler for law tasks" "True"
+    if [ "${CF_LOCAL_SCHEDULER}" != "True" ]; then
+        query CF_SCHEDULER_HOST "Address of a central scheduler for law tasks" "127.0.0.1"
+        query CF_SCHEDULER_PORT "Port of a central scheduler for law tasks" "8082"
+    else
+        export_and_save CF_SCHEDULER_HOST "127.0.0.1"
+        export_and_save CF_SCHEDULER_PORT "8082"
+    fi
+
+    query CF_FLAVOR "Flavor of the columnflow setup ('', 'cms')" "${CF_FLAVOR:-''}"
+
+    if [ "${CF_FLAVOR}" = "cms" ]; then
+        query CF_CRAB_STORAGE_ELEMENT "storage element for crab specific job outputs (e.g. T2_DE_DESY)" "''"
+        query CF_CRAB_BASE_DIRECTORY "base directory on storage element for crab specific job outputs" "/store/user/\$CF_CERN_USER/cf_crab_outputs"
+    fi
+}
+
 cf_setup_interactive() {
     # Starts the interactive part of the setup by querying for values of certain environment
     # variables with useful defaults. When a custom, named setup is triggered, the values of all
@@ -356,7 +378,7 @@ cf_setup_interactive() {
         local varname="$1"
         local text="$2"
         local default="$3"
-        local default_text="${4:-$default}"
+        local default_text="${4:-${default}}"
         local default_raw="${default}"
 
         # when the setup is the default one, use the default value when the env variable is empty,
@@ -364,7 +386,7 @@ cf_setup_interactive() {
         local value="${default}"
         if ${setup_is_default}; then
             # set the variable when existing
-            eval "value=\${$varname:-\$value}"
+            eval "value=\${$varname:-\${value}}"
         else
             printf "${text} ($( cf_color default_bright ${varname} ), default $( cf_color default_bright ${default_text} )):  "
             read query_response
@@ -547,6 +569,7 @@ EOF
                     gfal2 \
                     gfal2-util \
                     python-gfal2 \
+                    myproxy \
                     conda-pack \
                     || return "$?"
                 micromamba clean --yes --all


### PR DESCRIPTION
This PR adds support for crab jobs and is therefore rather extensive.

The necessary steps were:

- Adding `CrabWorkflow`, inheriting from `law.cms.CrabWorkflow`
- Adding a new setup function to the `remote_boostrap.sh` script.
- Added new variables that are queried during the setup (crab related storage element and base directory)
  - Here I also updated the way that "common variables" are queried. So far, every project had to ask for the same variables with **hopefully** the same defaults, and in case there was an update in cf, all projects had to adjust their setup. There is a common function `cf_setup_interactive_common_variables` now which is defined once in cf and can be called downstream.
  - There is a variable now called `CF_FLAVOR` which is empty by default. However, when set to `cms`, CMS-specific features (such as the crab submission) are enabled. We should use the same mechanism to further separate experiment (mostly CMS) specifics from the CF core (see #155.)
- The way that cmssw sandboxes are setup in remote jobs had to be slightly tweaked to find the correct `scramv1` executable in crab jobs. 
- There is a common `RemoteWorkflowMixin` now that handles the lookup of software dependencies of remote jobs.
- `myproxy` was added to the conda stack.

Who'd be in for the review @mafrahm @dsavoiu @pkausw ?

Closes #296.