### PR TITLE
Set proper LAW_CONFIG_FILE in remote jobs.

### DIFF
--- a/analysis_templates/cms_minimal/setup.sh
+++ b/analysis_templates/cms_minimal/setup.sh
@@ -128,8 +128,8 @@ setup___cf_short_name_lc__() {
     # law setup
     #
 
-    export LAW_HOME="${__cf_short_name_uc___BASE}/.law"
-    export LAW_CONFIG_FILE="${__cf_short_name_uc___BASE}/law.cfg"
+    export LAW_HOME="${LAW_HOME:-${__cf_short_name_uc___BASE}/.law}"
+    export LAW_CONFIG_FILE="${LAW_CONFIG_FILE:-${__cf_short_name_uc___BASE}/law.cfg}"
 
     if which law &> /dev/null; then
         # source law's bash completion scipt

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -354,8 +354,8 @@ class RemoteWorkflowMixin(object):
 
     def add_bundle_render_variables(
         self,
-        reqs: dict[str, AnalysisTask],
         config: law.BaseJobFileFactory.Config,
+        reqs: dict[str, AnalysisTask],
     ) -> None:
         """
         Adds render variables to the job *config* related to repository, conda environment, bash and
@@ -405,6 +405,76 @@ class RemoteWorkflowMixin(object):
             config.render_variables["cf_cmssw_sandbox_uris"] = join_bash(uris)
             config.render_variables["cf_cmssw_sandbox_patterns"] = join_bash(patterns)
             config.render_variables["cf_cmssw_sandbox_names"] = join_bash(names)
+
+    def add_common_configs(
+        self,
+        config: law.BaseJobFileFactory.Config,
+        reqs: dict[str, AnalysisTask],
+        *,
+        law_config: bool = True,
+        voms: bool = True,
+        kerberos: bool = False,
+        wlcg: bool = True,
+    ) -> None:
+        """
+        Adds job settings like common input files or render variables to the job *config*. Workflow
+        requirements are given as *reqs* to let common options potentially depend on them.
+        Additional keyword arguments control specific behavior of this method.
+
+        :param reqs: Dictionary of workflow requirements.
+        :param config: The job :py:class:`law.BaseJobFileFactory.Config`.
+        :param law_config: Whether the law config should be forwarded (via render variables or input
+            file).
+        :param voms: Whether the voms proxy file should be forwarded.
+        :param kerberos: Whether the kerberos proxy file should be forwarded.
+        :param wlcg: Whether WLCG specific settings should be added.
+        """
+        # when the law config file is located within CF_REPO_BASE, just set a render variable,
+        # but otherwise send it as an input file
+        if law_config:
+            rel_path = os.path.relpath(os.environ["LAW_CONFIG_FILE"], os.environ["CF_REPO_BASE"])
+            if not rel_path.startswith(".."):
+                config.render_variables["law_config_file"] = os.path.join("$CF_REPO_BASE", rel_path)
+            else:
+                config.input_files["law_config_file"] = law.JobInputFile(
+                    "$LAW_CONFIG_FILE",
+                    share=True,
+                    render=False,
+                )
+
+        # forward voms proxy
+        if voms and not law.config.get_expanded_boolean("analysis", "skip_ensure_proxy", False):
+            vomsproxy_file = law.wlcg.get_vomsproxy_file()
+            if not law.wlcg.check_vomsproxy_validity(proxy_file=vomsproxy_file):
+                raise Exception("voms proxy not valid, submission aborted")
+            config.input_files["vomsproxy_file"] = law.JobInputFile(
+                vomsproxy_file,
+                share=True,
+                render=False,
+            )
+
+        # forward kerberos proxy
+        if kerberos and "KRB5CCNAME" in os.environ:
+            kfile = os.environ["KRB5CCNAME"]
+            kerberos_proxy_file = os.sep + kfile.split(os.sep, 1)[-1]
+            if os.path.exists(kerberos_proxy_file):
+                config.input_files["kerberosproxy_file"] = law.JobInputFile(
+                    kerberos_proxy_file,
+                    share=True,
+                    render=False,
+                )
+
+                # set the pre command to extend potential afs permissions
+                if not config.render_variables.get("cf_pre_setup_command"):
+                    config.render_variables["cf_pre_setup_command"] = "aklog"
+
+        # add the wlcg tools
+        if wlcg:
+            config.input_files["wlcg_tools"] = law.JobInputFile(
+                law.util.law_src_path("contrib/wlcg/scripts/law_wlcg_tools.sh"),
+                share=True,
+                render=False,
+            )
 
     def common_destination_info(self, info: dict[str, str]) -> dict[str, str]:
         """
@@ -534,23 +604,19 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
         return law.JobInputFile(bootstrap_file, share=True, render_job=True)
 
     def htcondor_job_config(self, config, job_num, branches):
-        # include the voms proxy if not skipped
-        if not law.config.get_expanded_boolean("analysis", "skip_ensure_proxy", False):
-            vomsproxy_file = law.wlcg.get_vomsproxy_file()
-            if not law.wlcg.check_vomsproxy_validity(proxy_file=vomsproxy_file):
-                raise Exception("voms proxy not valid, submission aborted")
-            config.input_files["vomsproxy_file"] = law.JobInputFile(
-                vomsproxy_file,
-                share=True,
-                render=False,
-            )
-
-        # include the wlcg specific tools script in the input sandbox
-        config.input_files["wlcg_tools"] = law.JobInputFile(
-            law.util.law_src_path("contrib/wlcg/scripts/law_wlcg_tools.sh"),
-            share=True,
-            render=False,
+        # add common config settings
+        workflow_reqs = self.htcondor_workflow_requires()
+        self.add_common_configs(
+            config,
+            workflow_reqs,
+            law_config=True,
+            voms=True,
+            kerberos=False,
+            wlcg=True,
         )
+
+        # add variables related to software bundles
+        self.add_bundle_render_variables(config, workflow_reqs)
 
         # some htcondor setups require a "log" config, but we can safely use /dev/null by default
         config.log = "log.txt" if self.htcondor_logs else "/dev/null"
@@ -589,9 +655,6 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
         config.render_variables.setdefault("cf_pre_setup_command", "")
         config.render_variables.setdefault("cf_post_setup_command", "")
         config.render_variables.setdefault("cf_remote_lcg_setup", law.config.get_expanded("job", "remote_lcg_setup"))
-
-        # add variables related to software bundles
-        self.add_bundle_render_variables(self.htcondor_workflow_requires(), config)
 
         # forward env variables
         for ev, rv in self.htcondor_forward_env_variables.items():
@@ -700,26 +763,15 @@ class SlurmWorkflow(AnalysisTask, law.slurm.SlurmWorkflow, RemoteWorkflowMixin):
         return law.JobInputFile(bootstrap_file, share=True, render_job=True)
 
     def slurm_job_config(self, config, job_num, branches):
-        # include the voms proxy if not skipped
-        if not law.config.get_expanded_boolean("analysis", "skip_ensure_proxy", False):
-            vomsproxy_file = law.wlcg.get_vomsproxy_file()
-            if os.path.exists(vomsproxy_file):
-                config.input_files["vomsproxy_file"] = law.JobInputFile(
-                    vomsproxy_file,
-                    share=True,
-                    render=False,
-                )
-
-        # include the kerberos ticket when existing
-        if "KRB5CCNAME" in os.environ:
-            kfile = os.environ["KRB5CCNAME"]
-            kerberos_proxy_file = os.sep + kfile.split(os.sep, 1)[-1]
-            if os.path.exists(kerberos_proxy_file):
-                config.input_files["kerberos_proxy_file"] = law.JobInputFile(
-                    kerberos_proxy_file,
-                    share=True,
-                    render=False,
-                )
+        # add common config settings
+        self.add_common_configs(
+            config,
+            {},
+            law_config=False,
+            voms=True,
+            kerberos=True,
+            wlcg=False,
+        )
 
         # set job time and nodes
         job_time = law.util.human_duration(
@@ -731,14 +783,14 @@ class SlurmWorkflow(AnalysisTask, law.slurm.SlurmWorkflow, RemoteWorkflowMixin):
 
         # custom, flavor dependent settings
         if self.slurm_flavor == "maxwell":
-            # extend kerberos privileges to afs on NAF
-            if "kerberos_proxy_file" in config.input_files:
-                config.render_variables["cf_pre_setup_command"] = "aklog"
+            # nothing yet
+            pass
 
         # render variales
         config.render_variables["cf_bootstrap_name"] = "slurm"
         config.render_variables.setdefault("cf_pre_setup_command", "")
         config.render_variables.setdefault("cf_post_setup_command", "")
+
         # custom tmp dir since slurm uses the job submission dir as the main job directory, and law
         # puts the tmp directory in this job directory which might become quite long; then,
         # python's default multiprocessing puts socket files into that tmp directory which comes

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -18,6 +18,7 @@ bootstrap_htcondor_standalone() {
     export CF_LOCAL_SCHEDULER="{{cf_local_scheduler}}"
     export CF_WLCG_CACHE_ROOT="${LAW_JOB_HOME}/cf_wlcg_cache"
     export CF_WLCG_TOOLS="{{wlcg_tools}}"
+    export LAW_CONFIG_FILE="{{law_config_file}}"
     [ ! -z "{{vomsproxy_file}}" ] && export X509_USER_PROXY="${PWD}/{{vomsproxy_file}}"
     local sharing_software="$( [ -z "{{cf_software_base}}" ] && echo "false" || echo "true" )"
     local lcg_setup="{{cf_remote_lcg_setup}}"
@@ -110,7 +111,7 @@ bootstrap_slurm() {
     export CF_REMOTE_JOB="1"
     export CF_REPO_BASE="{{cf_repo_base}}"
     export CF_WLCG_CACHE_ROOT="${LAW_JOB_HOME}/cf_wlcg_cache"
-    export KRB5CCNAME="FILE:{{kerberos_proxy_file}}"
+    export KRB5CCNAME="FILE:{{kerberosproxy_file}}"
     [ ! -z "{{vomsproxy_file}}" ] && export X509_USER_PROXY="{{vomsproxy_file}}"
 
     # optional custom command before the setup is sourced
@@ -138,6 +139,7 @@ bootstrap_crab() {
     export CF_STORE_NAME="{{cf_store_name}}"
     export CF_WLCG_CACHE_ROOT="${LAW_JOB_HOME}/cf_wlcg_cache"
     export CF_WLCG_TOOLS="{{wlcg_tools}}"
+    export LAW_CONFIG_FILE="{{law_config_file}}"
     local lcg_setup="{{cf_remote_lcg_setup}}"
     lcg_setup="${lcg_setup:-/cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh}"
 

--- a/setup.sh
+++ b/setup.sh
@@ -140,9 +140,9 @@ setup_columnflow() {
     #   X509_USER_PROXY
     #       Set to "/tmp/x509up_u$( id -u )" if not already set.
     #   LAW_HOME
-    #       Set to $CF_BASE/.law.
+    #       Set to "$CF_BASE/.law" if not already set.
     #   LAW_CONFIG_FILE
-    #       Set to $CF_BASE/law.cfg.
+    #       Set to "$CF_BASE/law.cfg" if not already set.
 
     # prevent repeated setups
     if [ "${CF_SETUP}" = "1" ]; then
@@ -233,8 +233,8 @@ setup_columnflow() {
     # law setup
     #
 
-    export LAW_HOME="${CF_BASE}/.law"
-    export LAW_CONFIG_FILE="${CF_BASE}/law.cfg"
+    export LAW_HOME="${LAW_HOME:-${CF_BASE}/.law}"
+    export LAW_CONFIG_FILE="${LAW_CONFIG_FILE:-${CF_BASE}/law.cfg}"
 
     if which law &> /dev/null; then
         # source law's bash completion scipt


### PR DESCRIPTION
This PR updates the behavior of remote jobs in their handling of the LAW_CONFIG_FILE.

So far, remote jobs disregarded the LAW_CONFIG_FILE set in the local submission environment. This can obviously lead to different settings being used in remote jobs than expected. This is fixed now.

In addition, I streamlined the handling of files to be sent (or set) in remote jobs (law config, kerberos token, voms proxy token, wlcg tools, ...).