### PR TITLE
Centralize types.

### DIFF
--- a/columnflow/calibration/__init__.py
+++ b/columnflow/calibration/__init__.py
@@ -7,8 +7,8 @@ Object and event calibration tools.
 from __future__ import annotations
 
 import inspect
-from typing import Callable, Sequence
 
+from columnflow.types import Callable, Sequence
 from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
 from columnflow.config_util import expand_shift_sources

--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -5,8 +5,8 @@ Jet energy corrections and jet resolution smearing.
 """
 
 import functools
-from typing import Any
 
+from columnflow.types import Any
 from columnflow.calibration import Calibrator, calibrator
 from columnflow.calibration.util import ak_random, propagate_met
 from columnflow.production.util import attach_coffea_behavior

--- a/columnflow/calibration/util.py
+++ b/columnflow/calibration/util.py
@@ -6,8 +6,7 @@ Useful functions for use by calibrators
 
 from __future__ import annotations
 
-from typing import Callable
-
+from columnflow.types import Callable
 from columnflow.columnar_util import flat_np_view, layout_ak_array
 from columnflow.util import maybe_import
 

--- a/columnflow/categorization/__init__.py
+++ b/columnflow/categorization/__init__.py
@@ -7,8 +7,8 @@ Event categorization tools.
 from __future__ import annotations
 
 import inspect
-from typing import Callable
 
+from columnflow.types import Callable
 from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
 

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -26,12 +26,12 @@ import multiprocessing
 import multiprocessing.pool
 from functools import partial
 from collections import namedtuple, OrderedDict, defaultdict
-from typing import Sequence, Callable, Any
 
 import law
 import order as od
 from law.util import InsertableDict
 
+from columnflow.types import Sequence, Callable, Any
 from columnflow.util import (
     UNSET, maybe_import, classproperty, DotDict, DerivableMeta, Derivable, pattern_matcher,
     get_source_code,

--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -21,10 +21,11 @@ __all__ = [
 import re
 import itertools
 from collections import OrderedDict
-from typing import Callable, Any, Sequence
 
 import law
 import order as od
+
+from columnflow.types import Callable, Any, Sequence
 
 
 def get_root_processes_from_campaign(campaign: od.Campaign) -> od.UniqueObjectIndex:

--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 import enum
 import copy as _copy
-from typing import Generator, Callable, TextIO, Sequence, Any
 
 import law
 import order as od
 
+from columnflow.types import Generator, Callable, TextIO, Sequence, Any
 from columnflow.util import (
     DerivableMeta, Derivable, maybe_import, DotDict, is_pattern, is_regex, pattern_matcher,
 )

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 import os
 from collections import OrderedDict
-from typing import Sequence, Any
 
 import law
 
 from columnflow import __version__ as cf_version
+from columnflow.types import Sequence, Any
 from columnflow.inference import InferenceModel, ParameterType, ParameterTransformation
 from columnflow.util import DotDict, maybe_import, real_path, ensure_dir, safe_div
 

--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 import abc
 from collections import OrderedDict
-from typing import Any, Sequence
 
 import law
 import order as od
 
+from columnflow.types import Any, Sequence
 from columnflow.util import maybe_import, Derivable, DotDict, KeyValueMessage
 from columnflow.columnar_util import Route
 

--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -6,8 +6,8 @@ Example plot function.
 
 from __future__ import annotations
 
-from typing import Sequence
 
+from columnflow.types import Sequence
 from columnflow.util import maybe_import, test_float
 from columnflow.plotting.plot_util import get_position
 

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -7,10 +7,10 @@ Example plot functions for one-dimensional plots.
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Iterable
 
 import law
 
+from columnflow.types import Iterable
 from columnflow.util import maybe_import
 from columnflow.plotting.plot_all import plot_all
 from columnflow.plotting.plot_util import (

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -6,12 +6,11 @@ Some utils for plot functions.
 
 from __future__ import annotations
 
-import order as od
-
-import functools
 import operator
-
+import functools
 from collections import OrderedDict
+
+import order as od
 
 from columnflow.util import maybe_import
 

--- a/columnflow/production/__init__.py
+++ b/columnflow/production/__init__.py
@@ -7,8 +7,8 @@ Tools for producing new array columns (e.g. high-level variables).
 from __future__ import annotations
 
 import inspect
-from typing import Callable, Sequence
 
+from columnflow.types import Callable, Sequence
 from columnflow.util import DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
 from columnflow.config_util import expand_shift_sources

--- a/columnflow/production/util.py
+++ b/columnflow/production/util.py
@@ -6,8 +6,7 @@ General producers that might be utilized in various places.
 
 from __future__ import annotations
 
-from typing import Sequence, Union
-
+from columnflow.types import Sequence, Union
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
 from columnflow.columnar_util import set_ak_column, attach_behavior

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -7,11 +7,11 @@ Object and event selection tools.
 from __future__ import annotations
 
 import inspect
-from typing import Callable, Sequence
 
 import law
 import order as od
 
+from columnflow.types import Callable, Sequence
 from columnflow.util import maybe_import, DotDict, DerivableMeta
 from columnflow.columnar_util import TaskArrayFunction
 from columnflow.config_util import expand_shift_sources

--- a/columnflow/selection/cms/met_filters.py
+++ b/columnflow/selection/cms/met_filters.py
@@ -6,8 +6,7 @@ Selector related to MET filters.
 
 from __future__ import annotations
 
-from typing import Iterable
-
+from columnflow.types import Iterable
 from columnflow.selection import Selector, selector, SelectionResult
 from columnflow.util import maybe_import
 from columnflow.columnar_util import Route

--- a/columnflow/selection/matching.py
+++ b/columnflow/selection/matching.py
@@ -6,8 +6,7 @@ Distance-based methods.
 
 from __future__ import annotations
 
-from typing import Callable, Union
-
+from columnflow.types import Callable, Union
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.util import maybe_import
 

--- a/columnflow/selection/stats.py
+++ b/columnflow/selection/stats.py
@@ -11,8 +11,8 @@ import itertools
 from functools import reduce
 from collections import defaultdict
 from operator import and_, getitem as getitem_
-from typing import Sequence, Callable
 
+from columnflow.types import Sequence, Callable
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.util import maybe_import, InsertableDict
 

--- a/columnflow/tasks/cms/external.py
+++ b/columnflow/tasks/cms/external.py
@@ -6,11 +6,10 @@ CMS related tasks dealing with external data.
 
 from __future__ import annotations
 
-from typing import Sequence
-
 import luigi
 import law
 
+from columnflow.types import Sequence
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, ConfigTask, wrapper_factory
 from columnflow.tasks.external import BundleExternalFiles
 from columnflow.util import safe_div

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -10,12 +10,12 @@ import os
 import time
 import shutil
 import subprocess
-from typing import Sequence
 
 import luigi
 import law
 import order as od
 
+from columnflow.types import Sequence
 from columnflow.tasks.framework.base import AnalysisTask, ConfigTask, DatasetTask, wrapper_factory
 from columnflow.util import wget, DotDict
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -12,12 +12,12 @@ import importlib
 import itertools
 import inspect
 import functools
-from typing import Sequence, Callable, Any
 
 import luigi
 import law
 import order as od
 
+from columnflow.types import Sequence, Callable, Any
 from columnflow.util import DotDict
 
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -10,12 +10,12 @@ import gc
 import time
 import itertools
 from collections import Counter
-from typing import Sequence, Any
 
 import luigi
 import law
 import order as od
 
+from columnflow.types import Sequence, Any
 from columnflow.tasks.framework.base import AnalysisTask, ConfigTask, RESOLVE_DEFAULT
 from columnflow.calibration import Calibrator
 from columnflow.selection import Selector

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -5,11 +5,11 @@ Base classes for different types of plotting tasks.
 """
 
 import importlib
-from typing import Any, Callable
 
 import law
 import luigi
 
+from columnflow.types import Any, Callable
 from columnflow.tasks.framework.base import ConfigTask
 from columnflow.tasks.framework.mixins import DatasetsProcessesMixin, VariablesMixin
 from columnflow.tasks.framework.parameters import SettingsParameter, MultiSettingsParameter

--- a/columnflow/types.py
+++ b/columnflow/types.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+
+"""
+Custom type definitions and shorthands to simplify imports of types that are spread across multiple
+packages.
+"""
+
+from __future__ import annotations
+
+
+__all__ = []
+
+
+from collections.abc import KeysView, ValuesView  # noqa
+from typing import (  # noqa
+    Any, Union, TypeVar, ClassVar, List, Tuple, Sequence, Set, Dict, Callable, Generator, TextIO,
+    Iterable,
+)
+from types import ModuleType, GeneratorType  # noqa
+
+from typing_extensions import Annotated, _AnnotatedAlias as AnnotatedType  # noqa
+
+#: Generic type variable, more stringent than Any.
+T = TypeVar("T")

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -30,12 +30,12 @@ import multiprocessing
 import multiprocessing.pool
 from functools import wraps
 from collections import OrderedDict
-from typing import Callable, Any, Sequence, Union
-from types import ModuleType
 
 import law
 from law.util import InsertableDict  # noqa
 import luigi
+
+from columnflow.types import Callable, Any, Sequence, Union, ModuleType
 
 
 #: Placeholder for an unset value.


### PR DESCRIPTION
This is a small PR that adds `columnflow.types` as a place where types are imported centrally and from which our code base should, in turn, get those types.

There are usually 4 or 5 packages where most types are located, such as `types`, `typing`, `type_extensions`, or `collections.abc`, and it might also be python version dependent where a specific type is eventually coming from (e.g. a type that has been previously only available in `typing_extensions`, a third-party package, might be available in the built-in `typing` in a newer python version). With this new central module, we can make these version-dependent imports in a single place instead of cluttering a bunch of files throughout the repo.

The numerous other code changes in this PR are only related to changed imports.