### PR TITLE
updating datacard labels

### DIFF
--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -137,7 +137,7 @@ class CreateDatacards(
 
     def output(self):
         cat_obj = self.branch_data
-        basename = lambda name, ext: f"{name}__cat_{cat_obj.config_category}__var_{cat_obj.config_variable}.{ext}"
+        basename = lambda name, ext: f"{name}__cat_{cat_obj.name}__var_{cat_obj.config_variable}.{ext}"
 
         return {
             "card": self.target(basename("datacard", "txt")),


### PR DESCRIPTION
the config_category is not necessarily unique; so using the category name is better such that we can create datacards with different names