### PR TITLE
Enhance cmssw sandboxes

### DIFF
--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -93,11 +93,31 @@ class BundleSoftware(AnalysisTask, law.tasks.TransferLocalFile):
         self.transfer(bundle)
 
 
-class BuildBashSandbox(AnalysisTask):
+class SandboxFileTask(AnalysisTask):
 
     sandbox_file = luigi.Parameter(
         description="the sandbox file to install",
     )
+
+    @classmethod
+    def resolve_param_values(cls, params):
+        params = super().resolve_param_values(params)
+
+        # update the sandbox file when set
+        if params.get("sandbox_file") not in (None, "", law.NO_STR):
+            # expand variables
+            path = os.path.expandvars(os.path.expanduser(params["sandbox_file"]))
+            # add default file extension
+            if not os.path.splitext(path)[1]:
+                path += ".sh"
+            # save again
+            params["sandbox_file"] = path
+
+        return params
+
+
+class BuildBashSandbox(SandboxFileTask):
+
     sandbox = luigi.Parameter(
         default=law.NO_STR,
         description="do not set manually",
@@ -113,8 +133,8 @@ class BuildBashSandbox(AnalysisTask):
 
         # resolve the sandbox file relative to $CF_BASE/sandboxes
         if "sandbox_file" in params:
-            path = os.path.expandvars(os.path.expanduser(params["sandbox_file"]))
-            abs_path = real_path(law.Sandbox.remove_type(path))
+            path = params["sandbox_file"]
+            abs_path = real_path(path)
             path = abs_path if os.path.exists(abs_path) else os.path.join("$CF_BASE", "sandboxes", path)
             params["sandbox_file"] = path
             params["sandbox"] = law.Sandbox.join_key("bash", path)
@@ -152,10 +172,8 @@ class BundleBashSandbox(AnalysisTask, law.tasks.TransferLocalFile):
 
         # get the name and install path of the sandbox
         from cf_sandbox_file_hash import create_sandbox_file_hash
-        sandbox_file = os.path.expandvars(os.path.expanduser(self.sandbox_file))
-        sandbox_file = law.Sandbox.remove_type(sandbox_file)
-        self.sandbox_file_hash = create_sandbox_file_hash(sandbox_file)
-        self.venv_name = os.path.splitext(os.path.basename(sandbox_file))[0]
+        self.sandbox_file_hash = create_sandbox_file_hash(self.sandbox_file)
+        self.venv_name = os.path.splitext(os.path.basename(self.sandbox_file))[0]
         self.venv_name_hashed = f"{self.venv_name}_{self.sandbox_file_hash}"
         self.venv_path = os.path.join(os.environ["CF_VENV_BASE"], self.venv_name_hashed)
 
@@ -210,7 +228,7 @@ class BundleBashSandbox(AnalysisTask, law.tasks.TransferLocalFile):
         self.transfer(bundle)
 
 
-class BundleCMSSWSandbox(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLocalFile):
+class BundleCMSSWSandbox(SandboxFileTask, law.cms.BundleCMSSW, law.tasks.TransferLocalFile):
 
     sandbox_file = luigi.Parameter(
         description="name of the cmssw sandbox file; when not absolute, the path is evaluated "
@@ -223,6 +241,7 @@ class BundleCMSSWSandbox(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLo
     version = None
 
     exclude = "^src/tmp"
+    include = ("venv", "venvs")
 
     # upstream requirements
     reqs = Requirements(
@@ -234,10 +253,8 @@ class BundleCMSSWSandbox(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLo
 
         # get the name and install path of the sandbox
         from cf_sandbox_file_hash import create_sandbox_file_hash
-        sandbox_file = os.path.expandvars(os.path.expanduser(self.sandbox_file))
-        sandbox_file = law.Sandbox.remove_type(sandbox_file)
-        self.sandbox_file_hash = create_sandbox_file_hash(sandbox_file)
-        self.cmssw_env_name = os.path.splitext(os.path.basename(sandbox_file))[0]
+        self.sandbox_file_hash = create_sandbox_file_hash(self.sandbox_file)
+        self.cmssw_env_name = os.path.splitext(os.path.basename(self.sandbox_file))[0]
         self.cmssw_env_name_hashed = f"{self.cmssw_env_name}_{self.sandbox_file_hash}"
 
     def requires(self):
@@ -245,7 +262,12 @@ class BundleCMSSWSandbox(AnalysisTask, law.cms.BundleCMSSW, law.tasks.TransferLo
 
     def get_cmssw_path(self):
         # invoking .env will already trigger building the sandbox
-        return self.requires().sandbox_inst.env["CMSSW_BASE"]
+        req = self.requires()
+        if getattr(req, "sandbox_inst", None):
+            return req.sandbox_inst.env["CMSSW_BASE"]
+        if "CMSSW_BASE" in os.environ:
+            return os.environ["CMSSW_BASE"]
+        raise Exception("could not determine CMSSW_BASE")
 
     def single_output(self):
         cmssw_path = os.path.basename(self.get_cmssw_path())

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -107,6 +107,8 @@ class SandboxFileTask(AnalysisTask):
         if params.get("sandbox_file") not in (None, "", law.NO_STR):
             # expand variables
             path = os.path.expandvars(os.path.expanduser(params["sandbox_file"]))
+            # remove optional sandbox types
+            path = law.Sandbox.remove_type(path)
             # add default file extension
             if not os.path.splitext(path)[1]:
                 path += ".sh"

--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -4,6 +4,11 @@
 # depending on whether the installation is already present, and whether the script is called as part
 # of a remote (law) job (CF_REMOTE_JOB=1).
 #
+# In case a function or executable named "cf_cmssw_custom_install" is defined, it is invoked inside
+# the src directory of the CMSSW checkout after a first "scram build" pass and followed by a second
+# pass. If its refers to a file, that file is sourced. Likewise, if defined, a function or
+# executable named "cf_cmssw_custom_setup" is invoked after the sandbox is activated.
+#
 # Six environment variables are expected to be set before this script is called:
 #   CF_SANDBOX_FILE
 #       The path of the file that contained the sandbox definition and that sourced _this_ script.
@@ -62,11 +67,8 @@ setup_cmssw() {
 
     # default mode
     if [ -z "${mode}" ]; then
-        if [ ! -z "${CF_SANDBOX_SETUP_MODE}" ]; then
-            mode="${CF_SANDBOX_SETUP_MODE}"
-        else
-            mode="install"
-        fi
+        mode="install"
+        [ ! -z "${CF_SANDBOX_SETUP_MODE}" ] && mode="${CF_SANDBOX_SETUP_MODE}"
     fi
 
     # force install mode for remote jobs
@@ -161,10 +163,10 @@ setup_cmssw() {
                 # wait at most 20 minutes
                 sleep_counter="$(( $sleep_counter + 1 ))"
                 if [ "${sleep_counter}" -ge 120 ]; then
-                    >&2 echo "cmssw ${CF_CMSSW_VERSION} is setup in different process, but number of sleeps exceeded"
+                    >&2 echo "${CF_CMSSW_VERSION} is setup in different process, but number of sleeps exceeded"
                     return "20"
                 fi
-                cf_color yellow "cmssw ${CF_CMSSW_VERSION} already being setup in different process, sleep ${sleep_counter} / 120"
+                cf_color yellow "${CF_CMSSW_VERSION} already being setup in different process, sleep ${sleep_counter} / 120"
                 sleep 10
             done
         fi
@@ -208,22 +210,44 @@ setup_cmssw() {
             echo
             cf_color cyan "installing ${CF_CMSSW_VERSION} on ${CF_SCRAM_ARCH} in ${install_base}"
 
+            # first install pass
             (
                 mkdir -p "${install_base}"
                 cd "${install_base}"
-                source "/cvmfs/cms.cern.ch/cmsset_default.sh" ""
                 export SCRAM_ARCH="${CF_SCRAM_ARCH}"
-                scramv1 project CMSSW "${CF_CMSSW_VERSION}"
-                cd "${CF_CMSSW_VERSION}/src"
-                eval "$( scramv1 runtime -sh )"
+                source "/cvmfs/cms.cern.ch/cmsset_default.sh" "" &&
+                scramv1 project CMSSW "${CF_CMSSW_VERSION}" &&
+                cd "${CF_CMSSW_VERSION}/src" &&
+                eval "$( scramv1 runtime -sh )" &&
                 scram b
-
-                # write the flag into a file
-                echo "version ${CF_CMSSW_FLAG}" > "${CF_SANDBOX_FLAG_FILE}"
-                rm -f "${pending_flag_file}"
             )
             local ret="$?"
             [ "${ret}" != "0" ] && clear_pending && return "${ret}"
+
+            # custom install hook and second install pass
+            (
+                cd "${install_path}/src"
+                source "/cvmfs/cms.cern.ch/cmsset_default.sh" ""
+                eval "$( scramv1 runtime -sh )"
+
+                if command -v cf_cmssw_custom_install &> /dev/null; then
+                    echo -e "\nrunning cf_cmssw_custom_install"
+                    cf_cmssw_custom_install &&
+                    cd "${install_path}/src" &&
+                    scram b
+                elif [ ! -z "${cf_cmssw_custom_install}" ] && [ -f "${cf_cmssw_custom_install}" ]; then
+                    echo -e "\nsourcing cf_cmssw_custom_install file"
+                    source "${cf_cmssw_custom_install}" "" &&
+                    cd "${install_path}/src" &&
+                    scram b
+                fi
+            )
+            ret="$?"
+            [ "${ret}" != "0" ] && clear_pending && return "${ret}"
+
+            # write the flag into a file
+            echo "version ${CF_CMSSW_FLAG}" > "${CF_SANDBOX_FLAG_FILE}"
+            clear_pending
         fi
 
         # remove the pending_flag
@@ -296,7 +320,15 @@ setup_cmssw() {
     export SCRAM_ARCH="${CF_SCRAM_ARCH}"
     export CMSSW_VERSION="${CF_CMSSW_VERSION}"
     cd "${install_path}/src"
-    eval "$( scramv1 runtime -sh )"
+    eval "$( scramv1 runtime -sh )" || return "$?"
+
+    # custom setup
+    if command -v cf_cmssw_custom_setup &> /dev/null; then
+        cf_cmssw_custom_setup || return "$?"
+    elif [ ! -z "${cf_cmssw_custom_setup}" ] && [ -f "${cf_cmssw_custom_setup}" ]; then
+        source "${cf_cmssw_custom_setup}" "" || return "$?"
+    fi
+
     cd "${orig_dir}"
 
     # prepend persistent path fragments again to ensure priority for local packages and

--- a/sandboxes/cmssw_columnar.sh
+++ b/sandboxes/cmssw_columnar.sh
@@ -23,7 +23,7 @@ action() {
         # install a venv into ${CMSSW_BASE}/venvs, which is included by BundleCMSSWSandbox
         CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_create_venv columnar &&
         source "${CMSSW_BASE}/venvs/columnar/bin/activate" "" &&
-        pip install -r "${this_dir}/columnar.txt" &&
+        pip install -r "${CF_BASE}/sandboxes/columnar.txt" &&
         CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_make_venv_relocatable columnar
     }
     cf_cmssw_custom_setup() {

--- a/sandboxes/cmssw_columnar.sh
+++ b/sandboxes/cmssw_columnar.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Script that sets up a CMSSW environment in $CF_CMSSW_BASE.
+# For more info on functionality and parameters, see the generic setup script _setup_cmssw.sh.
+
+action() {
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
+    local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
+
+    # get the os version
+    local os_version="$( cat /etc/os-release | grep VERSION_ID | sed -E 's/VERSION_ID="([0-9]+)"/\1/' )"
+
+    # set variables and source the generic CMSSW setup
+    export CF_SANDBOX_FILE="${CF_SANDBOX_FILE:-${this_file}}"
+    export CF_SCRAM_ARCH="$( [ "${os_version}" = "8" ] && echo "el8" || echo "slc7" )_amd64_gcc10"
+    export CF_CMSSW_VERSION="CMSSW_12_6_2"
+    export CF_CMSSW_ENV_NAME="$( basename "${this_file%.sh}" )"
+    export CF_CMSSW_FLAG="1"  # increment when content changed
+
+    # define custom install and setup functions
+    cf_cmssw_custom_install() {
+        # install a venv into ${CMSSW_BASE}/venvs, which is included by BundleCMSSWSandbox
+        CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_create_venv columnar &&
+        source "${CMSSW_BASE}/venvs/columnar/bin/activate" "" &&
+        pip install -r "${this_dir}/columnar.txt" &&
+        CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_make_venv_relocatable columnar
+    }
+    cf_cmssw_custom_setup() {
+        source "${CMSSW_BASE}/venvs/columnar/bin/activate" "" &&
+        export PYTHONPATH="${PYTHONPATH}:$( python -c "import os; print(os.path.normpath('$( root-config --libdir )'))" )"
+    }
+
+    source "${this_dir}/_setup_cmssw.sh" "$@"
+}
+action "$@"


### PR DESCRIPTION
This PR enhances the way how CMSSW sandboxes are built and bundled.

For #306 I was testing different approaches for converting arrays to root files and one of them was `ak.to_rdataframe` which required ROOT to be installed. This would have only been possible in a cmssw sandbox, but with additional software installed through a venv on top. This was not possible before as there was no custom hook to install something between `cmsenv` and `scram b` during the cmssw setup.

This is now possible with this PR. As a showcase I added a `cmssw_columnar` sandbox which makes use of this hook to install our `columnar` requirements on top of cmssw.

Besides the features above, I streamlined the sandbox file resolution in the sandbox tasks in `tasks/framework/remote.py`.