### PR TITLE
Allow writing root files in UniteColumns.

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -10,11 +10,12 @@ __all__ = [
     "mandatory_coffea_columns", "EMPTY_INT", "EMPTY_FLOAT",
     "Route", "RouteFilter", "ArrayFunction", "TaskArrayFunction", "ChunkedIOHandler",
     "eval_item", "get_ak_routes", "has_ak_column", "set_ak_column", "remove_ak_column",
-    "add_ak_alias", "add_ak_aliases", "update_ak_array", "flatten_ak_array", "sort_ak_fields",
-    "sorted_ak_to_parquet", "attach_behavior", "layout_ak_array", "flat_np_view",
-    "deferred_column", "optional_column",
+    "add_ak_alias", "add_ak_aliases", "update_ak_array", "fill_ak_optionals", "flatten_ak_array",
+    "sort_ak_fields", "sorted_ak_to_parquet", "sorted_ak_to_root", "attach_behavior",
+    "layout_ak_array", "flat_np_view", "deferred_column", "optional_column",
 ]
 
+import os
 import gc
 import re
 import math
@@ -925,6 +926,45 @@ def update_ak_array(
     return ak_array
 
 
+def fill_ak_optionals(
+    ak_array: ak.Array,
+    null_value: int | float = EMPTY_INT,
+) -> ak.Array:
+    """
+    Fills missing (None) values in a non-nested *ak_array* with *null_value*, preserving the
+    original primitive type but removing the option type. Please note that even if *ak_array* does
+    not contain any None values, but its type contains a option type flag, *null_value* is actually
+    not used yet still required by :py:func:`awkward.fill_none` which is used internally.
+
+    :param ak_array: The input array.
+    :param null: The value that is used to fill potential None values.
+    :return: The updated array.
+    """
+    # get the type and check if it's optional in the first place
+    inner_type = ak.type(ak_array)
+    seen = set()
+    while getattr(getattr(inner_type, "content", None), "content", None):
+        # recursion guard
+        if repr(inner_type) in seen:
+            raise Exception(f"cannot determine primitive type of {repr(ak.type(ak_array))}")
+        seen.add(repr(inner_type))
+        # get the next type
+        inner_type = inner_type.content
+
+    # do nothing when the inner type is not an option type
+    if not isinstance(inner_type, ak.types.OptionType):
+        return ak_array
+
+    # determine the np type for the fill value
+    np_type = getattr(getattr(inner_type, "content", None), "primitive", "float32")
+    np_type = getattr(np, np_type, np.float32)
+
+    # fill possible None's with null_value, removing the option type
+    ak_array = ak.fill_none(ak_array, np_type(null_value))
+
+    return ak_array
+
+
 def flatten_ak_array(
     ak_array: ak.Array,
     routes: Sequence | set | Callable[[str], bool] | None = None,
@@ -1019,6 +1059,55 @@ def sorted_ak_to_parquet(
 
     # TODO: empty fields cannot be saved to parquet, but for that we would need to identify them
     ak.to_parquet(ak_array, *args, **kwargs)
+
+
+def sorted_ak_to_root(
+    ak_array: ak.Array,
+    path: str,
+    tree_name: str = "events",
+    nano_format: bool = False,
+    null_value: int | float | None = None,
+) -> None:
+    """
+    Sorts the fields in an awkward array *ak_array* recursively with :py:func:`sort_ak_fields` and
+    saves it as a root tree named *tree_name* to a file at *path* using uproot.
+
+    By default, names of nested columns that will be translated into branch names contain dots.
+    If *nano_format* is *True*, dots are converted to underscores.
+
+    Please note that option types, denoted by e.g. ``"?float32"``, cannot be saved in root trees.
+    However, if a *null_value* is defined, potentially missing entries are filled with this value
+    first. When not set, consider using methods such as ``ak.fill_none()`` to fill empty values
+    manully.
+
+    :param ak_array: The input array.
+    :param path: The path of the root file to create.
+    :param tree_name: The name of the tree to create inside the root file.
+    :param nano_format: A flag whether to use the nano underscore format for branch names.
+    :param null_value: The value that is used to fill potential None values.
+    """
+    # sort fields
+    ak_array = sort_ak_fields(ak_array)
+
+    # flatten
+    data = flatten_ak_array(ak_array, nano_format=nano_format)
+
+    # fill None's
+    if null_value is not None:
+        data = {
+            name: fill_ak_optionals(ak_array_, null_value)
+            for name, ak_array_ in data.items()
+        }
+
+    # prepare the output path
+    path = os.path.expandvars(os.path.expanduser(path))
+    if not os.path.exists(os.path.dirname(path)):
+        os.makedirs(os.path.dirname(path))
+
+    # create the file
+    f = uproot.recreate(path)
+    f[tree_name] = data
+    f.close()
 
 
 def attach_behavior(
@@ -2331,7 +2420,8 @@ class DaskArrayReader(object):
     def close(self) -> None:
         # free memory and perform an eager, overly cautious gc round
         self.dak_array = None
-        self.partition_cache.clear()
+        if getattr(self, "partition_cache", None):
+            self.partition_cache.clear()
         gc.collect()
 
     def _materialize_via_partitions(

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -937,7 +937,7 @@ def fill_ak_optionals(
     not used yet still required by :py:func:`awkward.fill_none` which is used internally.
 
     :param ak_array: The input array.
-    :param null: The value that is used to fill potential None values.
+    :param null_value: The value that is used to fill potential None values.
     :return: The updated array.
     """
     # get the type and check if it's optional in the first place

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -90,7 +90,7 @@ class UniteColumns(
         return {"events": self.target(f"data_{self.branch}.{self.file_type}")}
 
     @law.decorator.log
-    @law.decorator.localize(input=True, output=False)
+    @law.decorator.localize(input=True, output=True)
     @law.decorator.safe_output
     def run(self):
         from columnflow.columnar_util import (

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -4,6 +4,7 @@
 Task to unite columns horizontally into a single file for further, possibly external processing.
 """
 
+import luigi
 import law
 
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
@@ -28,6 +29,12 @@ class UniteColumns(
     RemoteWorkflow,
 ):
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
+
+    file_type = luigi.ChoiceParameter(
+        default="parquet",
+        choices=("parquet", "root"),
+        description="the file type to create; choices: parquet,root; default: parquet",
+    )
 
     # upstream requirements
     reqs = Requirements(
@@ -80,7 +87,7 @@ class UniteColumns(
 
     @MergeReducedEventsUser.maybe_dummy
     def output(self):
-        return {"columns": self.target(f"data_{self.branch}.parquet")}
+        return {"events": self.target(f"data_{self.branch}.{self.file_type}")}
 
     @law.decorator.log
     @law.decorator.localize(input=True, output=False)
@@ -88,6 +95,7 @@ class UniteColumns(
     def run(self):
         from columnflow.columnar_util import (
             Route, RouteFilter, mandatory_coffea_columns, update_ak_array, sorted_ak_to_parquet,
+            sorted_ak_to_root, EMPTY_FLOAT,
         )
 
         # prepare inputs and outputs
@@ -132,14 +140,20 @@ class UniteColumns(
             if self.check_finite_output:
                 self.raise_if_not_finite(events)
 
-            # save as parquet via a thread in the same pool
-            chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
+            # save as parquet or root via a thread in the same pool
+            chunk = tmp_dir.child(f"file_{pos.index}.{self.file_type}", type="f")
             output_chunks[pos.index] = chunk
-            self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+            if self.file_type == "parquet":
+                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+            else:  # root
+                self.chunked_io.queue(sorted_ak_to_root, (events, chunk.path), {"null_value": EMPTY_FLOAT})
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
-        law.pyarrow.merge_parquet_task(self, sorted_chunks, output["columns"], local=True)
+        if self.file_type == "parquet":
+            law.pyarrow.merge_parquet_task(self, sorted_chunks, output["events"], local=True)
+        else:  # root
+            law.root.hadd_task(self, sorted_chunks, output["events"], local=True)
 
 
 # overwrite class defaults


### PR DESCRIPTION
As documented in #306, the `UniteColumns` task should have the option to create root files to be able to share "snapshots" of events and columns with groups that have a root-based workflow.

This PR adds an option `--file-type {parquet,root}` to the `UniteColumns` task which allows switching between the formats. `parquet` still remains the default. The core functionality for exporting arrays to root trees is offloaded to two new columnar utils:

- `fill_ak_optionals`: Fills optional values (`None`'s) in an array and effectively removes the `ak.OptionType` flag from the inner primitive type (e.g. `?float32` → `float32`). This is required optional types cannot be converted to branches in root trees.
- `sorted_ak_to_root`: Takes an awkward array, removes option types using `fill_ak_optionals ` and converts the array into flat branches (using `flatten_ak_array`) and saves them in a tree using `uproot`.

@gsaha009

Closes #306.