### PR TITLE
Feature/slice histograms

### DIFF
--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 
 import order as od
 
-from columnflow.util import maybe_import, try_int
+from columnflow.util import maybe_import, try_int, try_complex
 
 math = maybe_import("math")
 hist = maybe_import("hist")
@@ -120,6 +120,17 @@ def apply_variable_settings(
             for proc_inst, h in list(hists.items()):
                 rebin_factor = int(rebin_factor)
                 h = h[{var_inst.name: hist.rebin(rebin_factor)}]
+                hists[proc_inst] = h
+
+        slices = getattr(var_inst, "slice", None) or var_inst.x("slice", None)
+        if (
+            slices and isinstance(slices, Iterable) and len(slices) >= 2 and
+            try_complex(slices[0]) and try_complex(slices[1])
+        ):
+            slice_0 = int(slices[0]) if try_int(slices[0]) else complex(slices[0])
+            slice_1 = int(slices[1]) if try_int(slices[1]) else complex(slices[1])
+            for proc_inst, h in list(hists.items()):
+                h = h[{var_inst.name: slice(slice_0, slice_1)}]
                 hists[proc_inst] = h
 
     return hists

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import law
 
 from columnflow.util import try_float, try_complex, DotDict
+from columnflow.types import Iterable
 
 
 class SettingsParameter(law.CSVParameter):
@@ -32,7 +33,7 @@ class SettingsParameter(law.CSVParameter):
         pair = setting.split("=", 1)
         key, value = pair if len(pair) == 2 else (pair[0], "True")
         if ";" in value:
-            # split by semicolon and parse each value
+            # split by ";" and parse each value
             value = tuple(cls.parse_value(v) for v in value.split(";"))
         else:
             value = cls.parse_value(value)
@@ -51,7 +52,8 @@ class SettingsParameter(law.CSVParameter):
         return value
 
     @classmethod
-    def serialize_setting(cls, name: str, value: str) -> str:
+    def serialize_setting(cls, name: str, value: str | Iterable[str]) -> str:
+        value = ";".join(str(v) for v in law.util.make_tuple(value))
         return f"{name}={value}"
 
     def __init__(self, **kwargs):
@@ -114,7 +116,6 @@ class MultiSettingsParameter(law.MultiCSVParameter):
         )
         # next, merge dicts
         outputs = law.util.merge_dicts(*outputs, deep=True)
-
         return outputs
 
     def serialize(self, value):

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import law
 
-from columnflow.util import try_float, DotDict
+from columnflow.util import try_float, try_complex, DotDict
 
 
 class SettingsParameter(law.CSVParameter):
@@ -42,6 +42,8 @@ class SettingsParameter(law.CSVParameter):
     def parse_value(cls, value):
         if try_float(value):
             value = float(value)
+        elif try_complex(value):
+            value = complex(value)
         elif value.lower() == "true":
             value = True
         elif value.lower() == "false":

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -27,14 +27,16 @@ class SettingsParameter(law.CSVParameter):
         p.serialize({"param1": 2, "param2": False})
         => "param1=2,param2=False"
     """
+    settings_delimiter = "="
+    tuple_delimiter = ";"
 
     @classmethod
     def parse_setting(cls, setting: str) -> tuple[str, float | bool | str]:
-        pair = setting.split("=", 1)
+        pair = setting.split(cls.settings_delimiter, 1)
         key, value = pair if len(pair) == 2 else (pair[0], "True")
         if ";" in value:
             # split by ";" and parse each value
-            value = tuple(cls.parse_value(v) for v in value.split(";"))
+            value = tuple(cls.parse_value(v) for v in value.split(cls.tuple_delimiter))
         else:
             value = cls.parse_value(value)
         return (key, value)

--- a/columnflow/tasks/framework/parameters.py
+++ b/columnflow/tasks/framework/parameters.py
@@ -31,13 +31,22 @@ class SettingsParameter(law.CSVParameter):
     def parse_setting(cls, setting: str) -> tuple[str, float | bool | str]:
         pair = setting.split("=", 1)
         key, value = pair if len(pair) == 2 else (pair[0], "True")
+        if ";" in value:
+            # split by semicolon and parse each value
+            value = tuple(cls.parse_value(v) for v in value.split(";"))
+        else:
+            value = cls.parse_value(value)
+        return (key, value)
+
+    @classmethod
+    def parse_value(cls, value):
         if try_float(value):
             value = float(value)
         elif value.lower() == "true":
             value = True
         elif value.lower() == "false":
             value = False
-        return (key, value)
+        return value
 
     @classmethod
     def serialize_setting(cls, name: str, value: str) -> str:

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -10,7 +10,7 @@ __all__ = [
     "UNSET",
     "maybe_import", "import_plt", "import_ROOT", "import_file", "create_random_name", "expand_path",
     "real_path", "ensure_dir", "wget", "call_thread", "call_proc", "ensure_proxy", "dev_sandbox",
-    "safe_div", "try_float", "try_int", "is_pattern", "is_regex", "pattern_matcher",
+    "safe_div", "try_float", "try_complex", "try_int", "is_pattern", "is_regex", "pattern_matcher",
     "dict_add_strict", "get_source_code",
     "DotDict", "MockModule", "FunctionArgs", "ClassPropertyDescriptor", "classproperty",
     "DerivableMeta", "Derivable",
@@ -407,6 +407,17 @@ def try_float(f: Any) -> bool:
     """
     try:
         float(f)
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def try_complex(f: Any) -> bool:
+    """
+    Tests whether a value *f* can be converted to a complex number.
+    """
+    try:
+        complex(f)
         return True
     except (ValueError, TypeError):
         return False

--- a/tests/test_task_parameters.py
+++ b/tests/test_task_parameters.py
@@ -14,6 +14,11 @@ class TaskParametersTest(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
     def test_settings_parameter(self):
+        # check that the default delimiters have not been changed
+        self.assertEqual(SettingsParameter.settings_delimiter, "=")
+        self.assertEqual(SettingsParameter.tuple_delimiter, ";")
+
+        # initialize a SettingParameter
         p = SettingsParameter()
 
         # parsing
@@ -46,6 +51,7 @@ class TaskParametersTest(unittest.TestCase):
         )
 
     def test_multi_settings_parameter(self):
+        # initialize a MultiSettingsParameter
         p = MultiSettingsParameter()
 
         # parsing

--- a/tests/test_task_parameters.py
+++ b/tests/test_task_parameters.py
@@ -25,8 +25,8 @@ class TaskParametersTest(unittest.TestCase):
         )
         self.assertEqual(
             # parsing of semicolon separated values
-            p.parse("param1=1;2;3;4,param2=a;b;true;false"),
-            {"param1": (1, 2, 3, 4), "param2": ("a", "b", True, False)},
+            p.parse("param1=1;2;3j;4j,param2=a;b;true;false"),
+            {"param1": (1, 2, 3j, 4j), "param2": ("a", "b", True, False)},
         )
         self.assertEqual(
             # if a parameter is set multiple times, prioritize last one
@@ -53,9 +53,9 @@ class TaskParametersTest(unittest.TestCase):
         )
         self.assertEqual(
             # parsing of semicolon separated values
-            p.parse("obj1,k1=1;2;3;4,k2=a;b;true;false:obj2,k3=5;6;x;y"),
+            p.parse("obj1,k1=1;2;3j;4j,k2=a;b;true;false:obj2,k3=5;6;x;y"),
             {
-                "obj1": {"k1": (1, 2, 3, 4), "k2": ("a", "b", True, False)},
+                "obj1": {"k1": (1, 2, 3j, 4j), "k2": ("a", "b", True, False)},
                 "obj2": {"k3": (5, 6, "x", "y")},
             },
         )

--- a/tests/test_task_parameters.py
+++ b/tests/test_task_parameters.py
@@ -24,7 +24,7 @@ class TaskParametersTest(unittest.TestCase):
             {"param1": 10.0, "param2": True, "param3": "text", "param4": False},
         )
         self.assertEqual(
-            # parsing of semicolon separated values
+            # parsing of lists of values, separated via ";"
             p.parse("param1=1;2;3j;4j,param2=a;b;true;false"),
             {"param1": (1, 2, 3j, 4j), "param2": ("a", "b", True, False)},
         )
@@ -39,6 +39,11 @@ class TaskParametersTest(unittest.TestCase):
             p.serialize({"param1": 2, "param2": False}),
             "param1=2,param2=False",
         )
+        print(p.serialize({"param1": [1, 2j, "A", True, False]}))
+        self.assertEqual(
+            p.serialize({"param1": [1, 2j, "A", True, False]}),
+            "param1=1;2j;A;True;False",
+        )
 
     def test_multi_settings_parameter(self):
         p = MultiSettingsParameter()
@@ -52,7 +57,7 @@ class TaskParametersTest(unittest.TestCase):
             {"obj1": {"k1": 10.0, "k2": True, "k3": "text"}, "obj2": {"k4": False}},
         )
         self.assertEqual(
-            # parsing of semicolon separated values
+            # parsing of lists of values, separated via ";"
             p.parse("obj1,k1=1;2;3j;4j,k2=a;b;true;false:obj2,k3=5;6;x;y"),
             {
                 "obj1": {"k1": (1, 2, 3j, 4j), "k2": ("a", "b", True, False)},

--- a/tests/test_task_parameters.py
+++ b/tests/test_task_parameters.py
@@ -24,6 +24,11 @@ class TaskParametersTest(unittest.TestCase):
             {"param1": 10.0, "param2": True, "param3": "text", "param4": False},
         )
         self.assertEqual(
+            # parsing of semicolon separated values
+            p.parse("param1=1;2;3;4,param2=a;b;true;false"),
+            {"param1": (1, 2, 3, 4), "param2": ("a", "b", True, False)},
+        )
+        self.assertEqual(
             # if a parameter is set multiple times, prioritize last one
             p.parse("A=1,B,A=2"),
             {"B": True, "A": 2.0},
@@ -45,6 +50,14 @@ class TaskParametersTest(unittest.TestCase):
         self.assertEqual(
             p.parse("obj1,k1=10,k2,k3=text:obj2,k4=false"),
             {"obj1": {"k1": 10.0, "k2": True, "k3": "text"}, "obj2": {"k4": False}},
+        )
+        self.assertEqual(
+            # parsing of semicolon separated values
+            p.parse("obj1,k1=1;2;3;4,k2=a;b;true;false:obj2,k3=5;6;x;y"),
+            {
+                "obj1": {"k1": (1, 2, 3, 4), "k2": ("a", "b", True, False)},
+                "obj2": {"k3": (5, 6, "x", "y")},
+            },
         )
         self.assertEqual(
             # providing the same key twice results in once combined dict

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ import unittest
 
 from columnflow.util import (
     create_random_name, maybe_import, MockModule, DotDict, Derivable,
-    safe_div, try_float, try_int, is_regex, is_pattern, pattern_matcher,
+    safe_div, try_float, try_int, try_complex, is_regex, is_pattern, pattern_matcher,
 )
 
 
@@ -43,6 +43,13 @@ class UtilTest(unittest.TestCase):
             self.assertFalse(try_number("some_string"))
             self.assertFalse(try_number(1j))
             self.assertFalse(try_number([1, 2]))
+
+    def test_try_complex(self):
+        self.assertTrue(try_complex("1.2+2.5j"))
+        self.assertFalse(try_complex("some_string"))
+        self.assertFalse(try_complex([1, 2]))
+        # real numbers are also complex number
+        self.assertTrue(try_complex("5.0"))
 
     def test_is_regex(self):
         self.assertTrue(is_regex(r"^foo\d+.*$"))


### PR DESCRIPTION
This PR adds the `slices` variable setting that allows slicing a histogram during Plotting. Example:

Exemplary task call from hh2bbww analysis:
```
law run cf.PlotVariables1D --variable-settings "jet1_pt,slice=5;15" --version prod1 --variables jet1_pt  --processes ggHH_kl_1_kt_1_dl_hbbhww --remove-output 0,a,y
```
This selects all bins from bin 5 to bin 15. You could also select bins from some x_min to x_max range by passing e.g. `--variable-settings "jet1_pt,slice=50j;200j"`

![plot__proc_ggHH_kl_1_kt_1_dl_hbbhww__cat_incl__var_jet1_pt](https://github.com/columnflow/columnflow/assets/49306645/39b37652-b177-4be0-babc-a4a743494053)

This only slices the histogram itself but does not modify the x_min and x_max range of the plot since they are taken from the variable inst, but this can be modified via `--variable-settings "jet1_pt,x_min=50,x_max=200"`. Already having this functionality makes this PR a bit pointless, but it also adds some functionality to the SettingsParameters and slicing might become useful for other use cases.

Closes #374 