### PR TITLE
customize muon_weights output column names

### DIFF
--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -18,15 +18,14 @@ ak = maybe_import("awkward")
     uses={
         "Muon.pt", "Muon.eta",
     },
-    produces={
-        "muon_weight", "muon_weight_up", "muon_weight_down",
-    },
+    # produces in the init
     # only run on mc
     mc_only=True,
     # function to determine the correction file
     get_muon_file=(lambda self, external_files: external_files.muon_sf),
     # function to determine the muon weight config
     get_muon_config=(lambda self: self.config_inst.x.muon_sf_names),
+    weight_name=(lambda self: "muon_weight"),
 )
 def muon_weights(
     self: Producer,
@@ -83,7 +82,6 @@ def muon_weights(
             "ValType": syst,  # syst key in 2017
         }
         inputs = [variable_map_syst[inp.name] for inp in self.muon_sf_corrector.inputs]
-
         sf_flat = self.muon_sf_corrector(*inputs)
 
         # add the correct layout to it
@@ -93,7 +91,7 @@ def muon_weights(
         weight = ak.prod(sf, axis=1, mask_identity=False)
 
         # store it
-        events = set_ak_column(events, f"muon_weight{postfix}", weight, value_type=np.float32)
+        events = set_ak_column(events, f"{self.weight_name()}{postfix}", weight, value_type=np.float32)
 
     return events
 
@@ -128,3 +126,9 @@ def muon_weights_setup(
     # check versions
     if self.muon_sf_corrector.version not in (1,):
         raise Exception(f"unsuppprted muon sf corrector version {self.muon_sf_corrector.version}")
+
+
+@muon_weights.init
+def muon_weights_init(self: Producer, **kwargs) -> None:
+    weight_name = self.weight_name()
+    self.produces |= {weight_name, f"{weight_name}_up", f"{weight_name}_down"}

--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -25,7 +25,7 @@ ak = maybe_import("awkward")
     get_muon_file=(lambda self, external_files: external_files.muon_sf),
     # function to determine the muon weight config
     get_muon_config=(lambda self: self.config_inst.x.muon_sf_names),
-    weight_name=(lambda self: "muon_weight"),
+    weight_name="muon_weight",
     supported_versions=(1, 2),
 )
 def muon_weights(
@@ -92,7 +92,7 @@ def muon_weights(
         weight = ak.prod(sf, axis=1, mask_identity=False)
 
         # store it
-        events = set_ak_column(events, f"{self.weight_name()}{postfix}", weight, value_type=np.float32)
+        events = set_ak_column(events, f"{self.weight_name}{postfix}", weight, value_type=np.float32)
 
     return events
 
@@ -131,5 +131,5 @@ def muon_weights_setup(
 
 @muon_weights.init
 def muon_weights_init(self: Producer, **kwargs) -> None:
-    weight_name = self.weight_name()
+    weight_name = self.weight_name
     self.produces |= {weight_name, f"{weight_name}_up", f"{weight_name}_down"}

--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -26,6 +26,7 @@ ak = maybe_import("awkward")
     # function to determine the muon weight config
     get_muon_config=(lambda self: self.config_inst.x.muon_sf_names),
     weight_name=(lambda self: "muon_weight"),
+    supported_versions=(1, 2),
 )
 def muon_weights(
     self: Producer,
@@ -124,7 +125,7 @@ def muon_weights_setup(
     self.muon_sf_corrector = correction_set[corrector_name]
 
     # check versions
-    if self.muon_sf_corrector.version not in (1,):
+    if self.supported_versions and self.muon_sf_corrector.version not in self.supported_versions:
         raise Exception(f"unsuppprted muon sf corrector version {self.muon_sf_corrector.version}")
 
 


### PR DESCRIPTION
This PR allows users to produce different types of muon weights by allowing to customize the output column names.

Examples:

```python
muon_id_weights = muon_weights.derive("muon_id_weights", cls_dict={
    "weight_name": lambda self: "muon_id_weight",
    "get_muon_config": (lambda self: self.config_inst.x.muon_iso_sf_names)
})
muon_iso_weights = muon_weights.derive("muon_iso_weights", cls_dict={
    "weight_name": lambda self: "muon_iso_weight",
    "get_muon_config": (lambda self: self.config_inst.x.muon_id_sf_names)
})
muon_trigger_weights = muon_weights.derive("muon_trigger_weights", cls_dict={
    "weight_name": lambda self: "muon_trigger_weight",
    "get_muon_config": (lambda self: self.config_inst.x.muon_trigger_sf_names)
})
```

We could also provide a Producer (in a separate PR) that combines the iso and id weights into a single weight column, e.g.

```python
@producer(
    uses={muon_id_weights, muon_iso_weights},
    produces={
        "muon_weight",
        "muon_weight_id_up", "muon_weight_id_down",
        "muon_weight_iso_up", "muon_weight_iso_down",
        "muon_weight_id_up_iso_up", "muon_weight_id_down_iso_down"
    },
    mc_only=True,
)
def muon_id_iso_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
    """
    Producer that calculates the muon id and iso weights.
    """
    # run muon id and iso weights
    events = self[muon_id_weights](events, **kwargs)
    events = self[muon_iso_weights](events, **kwargs)

    # calculate the full muon weight with id and iso variations
    events = set_ak_column_f32(events, "muon_weight", events.muon_id_weight * events.muon_iso_weight)
    events = set_ak_column_f32(events, "muon_weight_id_up", events.muon_id_weight_up * events.muon_iso_weight)
    events = set_ak_column_f32(events, "muon_weight_id_down", events.muon_id_weight_down * events.muon_iso_weight)
    events = set_ak_column_f32(events, "muon_weight_iso_up", events.muon_id_weight * events.muon_iso_weight_up)
    events = set_ak_column_f32(events, "muon_weight_iso_down", events.muon_id_weight * events.muon_iso_weight_down)
    events = set_ak_column_f32(events, "muon_weight_id_up_iso_up", events.muon_id_weight_up * events.muon_iso_weight_up)
    events = set_ak_column_f32(
        events,
        "muon_weight_id_down_iso_down",
        events.muon_id_weight_down * events.muon_iso_weight_down,
    )

    return events
```

In that way, we could use a single weight column to vary the muon id and iso either separately or as a combined nuisance. To combine id and iso, we might need to build an envelope of all possible id/iso variations, similarly to the [scale](https://github.com/columnflow/columnflow/blob/master/columnflow/production/cms/scale.py) Producer.