### PR TITLE
Ensure Python 3.7 compatibility.

### DIFF
--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -200,11 +200,9 @@ def prepare_plot_config(
 
     for process_inst, h in hists.items():
         # if given, per-process setting overrides task parameter
-        proc_hide_errors = (
-            phe
-            if (phe := getattr(process_inst, "hide_errors", None)) is not None
-            else hide_errors
-        )
+        proc_hide_errors = hide_errors
+        if getattr(process_inst, "hide_errors", None) is not None:
+            proc_hide_errors = process_inst.hide_errors
         if process_inst.is_data:
             data_hists.append(h)
             data_hide_errors.append(proc_hide_errors)

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -61,14 +61,19 @@ def pdf_weights(
 
     Resources:
 
-       - https://arxiv.org/pdf/1510.03865.pdf
+        - https://arxiv.org/pdf/1510.03865.pdf
     """
 
-    if outlier_action not in (known_actions := ("ignore", "remove", "raise")):
+    known_actions = ("ignore", "remove", "raise")
+    if outlier_action not in known_actions:
         raise ValueError(
             f"unknown outlier_action '{outlier_action}', known values are {','.join(known_actions)}",
         )
-    if outlier_log_mode not in (known_log_modes := ("none", "info", "debug", "warning")):
+        raise ValueError(
+            f"unknown outlier_action '{outlier_action}', known values are {','.join(known_actions)}",
+        )
+    known_log_modes = ("none", "info", "debug", "warning")
+    if outlier_log_mode not in known_log_modes:
         raise ValueError(
             f"unknown outlier_log_mode '{outlier_log_mode}', known values are "
             f"{','.join(known_log_modes)}",
@@ -107,7 +112,8 @@ def pdf_weights(
     events = set_ak_column_f32(events, "pdf_weight_up", 1 + stddev)
     events = set_ak_column_f32(events, "pdf_weight_down", 1 - stddev)
 
-    if ak.any(outlier_mask := (stddev > outlier_threshold)):
+    outlier_mask = (stddev > outlier_threshold)
+    if ak.any(outlier_mask):
         # catch events with large pdf variations
         occurances = ak.sum(outlier_mask)
         frac = occurances / ak.count(stddev, axis=0) * 100
@@ -134,7 +140,8 @@ def pdf_weights(
         }[outlier_log_mode]
         msg_func(msg)
 
-    if ak.any(invalid_pdf_weight := (pdf_weight_nominal == 0)):
+    invalid_pdf_weight = (pdf_weight_nominal == 0)
+    if ak.any(invalid_pdf_weight):
         # set all pdf weights to 0 when the nominal pdf weight is 0
         logger.warning(
             f"In dataset {self.dataset_inst.name}, {ak.sum(invalid_pdf_weight)} nominal "

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -67,16 +67,14 @@ def pdf_weights(
     known_actions = ("ignore", "remove", "raise")
     if outlier_action not in known_actions:
         raise ValueError(
-            f"unknown outlier_action '{outlier_action}', known values are {','.join(known_actions)}",
-        )
-        raise ValueError(
-            f"unknown outlier_action '{outlier_action}', known values are {','.join(known_actions)}",
+            f"unknown outlier_action '{outlier_action}', "
+            f"known values are {','.join(known_actions)}",
         )
     known_log_modes = ("none", "info", "debug", "warning")
     if outlier_log_mode not in known_log_modes:
         raise ValueError(
-            f"unknown outlier_log_mode '{outlier_log_mode}', known values are "
-            f"{','.join(known_log_modes)}",
+            f"unknown outlier_log_mode '{outlier_log_mode}', "
+            f"known values are {','.join(known_log_modes)}",
         )
 
     # check for the correct amount of weights

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -133,7 +133,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         # overwrite the version when set in the config
         if isinstance(getattr(cls, "version", None), luigi.Parameter) and "version" not in kwargs:
-            if config_version := cls.get_version_map_value(inst, params):
+            config_version = cls.get_version_map_value(inst, params)
+            if config_version:
                 params["version"] = config_version
 
         return params
@@ -153,7 +154,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             version_map = cls.get_version_map(inst)
 
         # the task family must be in the version map
-        if not (version := version_map.get(cls.task_family)):
+        version = version_map.get(cls.task_family)
+        if not version:
             return None
 
         # when version is a callable, invoke it
@@ -479,7 +481,8 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             return param
 
         # expand groups recursively
-        if groups_str and (param_groups := container.x(groups_str, {})):
+        if groups_str and container.x(groups_str, {}):
+            param_groups = container.x(groups_str)
             values = []
             lookup = law.util.make_list(param)
             handled_groups = set()

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -52,7 +52,8 @@ class CalibratorMixin(ConfigTask):
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
 
-        if config_inst := params.get("config_inst"):
+        config_inst = params.get("config_inst")
+        if config_inst:
             # add the default calibrator when empty
             params["calibrator"] = cls.resolve_config_default(
                 params,
@@ -70,7 +71,8 @@ class CalibratorMixin(ConfigTask):
         shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the calibrator, update it and add its shifts
-        if calibrator_inst := params.get("calibrator_inst"):
+        calibrator_inst = params.get("calibrator_inst")
+        if calibrator_inst:
             if cls.register_calibrator_shifts:
                 shifts |= calibrator_inst.all_shifts
             else:
@@ -140,7 +142,8 @@ class CalibratorsMixin(ConfigTask):
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
 
-        if config_inst := params.get("config_inst"):
+        config_inst = params.get("config_inst")
+        if config_inst:
             params["calibrators"] = cls.resolve_config_default_and_groups(
                 params,
                 params.get("calibrators"),
@@ -220,7 +223,8 @@ class SelectorMixin(ConfigTask):
         params = super().resolve_param_values(params)
 
         # add the default selector when empty
-        if config_inst := params.get("config_inst"):
+        config_inst = params.get("config_inst")
+        if config_inst:
             params["selector"] = cls.resolve_config_default(
                 params,
                 params.get("selector"),
@@ -237,7 +241,8 @@ class SelectorMixin(ConfigTask):
         shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the selector, update it and add its shifts
-        if selector_inst := params.get("selector_inst"):
+        selector_inst = params.get("selector_inst")
+        if selector_inst:
             if cls.register_selector_shifts:
                 shifts |= selector_inst.all_shifts
             else:
@@ -294,7 +299,8 @@ class SelectorStepsMixin(SelectorMixin):
         params = super().resolve_param_values(params)
 
         # apply selector_steps_groups and default_selector_steps from config
-        if config_inst := params.get("config_inst"):
+        config_inst = params.get("config_inst")
+        if config_inst:
             params["selector_steps"] = cls.resolve_config_default_and_groups(
                 params,
                 params.get("selector_steps"),
@@ -353,7 +359,8 @@ class ProducerMixin(ConfigTask):
         params = super().resolve_param_values(params)
 
         # add the default producer when empty
-        if config_inst := params.get("config_inst"):
+        config_inst = params.get("config_inst")
+        if config_inst:
             params["producer"] = cls.resolve_config_default(
                 params,
                 params.get("producer"),
@@ -370,7 +377,8 @@ class ProducerMixin(ConfigTask):
         shifts, upstream_shifts = super().get_known_shifts(config_inst, params)
 
         # get the producer, update it and add its shifts
-        if producer_inst := params.get("producer_inst"):
+        producer_inst = params.get("producer_inst")
+        if producer_inst:
             if cls.register_producer_shifts:
                 shifts |= producer_inst.all_shifts
             else:
@@ -438,7 +446,8 @@ class ProducersMixin(ConfigTask):
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
 
-        if config_inst := params.get("config_inst"):
+        config_inst = params.get("config_inst")
+        if config_inst:
             params["producers"] = cls.resolve_config_default_and_groups(
                 params,
                 params.get("producers"),
@@ -895,7 +904,9 @@ class MLModelsMixin(ConfigTask):
     def resolve_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
         params = super().resolve_param_values(params)
 
-        if (analysis_inst := params.get("analysis_inst")) and (config_inst := params.get("config_inst")):
+        analysis_inst = params.get("analysis_inst")
+        config_inst = params.get("config_inst")
+        if analysis_inst and config_inst:
             # apply ml_model_groups and default_ml_model from the config
             params["ml_models"] = cls.resolve_config_default_and_groups(
                 params,
@@ -963,7 +974,8 @@ class InferenceModelMixin(ConfigTask):
         params = super().resolve_param_values(params)
 
         # add the default inference model when empty
-        if config_inst := params.get("config_inst"):
+        config_inst = params.get("config_inst")
+        if config_inst:
             params["inference_model"] = cls.resolve_config_default(
                 params,
                 params.get("inference_model"),

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Development Status :: 4 - Beta",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: BSD License",
@@ -59,7 +60,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=install_requires,
-    python_requires=">=3.7, <=3.10",
+    python_requires=">=3.7, <=3.11",
     zip_safe=False,
     packages=find_packages(exclude=["tests"]),
 )


### PR DESCRIPTION
This PR re-ensures the compatibility with Python 3.7 (as recently discussed). In essence, the only non-compatible syntax was the use of walrus operators `:=` which is changed back by this PR.