### PR TITLE
add ml_model_settings parameter

### DIFF
--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -152,6 +152,13 @@ class MLModel(Derivable):
         if "configs" in kwargs:
             self._setup(kwargs["configs"])
 
+    def __str__(self):
+        """
+        Returns a string representation of this model instance. The string is composed of the class
+        name and the string representation of all parameters.
+        """
+        return f"{self.cls_name}__{self.parameters_repr}"
+
     @property
     def config_inst(self: MLModel) -> od.Config:
         if self.single_config and len(self.config_insts) != 1:
@@ -184,6 +191,24 @@ class MLModel(Derivable):
 
         # any other case
         return str(value)
+
+    @property
+    def parameters_repr(self: MLModel) -> str:
+        """
+        Returns a hash of string representation of all parameters. This is used to uniquely identify
+        a model instance based on its parameters.
+
+        :raises: Exception in case the parameters_repr changed after it was set.
+        :returns: String representation of all parameters.
+        """
+        parameters_repr = law.util.create_hash(self._join_parameter_pairs(only_significant=True))
+        if hasattr(self, "_parameters_repr") and self._parameters_repr != parameters_repr:
+            raise Exception(
+                f"parameters_repr changed from {self._parameters_repr} to {parameters_repr};"
+                "this should not happen",
+            )
+        self._parameters_repr = parameters_repr
+        return self._parameters_repr
 
     def _join_parameter_pairs(self: MLModel, only_significant: bool = True) -> str:
         """

--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -157,7 +157,10 @@ class MLModel(Derivable):
         Returns a string representation of this model instance. The string is composed of the class
         name and the string representation of all parameters.
         """
-        return f"{self.cls_name}__{self.parameters_repr}"
+        model_str = f"{self.cls_name}"
+        if self.parameters_repr:
+            model_str += f"__{self.parameters_repr}"
+        return model_str
 
     @property
     def config_inst(self: MLModel) -> od.Config:
@@ -201,6 +204,8 @@ class MLModel(Derivable):
         :raises: Exception in case the parameters_repr changed after it was set.
         :returns: String representation of all parameters.
         """
+        if not self.parameters:
+            return ""
         parameters_repr = law.util.create_hash(self._join_parameter_pairs(only_significant=True))
         if hasattr(self, "_parameters_repr") and self._parameters_repr != parameters_repr:
             raise Exception(

--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -228,11 +228,11 @@ class MLModel(Derivable):
 
     def parameter_pairs(self: MLModel, only_significant: bool = False) -> list[tuple[str, Any]]:
         """
-        Returns a list of all parameter name-value tuples. In this context, significant parameters
+        Returns a sorted list of all parameter name-value tuples. In this context, significant parameters
         are those that potentially lead to different results (e.g. network architecture parameters
         as opposed to some log level).
         """
-        return list(self.parameters.items())
+        return sorted(self.parameters.items())
 
     @property
     def accepts_scheduler_messages(self: MLModel) -> bool:

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1070,20 +1070,8 @@ class MLModelMixinBase(AnalysisTask):
 
     @property
     def ml_model_repr(self):
-        """Returns a string representation of the ML model and it's settings."""
-        if hasattr(self, "_ml_model_repr"):
-            # if existing, return the cached value
-            return self._ml_model_repr
-
-        repr = self.ml_model_inst.cls_name
-
-        if hasattr(self.ml_model_inst, "parameters_repr"):
-            # if existing, return the parameters_repr of the ml_model_inst
-            repr += f"__{self.ml_model_inst.parameters_repr}"
-
-        # cache the value and return it
-        self._ml_model_repr = repr
-        return self._ml_model_repr
+        """Returns a string representation of the ML model instance."""
+        return str(self.ml_model_inst)
 
     @classmethod
     def req_params(cls, inst: law.Task, **kwargs) -> dict[str, Any]:
@@ -1600,6 +1588,12 @@ class MLModelsMixin(ConfigTask):
 
     exclude_params_repr_empty = {"ml_models"}
 
+    @property
+    def ml_models_repr(self):
+        """Returns a string representation of the ML models."""
+        ml_models_repr = "__".join([str(model_inst) for model_inst in self.ml_model_insts])
+        return ml_models_repr
+
     @classmethod
     def resolve_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
         params = super().resolve_param_values(params)
@@ -1655,8 +1649,7 @@ class MLModelsMixin(ConfigTask):
         parts = super().store_parts()
 
         if self.ml_model_insts:
-            part = "__".join(model_inst.cls_name for model_inst in self.ml_model_insts)
-            parts.insert_before("version", "ml_models", f"ml__{part}")
+            parts.insert_before("version", "ml_models", f"ml__{self.ml_models_repr}")
 
         return parts
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1403,7 +1403,11 @@ class MLModelTrainingMixin(MLModelMixinBase):
             analysis_inst = params["analysis_inst"]
 
             # NOTE: we could try to implement resolving the default ml_model here
-            ml_model_inst = cls.get_ml_model_inst(params["ml_model"], analysis_inst, **params["ml_model_settings"])
+            ml_model_inst = cls.get_ml_model_inst(
+                params["ml_model"],
+                analysis_inst,
+                parameters=params["ml_model_settings"],
+            )
             params["ml_model_inst"] = ml_model_inst
 
             # resolve configs
@@ -1437,7 +1441,7 @@ class MLModelTrainingMixin(MLModelMixinBase):
             self.ml_model,
             self.analysis_inst,
             configs=list(self.configs),
-            **self.ml_model_settings,
+            parameters=self.ml_model_settings,
         )
 
     def store_parts(self) -> law.util.InsertableDict[str, str]:
@@ -1531,6 +1535,7 @@ class MLModelMixin(ConfigTask, MLModelMixinBase):
                     params["ml_model"],
                     analysis_inst,
                     requested_configs=[config_inst],
+                    parameters=params["ml_model_settings"],
                 )
             elif not cls.allow_empty_ml_model:
                 raise Exception(f"no ml_model configured for {cls.task_family}")
@@ -1547,6 +1552,7 @@ class MLModelMixin(ConfigTask, MLModelMixinBase):
                 self.ml_model,
                 self.analysis_inst,
                 requested_configs=[self.config_inst],
+                parameters=self.ml_model_settings,
             )
 
     def store_parts(self) -> law.util.InsertableDict:


### PR DESCRIPTION
This PR adds the 'ml_model_settings' parameter that writes key-value pairs directly into the `self.parameters` attribute.

Example:
```python
class MyModel(MLModel):
    def __init__(
        self,
        *args,
        **kwargs,
    ):
        # we cannot cast to dict on command line, but one can do this by hand
        ml_process_weights = self.parameters.get("ml_process_weights", {"st": 1, "tt": 2})
        if isinstance(ml_process_weight, tuple):
            ml_process_weights = {proc: int(weight) for proc, weight in [s.split(":") for s in ml_process_weights]}

        # store parameters of interest in the ml_model_inst, e.g. via the parameters attribute
        self.parameters = {
            "batchsize": int(self.parameters.get("batchsize", 1024)),
            "layers": tuple(int(layer) for layer in self.parameters.get("layers, (64, 64, 64)),
            "ml_process_weights": ml_process_weights
        }

        # create representation of ml_model_inst
        self.parameters_repr = law.util.create_hash(sorted(self.parameters.items()))

```

These parameters can then be changed on command line
```
law run cf.MLTraining --version v1 --ml-model MyModel --ml-model-settings "batchsize=2048,layers=32;32;32,ml_process_weights=st:1;tt:4"
```

Open questions:

1.) At the moment, the `ml_model_settings` is not implemented for the `MLModelsMixin`, therefore we can only use the "default" model (or create new model via `derive`) when e.g. creating histograms. We could add a `ml_models_settings` parameter to this mixin, but I'm not sure if this would be used much.
2.) Since the output of the model is now hashed, we might want to also automatically produce an output of the parameters or the `parameters_repr` such that ml trainings can always be reproduced if necessary.
