### PR TITLE
Disable parquet dictionary encoding.

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -646,6 +646,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         return {
             "compression": "ZSTD",
             "compression_level": 1,
+            "use_dictionary": False,
         }
 
 


### PR DESCRIPTION
This PR contains just a single change in a single line, but it's changing the way how arrays / tables in parquet files are indexed and compressed.

By default, the [`pyarrow.ParquetWriter`](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html) used by cf as well as, for instance, awkward, has the option to store column values using dictionary encoding (it builds a hash map of values and an accompanying index where these values are located in the original column). Our typical column values are predominantly floats that usually don't repeat so that this index is often as long as the column itself. As the index is also repeated per table partition, the increase in file size also depends on the number of partitions saved to disk. For this reason, [`awkward` disables dict encoding by default](https://github.com/scikit-hep/awkward/blob/fa4b2bc9546d6e2c4fd66801bed5af90748d54f9/src/awkward/operations/ak_to_parquet.py#L33).

However, when merging parquet files after having processed all chunks, we directly use a `ParquetWriter` object, that uses dict encoding by default. This PR sets this default to False.

As a result, merging is 50% faster and files are another 15% smaller (20% for larger files) on top of the recently added compression. Also, as the chunk / partition size has no influence any longer on the file size, any future decision about the chunk size for event processing can be purely based on "gain in CPU performance through vectorization" vs. "memory consumption".

Closes #328.