### PR TITLE
Use dict_encoding for selection results.

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -632,21 +632,27 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         raise Exception(f"cannot determine output location based on '{location}'")
 
-    def get_parquet_writer_opts(self) -> dict[str, Any]:
+    def get_parquet_writer_opts(self, repeating_values: bool = False) -> dict[str, Any]:
         """
         Returns an option dictionary that can be passed as *writer_opts* to
         :py:meth:`~law.pyarrow.merge_parquet_task`, for instance, at the end of chunked processing
         steps that produce a single parquet file. See :py:class:`~pyarrow.parquet.ParquetWriter` for
         valid options.
 
-        This method can be overwritten in subclasses to customize this behavior.
+        This method can be overwritten in subclasses to customize the exact behavior.
 
+        :param repeating_values: Whether the values to be written have predominantly repeating
+            values, in which case differnt compression and encoding strategies are followed.
         :return: A dictionary with options that can be passed to parquet writer objects.
         """
+        # use dict encoding if values are repeating
+        dict_encoding = bool(repeating_values)
+
+        # build and return options
         return {
             "compression": "ZSTD",
             "compression_level": 1,
-            "use_dictionary": False,
+            "use_dictionary": dict_encoding,
         }
 
 

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -187,8 +187,9 @@ class SelectEvents(
 
         # merge the result files
         sorted_chunks = [result_chunks[key] for key in sorted(result_chunks)]
+        writer_opts_masks = self.get_parquet_writer_opts(repeating_values=True)
         law.pyarrow.merge_parquet_task(
-            self, sorted_chunks, outputs["results"], local=True, writer_opts=self.get_parquet_writer_opts(),
+            self, sorted_chunks, outputs["results"], local=True, writer_opts=writer_opts_masks,
         )
 
         # merge the column files


### PR DESCRIPTION
This PR adds a switch to `get_parquet_writer_opts` to follow different encoding strategies in case values to be written are predominantly masks. So far, only dict encoding is used, but we might want to investigate this further in the future (e.g. different compression methods and levels).

This behavior is enabled now in `SelectEvents` for writing selection masks, reducing file sizes by approximately 20%.

Closes #338.