### PR TITLE
fix build docu for master branch

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ autodocsumm~=0.2.11
 myst-parser~=2.0.0
 
 # prod packages
--r ../requirements_prod.txt
+-r ../sandboxes/cf.txt
 
 # selection of packages from sandboxes
 -r ../sandboxes/columnar.txt


### PR DESCRIPTION
Correcting the path to the standard columnflow package requirement file in the docs/requirements.txt file, such that the readthedocs build does not fail anymore.