### PR TITLE
multiply cferr columns with nominal btag weight

### DIFF
--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -191,6 +191,14 @@ def btag_weights(
                     direction,
                     f"btag_weight_{name}_{direction}",
                 )
+                if syst_name in ["cferr1", "cferr2"]:
+                    # for c flavor uncertainties, multiply the uncertainty with the nominal btag weight
+                    events = set_ak_column(
+                        events,
+                        f"btag_weight_{name}_{direction}",
+                        events.btag_weight * events[f"btag_weight_{name}_{direction}"],
+                        value_type=np.float32,
+                    )
     elif self.shift_is_known_jec_source:
         # TODO: year dependent jec variations fully covered?
         events = add_weight(


### PR DESCRIPTION
For the `cferr` btag uncertainties, we only multiplied the SFs of all jets with flavor == 4.
Instead, we need to multiply the SFs of all jets with flavor == 4 with the nominal SFs we got from jets with flavor != 4.

This gets is especially clear when looking at events without any jets with flavor == 4. Previous to this fix, these events get assigned some btag_weight != 1, while the cferr variations are assigned a weight of 1.