### PR TITLE
Make `categorizer_map` regular `dict` to prevent silent `KeyErrors`.

### DIFF
--- a/columnflow/production/categories.py
+++ b/columnflow/production/categories.py
@@ -89,3 +89,6 @@ def category_ids_init(self: Producer) -> None:
             self.produces.add(categorizer)
 
             self.categorizer_map[cat_inst].append(categorizer)
+
+    # cast to normal dict to prevent silent failures on KeyError
+    self.categorizer_map = dict(self.categorizer_map)


### PR DESCRIPTION
This PR addresses an issue encountered in an analysis using dynamically defined categories.

Instead of the usual definition in the `init` method of a `TaskArrayFunction`, the categories were added dynamically in the `__call__` method just before the `category_ids` producer was called. Since the category instances were not present in the config at initialization time, the corresponding entries in the `category_ids.categorizer_map` were missing. This in turn should have caused a `KeyError` while looking up the categorizers for the dynamically added categories during `category_ids.__call__`, but this was suppressed since the `categorizer_map` was defined as a `defaultdict`, leading to the dynamically added categories being assigned the default (all-true) map and thus matching every event.

The above scenario is now prevented by making `categorizer_map` a regular `dict`, triggering a `KeyError` as expected.