### PR TITLE
disable call cache for Categorizers

### DIFF
--- a/columnflow/categorization/__init__.py
+++ b/columnflow/categorization/__init__.py
@@ -52,6 +52,9 @@ class Categorizer(TaskArrayFunction):
             # get the categorizer name
             cls_name = cls_dict.pop("cls_name", func.__name__)
 
+            # disable call caching since the current implementation does not work with multiple returns
+            cls_dict["call_force"] = True
+
             # create the subclass
             subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)
 


### PR DESCRIPTION
I came across the issue that my categorization fails as soon as some Categorizer is called multiple times. This is due to the implementation of the call caching (see [here](https://github.com/columnflow/columnflow/blob/d59cc33de9db650a0411fac2d1ef954e73299ccf/columnflow/columnar_util.py#L2178)), which works such that it only returns the first argument (the `events` ak.Array) when a TaskArrayFunction has been called before. This, however, does not work with the Categorizer, since two return values are expected and with the current implementation, the second output (the mask) is not cached.

This PR proposes the simple temporary solution of disabling the call caching for Categorizers until we have implemented some more advanced call caching.