### PR TITLE
tests for columnflow.util

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -7,7 +7,7 @@ Example plot function.
 from __future__ import annotations
 
 from columnflow.types import Sequence
-from columnflow.util import maybe_import, test_float
+from columnflow.util import maybe_import, try_float
 from columnflow.plotting.plot_util import get_position, get_cms_label
 
 hist = maybe_import("hist")
@@ -56,7 +56,7 @@ def draw_stack(
     **kwargs,
 ) -> None:
     # check if norm is a number
-    if test_float(norm):
+    if try_float(norm):
         h = hist.Stack(*[i / norm for i in h])
     else:
         if not isinstance(norm, Sequence) and not isinstance(norm, np.ndarray):

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 
 import order as od
 
-from columnflow.util import maybe_import, test_int
+from columnflow.util import maybe_import, try_int
 
 math = maybe_import("math")
 hist = maybe_import("hist")
@@ -92,7 +92,7 @@ def apply_process_settings(
     # apply "scale" setting directly to the hists
     for proc_inst, h in hists.items():
         scale_factor = getattr(proc_inst, "scale", None) or proc_inst.x("scale", None)
-        if test_int(scale_factor):
+        if try_int(scale_factor):
             scale_factor = int(scale_factor)
             hists[proc_inst] = h * scale_factor
             # TODO: there might be a prettier way for the label
@@ -116,7 +116,7 @@ def apply_variable_settings(
     # apply rebinning setting directly to histograms
     for var_inst in variable_insts:
         rebin_factor = getattr(var_inst, "rebin", None) or var_inst.x("rebin", None)
-        if test_int(rebin_factor):
+        if try_int(rebin_factor):
             for proc_inst, h in list(hists.items()):
                 rebin_factor = int(rebin_factor)
                 h = h[{var_inst.name: hist.rebin(rebin_factor)}]

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import law
 
-from columnflow.util import test_float, DotDict
+from columnflow.util import try_float, DotDict
 
 
 class SettingsParameter(law.CSVParameter):
@@ -31,7 +31,7 @@ class SettingsParameter(law.CSVParameter):
     def parse_setting(cls, setting: str) -> tuple[str, float | bool | str]:
         pair = setting.split("=", 1)
         key, value = pair if len(pair) == 2 else (pair[0], "True")
-        if test_float(value):
+        if try_float(value):
             value = float(value)
         elif value.lower() == "true":
             value = True

--- a/columnflow/tasks/yields.py
+++ b/columnflow/tasks/yields.py
@@ -18,7 +18,7 @@ from columnflow.tasks.framework.mixins import (
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms
-from columnflow.util import dev_sandbox, test_int
+from columnflow.util import dev_sandbox, try_int
 
 
 class CreateYieldTable(
@@ -98,7 +98,7 @@ class CreateYieldTable(
     def resolve_param_values(cls, params):
         params = super().resolve_param_values(params)
 
-        if "number_format" in params and test_int(params["number_format"]):
+        if "number_format" in params and try_int(params["number_format"]):
             # convert 'number_format' in integer if possible
             params["number_format"] = int(params["number_format"])
 

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -477,14 +477,14 @@ def pattern_matcher(pattern: Sequence[str] | str, mode: Callable = any) -> Calla
     if pattern in ["*", "^.*$"]:
         return lambda s: True
 
-    # identify fnmatch patterns
-    if is_pattern(pattern):
-        return lambda s: fnmatch.fnmatch(s, pattern)
-
     # identify regular expressions
     if is_regex(pattern):
         cre = re.compile(pattern)
         return lambda s: cre.match(s) is not None
+
+    # identify fnmatch patterns
+    if is_pattern(pattern):
+        return lambda s: fnmatch.fnmatch(s, pattern)
 
     # fallback to string comparison
     return lambda s: s == pattern
@@ -627,7 +627,7 @@ class MockModule(object):
 
 class FunctionArgs(object):
     """
-    Leight-weight utility class that wraps all passed *args* and *kwargs* and allows to invoke
+    Light-weight utility class that wraps all passed *args* and *kwargs* and allows to invoke
     different functions with them.
     """
 

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -10,7 +10,7 @@ __all__ = [
     "UNSET",
     "maybe_import", "import_plt", "import_ROOT", "import_file", "create_random_name", "expand_path",
     "real_path", "ensure_dir", "wget", "call_thread", "call_proc", "ensure_proxy", "dev_sandbox",
-    "safe_div", "test_float", "test_int", "is_pattern", "is_regex", "pattern_matcher",
+    "safe_div", "try_float", "try_int", "is_pattern", "is_regex", "pattern_matcher",
     "dict_add_strict", "get_source_code",
     "DotDict", "MockModule", "FunctionArgs", "ClassPropertyDescriptor", "classproperty",
     "DerivableMeta", "Derivable",
@@ -401,7 +401,7 @@ def safe_div(a: int | float, b: int | float) -> float:
     return (a / b) if b else 0.0
 
 
-def test_float(f: Any) -> bool:
+def try_float(f: Any) -> bool:
     """
     Tests whether a value *f* can be converted to a float.
     """
@@ -412,7 +412,7 @@ def test_float(f: Any) -> bool:
         return False
 
 
-def test_int(i: Any) -> bool:
+def try_int(i: Any) -> bool:
     """
     Tests whether a value *i* can be converted to an integer.
     """

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -28,7 +28,7 @@ Summary
    ensure_proxy
    dev_sandbox
    safe_div
-   test_float
+   try_float
    is_pattern
    is_regex
    pattern_matcher
@@ -139,10 +139,10 @@ Functions
 
 .. autofunction:: safe_div
 
-``test_float``
+``try_float``
 ++++++++++++++
 
-.. autofunction:: test_float
+.. autofunction:: try_float
 
 ``is_pattern``
 ++++++++++++++

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,10 +5,126 @@ __all__ = ["UtilTest"]
 
 import unittest
 
-from columnflow.util import create_random_name
+from columnflow.util import (
+    create_random_name, maybe_import, MockModule, DotDict, Derivable,
+    safe_div, test_float, test_int, is_regex, is_pattern, pattern_matcher,
+)
 
 
 class UtilTest(unittest.TestCase):
 
     def test_create_random_name(self):
         self.assertIsInstance(create_random_name(), str)
+
+    def test_maybe_import(self):
+        # non-existing package
+        mock_module = maybe_import("not_existing_package")
+        self.assertIsInstance(mock_module, MockModule)
+        with self.assertRaises(Exception):
+            mock_module()
+
+        with self.assertRaises(ImportError):
+            _ = maybe_import("not_existing_package", force=True)
+
+        # existing package
+        self.assertEqual(unittest, maybe_import("unittest"))
+
+    def test_save_div(self):
+        self.assertEqual(safe_div(10, 2), 5)
+        self.assertEqual(safe_div(10, 0), 0)
+
+    def test_test_int_test_float(self):
+        for test_number in (test_int, test_float):
+            self.assertIsInstance(test_number(1), bool)
+            self.assertIsInstance(test_number("some_string"), bool)
+            self.assertTrue(test_number(1))
+            self.assertTrue(test_number(1.5))
+            self.assertTrue(test_number(-1.5))
+            self.assertFalse(test_number("some_string"))
+            self.assertFalse(test_number(1j))
+            self.assertFalse(test_number([1, 2]))
+
+    def test_is_regex(self):
+        self.assertTrue(is_regex(r"^foo\d+.*$"))
+        self.assertFalse(is_regex(r"^no$atEnd"))
+        self.assertFalse(is_regex(r"no^atStart$"))
+
+    def test_is_pattern(self):
+        self.assertTrue(is_pattern("foo*"))
+        self.assertTrue(is_pattern("bar?"))
+        self.assertFalse(is_pattern("not_a_pattern"))
+
+    def test_pattern_matcher(self):
+        matcher = pattern_matcher("foo*")
+        self.assertTrue(matcher("foo"))
+        self.assertTrue(matcher("foo123"))
+        self.assertFalse(matcher("xfoo"))
+        self.assertFalse(matcher("bar123"))
+
+        matcher = pattern_matcher(r"^foo\d+.*$")
+        self.assertTrue(matcher("foo1"))
+        self.assertTrue(matcher("foo12x3"))
+        self.assertFalse(matcher("foo"))
+        self.assertFalse(matcher("foox1"))
+
+        matcher = pattern_matcher(("foo*", "*bar"), mode=any)
+        self.assertTrue(matcher("foo123"))
+        self.assertTrue(matcher("123bar"))
+
+        matcher = pattern_matcher(("foo*", "*bar"), mode=all)
+        self.assertFalse(matcher("foo123"))
+        self.assertFalse(matcher("123bar"))
+        self.assertTrue(matcher("foo123bar"))
+
+    def test_DotDict(self):
+        my_dict = DotDict({
+            "A": 1,
+            "B": 2,
+        })
+        self.assertEqual(my_dict.A, 1)
+        self.assertEqual(my_dict.get("B", 3), 2)
+        self.assertEqual(my_dict.get("C", 3), 3)
+        with self.assertRaises(AttributeError):
+            my_dict.C
+
+        my_dict = DotDict.wrap({
+            "A": 1,
+            "B": 2,
+            "C": {"D": 3},
+        })
+        self.assertEqual(my_dict.A, 1)
+        self.assertEqual(my_dict.C.D, 3)
+        my_dict = DotDict.wrap({
+            "A": 1,
+            "B": 2,
+            "C": [3, 4],
+        })
+        self.assertEqual(my_dict.C, [3, 4])
+
+    def test_Derivable(self):
+        class MyClass(Derivable):
+            A = 1
+            B = 2
+
+        derived_class = MyClass.derive("derived", cls_dict={
+            "A": 3,
+            "C": 4,
+            "dummy_method": lambda N: 3 * N,
+        })
+        deep_derived_class = derived_class.derive("deep_derived")
+
+        self.assertEqual(derived_class.cls_name, "derived")
+        self.assertEqual(derived_class.A, 3)
+        self.assertEqual(derived_class.B, 2)
+        self.assertEqual(derived_class.C, 4)
+        with self.assertRaises(AttributeError):
+            derived_class.D
+        with self.assertRaises(AttributeError):
+            MyClass.C
+
+        self.assertEqual(MyClass._subclasses, {"derived": derived_class})
+        self.assertTrue(MyClass.has_cls("derived"))
+        self.assertFalse(MyClass.has_cls("deep_derived", deep=False))
+        self.assertTrue(MyClass.has_cls("deep_derived", deep=True))
+        self.assertEqual(MyClass.get_cls("deep_derived", deep=True), deep_derived_class)
+        self.assertFalse(MyClass.has_cls("not_derived"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ import unittest
 
 from columnflow.util import (
     create_random_name, maybe_import, MockModule, DotDict, Derivable,
-    safe_div, test_float, test_int, is_regex, is_pattern, pattern_matcher,
+    safe_div, try_float, try_int, is_regex, is_pattern, pattern_matcher,
 )
 
 
@@ -33,16 +33,16 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(safe_div(10, 2), 5)
         self.assertEqual(safe_div(10, 0), 0)
 
-    def test_test_int_test_float(self):
-        for test_number in (test_int, test_float):
-            self.assertIsInstance(test_number(1), bool)
-            self.assertIsInstance(test_number("some_string"), bool)
-            self.assertTrue(test_number(1))
-            self.assertTrue(test_number(1.5))
-            self.assertTrue(test_number(-1.5))
-            self.assertFalse(test_number("some_string"))
-            self.assertFalse(test_number(1j))
-            self.assertFalse(test_number([1, 2]))
+    def test_try_int_try_float(self):
+        for try_number in (try_int, try_float):
+            self.assertIsInstance(try_number(1), bool)
+            self.assertIsInstance(try_number("some_string"), bool)
+            self.assertTrue(try_number(1))
+            self.assertTrue(try_number(1.5))
+            self.assertTrue(try_number(-1.5))
+            self.assertFalse(try_number("some_string"))
+            self.assertFalse(try_number(1j))
+            self.assertFalse(try_number([1, 2]))
 
     def test_is_regex(self):
         self.assertTrue(is_regex(r"^foo\d+.*$"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -101,6 +101,22 @@ class UtilTest(unittest.TestCase):
         })
         self.assertEqual(my_dict.C, [3, 4])
 
+        # DotDict can also be constructed from Iterable of key-value pairs
+        self.assertEqual(
+            DotDict([(1, 2), (3, 4)]),
+            DotDict({1: 2, 3: 4}),
+        )
+
+        # check that DotDict can not be created from something other than a dict-like object
+        with self.assertRaises(TypeError):
+            DotDict(1)
+        with self.assertRaises(TypeError):
+            # each element needs to be an Iterable of lenght 2
+            DotDict([1, 2])
+        with self.assertRaises(ValueError):
+            # each element needs to be an Iterable of lenght 2
+            DotDict([(1, 2, 3), (4, 5, 6)])
+
     def test_Derivable(self):
         class MyClass(Derivable):
             A = 1


### PR DESCRIPTION
I also fixed a minor issue in `pattern_matcher`, where regex expressions were considered as patterns as soon as the regex inlcudes a `*`