### PR TITLE
Add empty selector

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -249,8 +249,11 @@ cfg.add_channel(name="mutau", id=1)
 
 # add categories using the "add_category" tool which adds auto-generated ids
 # the "selection" entries refer to names of selectors, e.g. in selection/example.py
+# note: it is recommended to always add an inclusive category with id=1 or name="incl" which is used
+#       in various places, e.g. for the inclusive cutflow plots and the "empty" selector
 add_category(
     cfg,
+    id=1,
     name="incl",
     selection="cat_incl",
     label="inclusive",

--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -26,7 +26,7 @@ default_config: run2_2017_nano_v9
 default_dataset: st_tchannel_t_powheg
 
 calibration_modules: columnflow.calibration.cms.{jets,met}, __cf_module_name__.calibration.example
-selection_modules: columnflow.selection.cms.{json_filter, met_filters}, __cf_module_name__.selection.example
+selection_modules: columnflow.selection.{empty}, columnflow.selection.cms.{json_filter, met_filters}, __cf_module_name__.selection.example
 production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds}, __cf_module_name__.production.example
 categorization_modules: __cf_module_name__.categorization.example
 ml_modules: columnflow.ml, __cf_module_name__.ml.example

--- a/columnflow/selection/empty.py
+++ b/columnflow/selection/empty.py
@@ -42,8 +42,8 @@ def empty(
     :param **kwargs: Additional keyword arguments that are passed to all other
         :py:class:`TaskArrayFunction`'s.
 
-    :returns: A tuple containing the original events and a SelectionResult object with a trivial
-        event mask.
+    :returns: A tuple containing the original events and a :py:class:`SelectionResult` object with a
+        trivial event mask.
     """
     # create process ids
     events = self[process_ids](events, **kwargs)

--- a/columnflow/selection/empty.py
+++ b/columnflow/selection/empty.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+
+"""
+Empty selectors that still produce the minimal set of columns potentially required in downstream
+tasks.
+"""
+
+from collections import defaultdict
+
+from columnflow.selection import Selector, SelectionResult, selector
+from columnflow.selection.stats import increment_stats
+from columnflow.production.processes import process_ids
+from columnflow.production.cms.mc_weight import mc_weight
+from columnflow.columnar_util import set_ak_column
+from columnflow.util import maybe_import
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+
+
+@selector(
+    uses={
+        process_ids, mc_weight, increment_stats,
+    },
+    produces={
+        process_ids, mc_weight, "category_ids",
+    },
+    exposed=True,
+)
+def empty(
+    self: Selector,
+    events: ak.Array,
+    stats: defaultdict,
+    **kwargs,
+) -> tuple[ak.Array, SelectionResult]:
+    """
+    Empty selector that only writes a minimal set of columns that are potentially required in
+    downstream tasks, such as cutflow and plotting related tasks.
+
+    :param events: The input events.
+    :param stats: The statistics dictionary.
+    :param **kwargs: Additional keyword arguments that are passed to all other
+        :py:class:`TaskArrayFunction`'s.
+
+    :returns: A tuple containing the original events and a SelectionResult object with a trivial
+        event mask.
+    """
+    # create process ids
+    events = self[process_ids](events, **kwargs)
+
+    # add corrected mc weights
+    if self.dataset_inst.is_mc:
+        events = self[mc_weight](events, **kwargs)
+
+    # inclusive category id
+    category_ids = (np.ones(len(events), dtype=np.int64) * self.inclusive_category_id)[..., None]
+    events = set_ak_column(events, "category_ids", category_ids)
+
+    # empty selection result with a trivial event mask
+    results = SelectionResult(event=ak.Array(np.ones(len(events), dtype=np.bool_)))
+
+    # increment stats
+    weight_map = {
+        "num_events": Ellipsis,
+        "num_events_selected": Ellipsis,
+    }
+    if self.dataset_inst.is_mc:
+        weight_map["sum_mc_weight"] = events.mc_weight
+        weight_map["sum_mc_weight_selected"] = (events.mc_weight, Ellipsis)
+    group_map = {
+        # per process
+        "process": {
+            "values": events.process_id,
+            "mask_fn": (lambda v: events.process_id == v),
+        },
+    }
+    events, _ = self[increment_stats](
+        events,
+        results,
+        stats,
+        weight_map=weight_map,
+        group_map=group_map,
+        **kwargs,
+    )
+
+    return events, results
+
+
+@empty.init
+def empty_init(self: Selector) -> None:
+    """
+    Initializes the selector by finding the id of the inclusive category.
+
+    :raises ValueError: If the inclusive category cannot be found.
+    """
+    # find the id of the inclusive category
+    if "incl" in self.config_inst.categories:
+        self.inclusive_category_id = self.config_inst.categories.n.incl.id
+    elif 1 in self.config_inst.categories:
+        self.inclusive_category_id = 1
+    else:
+        raise ValueError(f"could not find inclusive category for {self.cls_name} selector")

--- a/columnflow/selection/empty.py
+++ b/columnflow/selection/empty.py
@@ -56,7 +56,7 @@ def empty(
     if self.dataset_inst.is_mc:
         events = self[mc_weight](events, **kwargs)
 
-    # inclusive category id
+    # category id
     category_ids = np.array(len(events) * [self.category_ids], dtype=np.int64)
     events = set_ak_column(events, "category_ids", category_ids)
 

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -4,6 +4,8 @@
 Task to produce and merge histograms.
 """
 
+from __future__ import annotations
+
 import luigi
 import law
 
@@ -48,6 +50,10 @@ class CreateHistograms(
     # names of columns that contain category ids
     # (might become a parameter at some point)
     category_id_columns = {"category_ids"}
+
+    @law.util.classproperty
+    def mandatory_columns(cls) -> set[str]:
+        return set(cls.category_id_columns) | {"process_id"}
 
     def workflow_requires(self):
         reqs = super().workflow_requires()

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -118,7 +118,7 @@ class SelectEvents(
         # show an early warning in case the selector does not produce some mandatory columns
         produced_columns = self.selector_inst.produced_columns
         for c in self.reqs.get("CreateHistograms", CreateHistograms).mandatory_columns:
-            if c not in produced_columns:
+            if Route(c) not in produced_columns:
                 self.logger.warning(
                     f"selector {self.selector_inst.cls_name} does not produce column {c} "
                     "which might be required later on for creating histograms downstream",

--- a/law.cfg
+++ b/law.cfg
@@ -22,7 +22,7 @@ default_dataset: st_tchannel_t
 
 production_modules: columnflow.production.{categories,processes,normalization}
 calibration_modules: columnflow.calibration
-selection_modules: columnflow.selection
+selection_modules: columnflow.selection.{empty}
 categorization_modules: columnflow.categorization
 ml_modules: columnflow.ml
 inference_modules: columnflow.inference


### PR DESCRIPTION
In our task graph, running `SelectEvents` is mandatory since a couple other tasks downstream require a minimal set of additional columns, most notable, the `CreateHistograms` task. In particular, we require `process_id` and `category_ids` to be set (and optionally `mc_weight` for sensible generator studies).

However, for generator studies we often do not want to apply any selections and just directly proceed to histograms. So far each analysis has to create its own `empty` selection which would still need to create the minimal set of expected columns.

This PR adds a generic `empty` selector to columnflow which is providing the three above mentioned columns, plus a selection masks with only `True`'s. By default, for the `category_ids` it uses the inclusive category, which usually exists. If not, it is possible to subclass the selector and set a fixed value.

In addition, to avoid surprises later on, there is a check now happening in `SelectEvents` that warns users about missing columns that are necessary for histogramming.

---

**Note**: `--selector empty --calibrators "" --producers ""` does the trick now for generator studies.