### PR TITLE
Change SelectionResult structure, add bool checks.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
@@ -118,7 +118,7 @@ def example(
     results += jet_results
 
     # combined event selection after all steps
-    results.main["event"] = results.steps.muon & results.steps.jet
+    results.event = results.steps.muon & results.steps.jet
 
     # create process ids
     events = self[process_ids](events, **kwargs)
@@ -133,7 +133,7 @@ def example(
     # increment stats
     weight_map = {
         "num_events": Ellipsis,
-        "num_events_selected": results.main.event,
+        "num_events_selected": results.event,
     }
     group_map = {}
     if self.dataset_inst.is_mc:
@@ -141,7 +141,7 @@ def example(
             **weight_map,
             # mc weight for all events
             "sum_mc_weight": (events.mc_weight, Ellipsis),
-            "sum_mc_weight_selected": (events.mc_weight, results.main.event),
+            "sum_mc_weight_selected": (events.mc_weight, results.event),
         }
         group_map = {
             # per process

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -163,15 +163,13 @@ class SelectionResult(od.AuxDataMixin):
 
             "objects": {
                 # object selection decisions or indices
-                # define type of this field here, define that `jet` is of
-                # type `Jet`
                 "Jet": {
                     "jet": array_of_jet_indices,
+                    "bjet": array_of_bjet_indices,
                 },
                 "Muon": {
                     "muon": array_of_muon_indices,
                 },
-                ...,
             },
 
             # additionally, you can also save auxiliary data, e.g.
@@ -203,28 +201,18 @@ class SelectionResult(od.AuxDataMixin):
                 "muon": array_of_event_masks,
                 ...
             },
+            # nested mappings of source collections to target collections with different indices
             objects={
+                # collections to be created from the initial "Jet" collection: "jet" and "bjet"
+                # define name of new field and provide indices of the corresponding objects
                 "Jet": {
                     "jet": array_of_jet_indices
+                    "bjet": list_of_bjet_indices,
                 },
-               ```suggestion
-            # section to define new fields in `ReduceEvents`
-            # following example defines new field `BJets`
-            "objects": {
-                # define the field to be used as source for your new field, in this case `Jet`
-                "Jet": {
-                    # Define name of new field and provide the list/array of indices of the corresponding 
-                    # objects in field `Jet`
-                    "BJet": list_of_bjet_indices,
-                 } ,
-                 # You can also overwrite existing fields with specific objects, e.g. only save selected Muons
-                 # after the `ReduceEvents` step
-                 "Muon": {
-                     "Muon": array_of_selected_muon_indices,
-                 },
-            },
-                    "muon": array, ...
-                }
+                # collections to be created from the initial "Muon" collection: "muon"
+                "Muon": {
+                    "muon": array_of_selected_muon_indices,
+                },
             },
             # others
             ...
@@ -313,6 +301,8 @@ class SelectionResult(od.AuxDataMixin):
         The conversion is performed with multiple calls of :external+ak:py:func:`ak.zip`.
 
         :raises ValueError: If the main events mask contains a type other than bool.
+        :raises KeyError: If the additional top-level fields in :py:attr:`other` have a field
+            "event", "step" or "objects" that might overwrite existing special fields.
         :return: :py:class:`~.SelectionResult` transformed into an awkward array.
         """
         # complain if the event mask consists of non-boolean values

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -207,7 +207,22 @@ class SelectionResult(od.AuxDataMixin):
                 "Jet": {
                     "jet": array_of_jet_indices
                 },
-                "Muon": {
+               ```suggestion
+            # section to define new fields in `ReduceEvents`
+            # following example defines new field `BJets`
+            "objects": {
+                # define the field to be used as source for your new field, in this case `Jet`
+                "Jet": {
+                    # Define name of new field and provide the list/array of indices of the corresponding 
+                    # objects in field `Jet`
+                    "BJet": list_of_bjet_indices,
+                 } ,
+                 # You can also overwrite existing fields with specific objects, e.g. only save selected Muons
+                 # after the `ReduceEvents` step
+                 "Muon": {
+                     "Muon": array_of_selected_muon_indices,
+                 },
+            },
                     "muon": array, ...
                 }
             },

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -6,6 +6,7 @@ Object and event selection tools.
 
 from __future__ import annotations
 
+import copy
 import inspect
 
 import law
@@ -252,17 +253,17 @@ class SelectionResult(od.AuxDataMixin):
 
         # logical AND between event masks
         if self.event is None:
-            self.event = other.event
+            self.event = copy.deepcopy(other.event)
         elif other.event is not None:
             self.event = self.event & other.event
         # update steps in-place
-        self.steps.update(other.steps)
+        self.steps.update(copy.deepcopy(other.steps))
         # use deep merging for objects
-        law.util.merge_dicts(self.objects, other.objects, inplace=True, deep=True)
+        law.util.merge_dicts(self.objects, copy.deepcopy(other.objects), inplace=True, deep=True)
         # update other fields in-place
-        self.other.update(other.other)
+        self.other.update(copy.deepcopy(other.other))
         # shallow update for aux
-        self.aux.update(other.aux)
+        self.aux.update(copy.deepcopy(other.aux))
 
         return self
 

--- a/columnflow/selection/stats.py
+++ b/columnflow/selection/stats.py
@@ -56,10 +56,10 @@ def increment_stats(
         weight_map = {
             # "num" operations
             "num_events": Ellipsis,  # all events
-            "num_events_selected": results.main.event,  # selected events only
+            "num_events_selected": results.event,  # selected events only
             # "sum" operations
             "sum_mc_weight": events.mc_weight,  # weights of all events
-            "sum_mc_weight_selected": (events.mc_weight, results.main.event),  # weights of selected events
+            "sum_mc_weight_selected": (events.mc_weight, results.event),  # weights of selected events
         }
 
         # usage within an exposed selector
@@ -235,6 +235,6 @@ def increment_event_stats(
     """
     weight_map = {
         "num_events": Ellipsis,
-        "num_events_selected": results.main.event,
+        "num_events_selected": results.event,
     }
     return self[increment_stats](events, results, stats, weight_map=weight_map, **kwargs)

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -161,6 +161,15 @@ class SelectEvents(
 
             # invoke the selection function
             events, results = self.selector_inst(events, stats)
+
+            # complain when there is no event mask
+            if results.event is None:
+                raise Exception(
+                    f"selector {self.selector_inst.cls_name} returned {results.__class__.__name__} "
+                    "object that does not contain 'event' mask",
+                )
+
+            # convert to array
             results_array = results.to_ak()
 
             # optional check for finite values


### PR DESCRIPTION
This PR slightly restructures the contents of the `SelectionResult` and adds a couple sanity checks as documented in #336 and #337.

Changes to `SelectionResult`:

- The main event mask used to be stored under `result.main.event`. This is now simply `result.event`.
- Other top-level fields (besides objects and steps) were also stored under `result.main.*` before but are now moved to `result.*` as well.

Added checks:

- When converting to arrays via the `to_ak()` method, there is now a check in place that verifies that event masks are booleans. We strictly require that to preserve the order of events across columns written in different places throughout columnflow.
- Inside `SelectEvents` an error is raised now in case the `selector_inst` returns a `SelectionResult` that has no event mask set. This is not entirely necessary per se, but we have some producers and other helpers that access the event mask, and it is cleaner to force the mask being there (which it is anyway in 99% of the cases), instead of having to do conditional checks in N places.

Fixes #336 and #337.