### PR TITLE
Introducing ColumnCollection's to define columns to keep.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -11,7 +11,7 @@ import order as od
 from scinum import Number
 
 from columnflow.util import DotDict, maybe_import
-from columnflow.columnar_util import EMPTY_FLOAT
+from columnflow.columnar_util import EMPTY_FLOAT, ColumnCollection
 from columnflow.config_util import (
     get_root_processes_from_campaign, add_shift_aliases, get_shifts_from_sources, add_category,
     verify_config_processes,
@@ -217,8 +217,8 @@ cfg.x.keep_columns = DotDict.wrap({
         "Muon.pt", "Muon.eta", "Muon.phi", "Muon.mass", "Muon.pfRelIso04_all",
         "MET.pt", "MET.phi", "MET.significance", "MET.covXX", "MET.covXY", "MET.covYY",
         "PV.npvs",
-        # columns added during selection
-        "deterministic_seed", "process_id", "mc_weight", "cutflow.*",
+        # all columns added during selection using a ColumnCollection flag
+        ColumnCollection.ALL_FROM_SELECTOR,
     },
     "cf.MergeSelectionMasks": {
         "cutflow.*",

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -7,7 +7,7 @@ Helpers and utilities for working with columnar libraries.
 from __future__ import annotations
 
 __all__ = [
-    "mandatory_coffea_columns", "EMPTY_INT", "EMPTY_FLOAT",
+    "mandatory_coffea_columns", "ColumnCollection", "EMPTY_INT", "EMPTY_FLOAT",
     "Route", "RouteFilter", "ArrayFunction", "TaskArrayFunction", "ChunkedIOHandler",
     "eval_item", "get_ak_routes", "has_ak_column", "set_ak_column", "remove_ak_column",
     "add_ak_alias", "add_ak_aliases", "update_ak_array", "flatten_ak_array", "sort_ak_fields",
@@ -529,6 +529,18 @@ class Route(od.TagMixin):
                         res = ak.fill_none(res, null_value)
 
         return res
+
+
+class ColumnCollection(enum.Flag):
+    """
+    Enumeration containing flags that describe arbitrary collection of columns.
+    """
+
+    ALL_FROM_CALIBRATOR = enum.auto()
+    ALL_FROM_CALIBRATORS = enum.auto()
+    ALL_FROM_SELECTOR = enum.auto()
+    ALL_FROM_PRODUCER = enum.auto()
+    ALL_FROM_PRODUCERS = enum.auto()
 
 
 def get_ak_routes(

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -18,6 +18,7 @@ import law
 import order as od
 
 from columnflow.types import Sequence, Callable, Any
+from columnflow.columnar_util import mandatory_coffea_columns, Route, ColumnCollection
 from columnflow.util import DotDict
 
 
@@ -709,6 +710,19 @@ class ConfigTask(AnalysisTask):
         parts.insert_after("task_family", "config", self.config_inst.name)
 
         return parts
+
+    def find_keep_columns(self: ConfigTask, collection: ColumnCollection) -> set[Route]:
+        """
+        Returns a set of :py:class:`Route` objects describing columns that should be kept given a
+        type of column *collection*.
+
+        :param collection: The collection to return.
+        :return: A set of :py:class:`Route` objects.
+        """
+        if collection == ColumnCollection.MANDATORY_COFFEA:
+            return set(Route(c) for c in mandatory_coffea_columns)
+
+        return set()
 
 
 class ShiftTask(ConfigTask):

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -94,8 +94,8 @@ class UniteColumns(
     @law.decorator.safe_output
     def run(self):
         from columnflow.columnar_util import (
-            Route, RouteFilter, mandatory_coffea_columns, update_ak_array, sorted_ak_to_parquet,
-            sorted_ak_to_root,
+            ColumnCollection, Route, RouteFilter, mandatory_coffea_columns, update_ak_array,
+            sorted_ak_to_parquet, sorted_ak_to_root,
         )
 
         # prepare inputs and outputs
@@ -108,7 +108,12 @@ class UniteColumns(
         tmp_dir.touch()
 
         # define columns that will be written
-        write_columns = set(self.config_inst.x.keep_columns.get(self.task_family, ["*"]))
+        write_columns = set()
+        for c in self.config_inst.x.keep_columns.get(self.task_family, ["*"]):
+            if isinstance(c, ColumnCollection):
+                write_columns |= self.find_keep_columns(c)
+            else:
+                write_columns.add(Route(c))
         route_filter = RouteFilter(write_columns)
 
         # define columns that need to be read


### PR DESCRIPTION
This PR introduces `ColumnCollection`'s which are flags to denote certain types of - as the names suggests - collections of columns.

Background: we got a couple questions recently on why certain columns were not existing in processed arrays at e.g. `ProduceColumns` or `CreateHistograms` level. The reason always was that the columns to keep were not properly defined in the `cfg.x.keep_columns` map. However, we already discussed that this is not very transparent anyway.

I think it's correct that these kind of "columns to keep" need to be defined *somewhere*, in most use cases it would be sufficient to have a placeholder in the `keep_columns` map that means something like "just keep all columns produced by the calibrators / selector / producers / ...". `ColumnCollection`s are exactly that.

So far, there are just a handful of flags (e.g. `ColumnCollection.ALL_FROM_SELECTOR`) but this could even be extended in the future.

For the particular use case of determining the columns to keep at various places where some columns are dropped (ReduceEvents, UniteColumns, MergeSelectionMasks), I added `find_keep_columns` to our mixin classes which makes a lot of sense inheritance-wise (e.g. all tasks having the `SelectorMixin` should be able to access columns produced by a selector and thus, should be able to resolve the `ColumnCollection.ALL_FROM_SELECTOR` flag).