### PR TITLE
allow merging of MultiSettingsParameters and implement tests

### DIFF
--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -24,7 +24,7 @@ class SettingsParameter(law.CSVParameter):
         => {"param1": 10.0, "param2": True, "param3": "text", "param4": False}
 
         p.serialize({"param1": 2, "param2": False})
-        => "param1=2.0,param2=False"
+        => "param1=2,param2=False"
     """
 
     @classmethod
@@ -74,7 +74,7 @@ class MultiSettingsParameter(law.MultiCSVParameter):
         p = MultiSettingsParameter()
 
         p.parse("obj1,k1=10,k2,k3=text:obj2,k4=false")
-        # => {"obj1": {"k1": 10.0, "k2": True, "k3": "text"}, {"obj2": {"k4": False}}}
+        # => {"obj1": {"k1": 10.0, "k2": True, "k3": "text"}, "obj2": {"k4": False}}
 
         p.serialize({"obj1": {"k1": "val"}, "obj2": {"k2": 2}})
         # => "obj1,k1=val:obj2,k2=2"
@@ -92,10 +92,13 @@ class MultiSettingsParameter(law.MultiCSVParameter):
     def parse(self, inp):
         inputs = super().parse(inp)
 
-        outputs = DotDict({
-            settings[0]: DotDict(SettingsParameter.parse_setting(s) for s in settings[1:])
+        # first, parse settings for each key individually
+        outputs = tuple(
+            DotDict({settings[0]: DotDict(SettingsParameter.parse_setting(s) for s in settings[1:])})
             for settings in inputs
-        })
+        )
+        # next, merge dicts
+        outputs = law.util.merge_dicts(*outputs, deep=True)
 
         return outputs
 

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -26,6 +26,11 @@ action() {
     ret="$?"
     [ "${gret}" = "0" ] && gret="${ret}"
 
+    # test_task_parameters
+    bash "${this_dir}/run_test" test_task_parameters
+    ret="$?"
+    [ "${gret}" = "0" ] && gret="${ret}"
+
     return "${gret}"
 }
 action "$@"

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -27,6 +27,7 @@ action() {
     [ "${gret}" = "0" ] && gret="${ret}"
 
     # test_task_parameters
+    echo
     bash "${this_dir}/run_test" test_task_parameters
     ret="$?"
     [ "${gret}" = "0" ] && gret="${ret}"

--- a/tests/test_task_parameters.py
+++ b/tests/test_task_parameters.py
@@ -1,0 +1,55 @@
+# coding: utf-8
+
+
+__all__ = ["TaskParametersTest"]
+
+
+import unittest
+
+from columnflow.tasks.framework.parameters import SettingsParameter, MultiSettingsParameter
+
+
+class TaskParametersTest(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def test_settings_parameter(self):
+        p = SettingsParameter()
+
+        # parsing
+        self.assertEqual(
+            p.parse("param1=10,param2,param3=text,param4=false"),
+            {"param1": 10.0, "param2": True, "param3": "text", "param4": False},
+        )
+        self.assertEqual(
+            # if a parameter is set multiple times, prioritize last one
+            p.parse("A=1,B,A=2"),
+            {"B": True, "A": 2.0},
+        )
+
+        # serializing
+        self.assertEqual(
+            p.serialize({"param1": 2, "param2": False}),
+            "param1=2,param2=False",
+        )
+
+    def test_multi_settings_parameter(self):
+        p = MultiSettingsParameter()
+
+        # parsing
+        self.assertEqual(
+            p.parse("obj1,k1=10,k2,k3=text:obj2,k4=false"),
+            {"obj1": {"k1": 10.0, "k2": True, "k3": "text"}, "obj2": {"k4": False}},
+        )
+        self.assertEqual(
+            # providing the same key twice results in once combined dict
+            p.parse("tt,A=2:st,A=2:tt,B=True"),
+            {"tt": {"A": 2.0, "B": True}, "st": {"A": 2.0}},
+        )
+
+        # serializing
+        self.assertEqual(
+            p.serialize({"obj1": {"k1": "val"}, "obj2": {"k2": 2}}),
+            "obj1,k1=val:obj2,k2=2",
+        )


### PR DESCRIPTION
This PR implements some tests for the `SettingsParameter` and `MultiSettingsParameter`.
It also fixes one issue, where dicts would be overwritten if you provide the same key twice, e.g.

```python
MultiSettingsParameter().parse("tt,A=2:st,A=2:tt,B=True") 
#  before: {"tt": {"B": True}, "st": {"A": 2.0}}
#  now: {"tt": {"A": 2.0, "B": True}, "st": {"A": 2.0}}
```