### PR TITLE
Configure filling of empty bins in inference model.

### DIFF
--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -251,7 +251,7 @@ class InferenceModel(Derivable):
         config_data_datasets: Sequence[str] | None = None,
         data_from_processes: Sequence[str] | None = None,
         mc_stats: float | tuple | None = None,
-        fill_empty_bins: float = 1e-5,
+        empty_bin_value: float = 1e-5,
     ) -> DotDict:
         """
         Returns a dictionary representing a category (interchangeably called bin or channel in other
@@ -265,7 +265,7 @@ class InferenceModel(Derivable):
               when *config_data_datasets* is not defined, make of a fake data contribution.
             - *mc_stats*: Either *None* to disable MC stat uncertainties, or a float or tuple of
               floats to control the options of MC stat options.
-            - *fill_empty_bins*: When bins are empty, they are filled with this value.
+            - *empty_bin_value*: When bins are no content, they are filled with this value.
         """
         return DotDict([
             ("name", str(name)),
@@ -274,7 +274,7 @@ class InferenceModel(Derivable):
             ("config_data_datasets", list(map(str, config_data_datasets or []))),
             ("data_from_processes", list(map(str, data_from_processes or []))),
             ("mc_stats", mc_stats),
-            ("fill_empty_bins", fill_empty_bins),
+            ("empty_bin_value", empty_bin_value),
             ("processes", []),
         ])
 

--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -251,6 +251,7 @@ class InferenceModel(Derivable):
         config_data_datasets: Sequence[str] | None = None,
         data_from_processes: Sequence[str] | None = None,
         mc_stats: float | tuple | None = None,
+        fill_empty_bins: float = 1e-5,
     ) -> DotDict:
         """
         Returns a dictionary representing a category (interchangeably called bin or channel in other
@@ -264,6 +265,7 @@ class InferenceModel(Derivable):
               when *config_data_datasets* is not defined, make of a fake data contribution.
             - *mc_stats*: Either *None* to disable MC stat uncertainties, or a float or tuple of
               floats to control the options of MC stat options.
+            - *fill_empty_bins*: When bins are empty, they are filled with this value.
         """
         return DotDict([
             ("name", str(name)),
@@ -272,6 +274,7 @@ class InferenceModel(Derivable):
             ("config_data_datasets", list(map(str, config_data_datasets or []))),
             ("data_from_processes", list(map(str, data_from_processes or []))),
             ("mc_stats", mc_stats),
+            ("fill_empty_bins", fill_empty_bins),
             ("processes", []),
         ])
 

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -329,8 +329,6 @@ class DatacardWriter(object):
               "category -> process -> parameter -> (down effect, up effect)",
             - the datacard pattern for extracting nominal shapes, and
             - the datacard pattern for extracting systematic shapes.
-
-        When *fill_empty_bins* is non-zero, empty (and negative!) bins are filled with this value.
         """
         # create the directory
         shapes_path = real_path(shapes_path)
@@ -357,12 +355,12 @@ class DatacardWriter(object):
 
             # helper to fill empty bins in-place
             fill_empty = lambda h: None
-            if cat_obj.fill_empty_bins:
+            if cat_obj.empty_bin_value:
                 def fill_empty(h):
                     value = h.view().value
                     mask = value <= 0
-                    value[mask] = cat_obj.fill_empty_bins
-                    h.view().variance[mask] = cat_obj.fill_empty_bins
+                    value[mask] = cat_obj.empty_bin_value
+                    h.view().variance[mask] = cat_obj.empty_bin_value
 
             _rates = rates[cat_name] = OrderedDict()
             _effects = effects[cat_name] = OrderedDict()


### PR DESCRIPTION
So far, the datacard writer had an internal setting that controlled whether empty shape bins would be filled with a small value (usually 1e-5).

This PR allows the InferenceModel to configure this behavior on a per-category level.