### PR TITLE
Update columnar software in venvs.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-# version 4
+# version 5
 
 # documentation packages
 sphinx~=6.2.1

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,12 +1,12 @@
-# version 12
+# version 13
 
-awkward==2.3.1
-uproot==5.0.11
-pyarrow==12.0.1
-dask-awkward==2023.7.1
-git+https://github.com/CoffeaTeam/coffea.git@v2023.7.0.rc0#egg=coffea
+awkward==2.4.6
+uproot==5.1.2
+pyarrow==13.0.0
+dask-awkward==2023.10.1
+git+https://github.com/CoffeaTeam/coffea.git@v2023.10.0.rc1#egg=coffea
 tabulate~=0.9.0
 zstandard~=0.21.0
 lz4~=4.3.2
-xxhash~=3.2.0
-correctionlib~=2.2.2
+xxhash~=3.4.1
+correctionlib~=2.4.0

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,4 +1,4 @@
-# version 7
+# version 8
 
 -r columnar.txt
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=install_requires,
-    python_requires=">=3.7, <=3.9",
+    python_requires=">=3.7, <=3.10",
     zip_safe=False,
     packages=find_packages(exclude=["tests"]),
 )


### PR DESCRIPTION
This PR updates the python packages in the `venv_columnar*` sandboxes.

Most notably, switching to pyarrow 13 is successful now, most likely due to updates in awkward itself.