### PR TITLE
add plot_profile function

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -86,7 +86,33 @@ def draw_hist(
     norm: float | Sequence | np.ndarray = 1.0,
     **kwargs,
 ) -> None:
+    if kwargs.get("color", "") is None:
+        # when color is set to None, remove it such that matplotlib automatically chooses a color
+        kwargs.pop("color")
+
     h = h / norm
+    defaults = {
+        "ax": ax,
+        "stack": False,
+        "histtype": "step",
+    }
+    defaults.update(kwargs)
+    h.plot1d(**defaults)
+
+
+def draw_profile(
+    ax: plt.Axes,
+    h: hist.Hist,
+    norm: float | Sequence | np.ndarray = 1.0,
+    **kwargs,
+) -> None:
+    """
+    Profiled histograms contains the storage type "Mean" and can therefore not be normalized
+    """
+    if kwargs.get("color", "") is None:
+        # when color is set to None, remove it such that matplotlib automatically chooses a color
+        kwargs.pop("color")
+
     defaults = {
         "ax": ax,
         "stack": False,
@@ -169,7 +195,7 @@ def plot_all(
     # available plot methods mapped to their names
     plot_methods = {
         func.__name__: func
-        for func in [draw_error_bands, draw_stack, draw_hist, draw_errorbars]
+        for func in [draw_error_bands, draw_stack, draw_hist, draw_profile, draw_errorbars]
     }
 
     plt.style.use(mplhep.style.CMS)

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -327,6 +327,7 @@ def plot_profile(
     Exemplary task call:
 
     .. code-block:: bash
+
         law run cf.PlotVariables1D --version prod1 --processes st_tchannel_t \
             --variables jet1_pt-jet2_pt \
             --plot-function columnflow.plotting.plot_functions_1d.plot_profile

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -436,7 +436,7 @@ def broadcast_nminus1d_to_nd(x: np.array, final_shape: list, axis: int = 1) -> n
     return x
 
 
-def get_profile_width(h_in: hist.Hist, axis: int = 1) -> (np.array, np.array):
+def get_profile_width(h_in: hist.Hist, axis: int = 1) -> tuple[np.array, np.array]:
     """
     Function that takes a histogram *h_in* and returns the mean and width
     when profiling over the axis *axis*.
@@ -458,7 +458,7 @@ def get_profile_width(h_in: hist.Hist, axis: int = 1) -> (np.array, np.array):
     return mean, width
 
 
-def get_profile_variations(h_in: hist.Hist, axis: int = 1) -> dict(str, hist.Hist):
+def get_profile_variations(h_in: hist.Hist, axis: int = 1) -> dict[str, hist.Hist]:
     """
     Returns a profile histogram plus the up and down variations of the profile
     from a normal histogram with N-1 axes.

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -392,3 +392,96 @@ reduce_with.funcs = {
     "maxabs": lambda v: max(abs(np.nanmax(v)), abs(np.nanmin(v))),
     "minabs": lambda v: min(abs(np.nanmax(v)), abs(np.nanmin(v))),
 }
+
+
+def broadcast_1d_to_nd(x: np.array, final_shape: list, axis: int = 1) -> np.array:
+    """
+    Helper function to broadcast a 1d array *x* to an nd array with shape *final_shape*.
+    The length of *x* should be the same as *final_shape[axis]*.
+    """
+    if len(x.shape) != 1:
+        raise Exception("Only 1d arrays allowed")
+    if final_shape[axis] != x.shape[0]:
+        raise Exception(f"Initial shape should match with final shape in requested axis {axis}")
+    initial_shape = [1] * len(final_shape)
+    initial_shape[axis] = x.shape[0]
+    x = np.reshape(x, initial_shape)
+    x = np.broadcast_to(x, final_shape)
+    return x
+
+
+def broadcast_nminus1d_to_nd(x: np.array, final_shape: list, axis: int = 1) -> np.array:
+    """
+    Helper function to broadcast a (n-1)d array *x* to an nd array with shape *final_shape*.
+    *final_shape* should be the same as *x.shape* except that the axis *axis* is missing.
+    """
+    if len(final_shape) - len(x.shape) != 1:
+        raise Exception("Only (n-1)d arrays allowed")
+
+    # shape comparison between x and final_shape
+    _init_shape = list(final_shape)
+    _init_shape.pop(axis)
+    if _init_shape != list(x.shape):
+        raise Exception(
+            f"input shape ({x.shape}) should agree with final_shape {final_shape} "
+            f"after inserting new axis at {axis}",
+        )
+
+    initial_shape = list(x.shape)
+    initial_shape.insert(axis, 1)
+
+    x = np.reshape(x, initial_shape)
+    x = np.broadcast_to(x, final_shape)
+
+    return x
+
+
+def get_profile_width(h_in: hist.Hist, axis: int = 1) -> (np.array, np.array):
+    """
+    Function that takes a histogram *h_in* and returns the mean and width
+    when profiling over the axis *axis*.
+    """
+    values = h_in.values()
+    centers = h_in.axes[axis].centers
+    centers = broadcast_1d_to_nd(centers, values.shape, axis)
+
+    num = np.sum(values * centers, axis=axis)
+    den = np.sum(values, axis=axis)
+
+    print(num.shape)
+
+    with np.errstate(invalid="ignore"):
+        mean = num / den
+        _mean = broadcast_nminus1d_to_nd(mean, values.shape, axis)
+        width = np.sum(values * (centers - _mean) ** 2, axis=axis) / den
+
+    return mean, width
+
+
+def get_profile_variations(h_in: hist.Hist, axis: int = 1) -> dict(str, hist.Hist):
+    """
+    Returns a profile histogram plus the up and down variations of the profile
+    from a normal histogram with N-1 axes.
+    The axis given is profiled over and removed from the final histograms.
+    """
+    # start with profile such that we only have to replace the mean
+    # NOTE: how do the variances change for the up/down variations?
+    h_profile = h_in.profile(axis)
+
+    mean, variance = get_profile_width(h_in, axis=axis)
+
+    h_nom = h_profile.copy()
+    h_up = h_profile.copy()
+    h_down = h_profile.copy()
+
+    # we modify the view of h_profile -> do not use h_profile anymore!
+    h_view = h_profile.view()
+
+    h_view.value = mean
+    h_nom[...] = h_view
+    h_view.value = mean + np.sqrt(variance)
+    h_up[...] = h_view
+    h_view.value = mean - np.sqrt(variance)
+    h_down[...] = h_view
+
+    return {"nominal": h_nom, "up": h_up, "down": h_down}


### PR DESCRIPTION
This task adds the possibilty to create profile plots

```
        law run cf.PlotVariables1D --version prod1 --processes st_tchannel_t \
            --variables jet1_pt-jet2_pt \
            --plot-function columnflow.plotting.plot_functions_1d.plot_profile
```
(tested with hh2bbww analysis)
![plot__proc_st_tchannel_t__cat_incl__var_jet1_pt-jet2_pt](https://github.com/columnflow/columnflow/assets/49306645/9017dede-f4a4-4125-b380-4890b22182d2)

I also fixed a minor inconsistency with plot colors when no color was set for a process