### PR TITLE
Trigger skip function creation in derived CSP subclasses.

### DIFF
--- a/columnflow/calibration/__init__.py
+++ b/columnflow/calibration/__init__.py
@@ -60,20 +60,16 @@ class Calibrator(TaskArrayFunction):
             skipping all other shifts.
         :return: New :py:class:`Calibrator` subclass.
         """
-        # prepare shifts_only
-        if shifts_only:
-            shifts_only = set(expand_shift_sources(shifts_only))
-
         def decorator(func: Callable) -> DerivableMeta:
             # create the class dict
             cls_dict = {
+                **kwargs,
                 "call_func": func,
                 "mc_only": mc_only,
                 "data_only": data_only,
                 "nominal_only": nominal_only,
                 "shifts_only": shifts_only,
             }
-            cls_dict.update(kwargs)
 
             # get the module name
             frame = inspect.stack()[1]
@@ -82,37 +78,67 @@ class Calibrator(TaskArrayFunction):
             # get the calibrator name
             cls_name = cls_dict.pop("cls_name", func.__name__)
 
-            # optionally add skip function
-            if mc_only and data_only:
-                raise Exception(f"calibrator {cls_name} received both mc_only and data_only")
-            if nominal_only and shifts_only:
-                raise Exception(f"calibrator {cls_name} received both nominal_only and shifts_only")
-            if mc_only or data_only or nominal_only or shifts_only:
-                if cls_dict.get("skip_func"):
+            # hook to update the class dict during class derivation
+            def update_cls_dict(cls_name, cls_dict, get_base_attr):
+                # helper to get in attr from either the cls_dict or a base class
+                def get_attr(attr):
+                    no_value = object()
+                    if attr in cls_dict:
+                        return cls_dict[attr]
+                    value = get_base_attr(attr, no_value)
+                    if value == no_value:
+                        raise AttributeError(f"attribute {attr} not found in {cls_name}")
+                    return value
+
+                mc_only = get_attr("mc_only")
+                data_only = get_attr("data_only")
+                nominal_only = get_attr("nominal_only")
+                shifts_only = get_attr("shifts_only")
+
+                # prepare shifts_only
+                if shifts_only:
+                    shifts_only_expanded = set(expand_shift_sources(shifts_only))
+                    if shifts_only_expanded != shifts_only:
+                        shifts_only = shifts_only_expanded
+                        cls_dict["shifts_only"] = shifts_only
+
+                # optionally add skip function
+                if mc_only and data_only:
+                    raise Exception(f"calibrator {cls_name} received both mc_only and data_only")
+                if nominal_only and shifts_only:
                     raise Exception(
-                        f"calibrator {cls_name} received custom skip_func, but either mc_only, "
-                        "data_only, nominal_only or shifts_only are set",
+                        f"calibrator {cls_name} received both nominal_only and shifts_only",
                     )
+                if mc_only or data_only or nominal_only or shifts_only:
+                    if cls_dict.get("skip_func"):
+                        raise Exception(
+                            f"calibrator {cls_name} received custom skip_func, but either mc_only, "
+                            "data_only, nominal_only or shifts_only are set",
+                        )
 
-                def skip_func(self):
-                    # check mc_only and data_only
-                    if getattr(self, "dataset_inst", None):
-                        if mc_only and not self.dataset_inst.is_mc:
-                            return True
-                        if data_only and not self.dataset_inst.is_data:
-                            return True
+                    def skip_func(self):
+                        # check mc_only and data_only
+                        if getattr(self, "dataset_inst", None):
+                            if mc_only and not self.dataset_inst.is_mc:
+                                return True
+                            if data_only and not self.dataset_inst.is_data:
+                                return True
 
-                    # check nominal_only and shifts_only
-                    if getattr(self, "global_shift_inst", None):
-                        if nominal_only and not self.global_shift_inst.is_nominal:
-                            return True
-                        if shifts_only and self.global_shift_inst.name not in shifts_only:
-                            return True
+                        # check nominal_only and shifts_only
+                        if getattr(self, "global_shift_inst", None):
+                            if nominal_only and not self.global_shift_inst.is_nominal:
+                                return True
+                            if shifts_only and self.global_shift_inst.name not in shifts_only:
+                                return True
 
-                    # in all other cases, do not skip
-                    return False
+                        # in all other cases, do not skip
+                        return False
 
-                cls_dict["skip_func"] = skip_func
+                    cls_dict["skip_func"] = skip_func
+
+                return cls_dict
+
+            cls_dict["update_cls_dict"] = update_cls_dict
 
             # create the subclass
             subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)

--- a/columnflow/production/__init__.py
+++ b/columnflow/production/__init__.py
@@ -60,20 +60,16 @@ class Producer(TaskArrayFunction):
             all other shifts.
         :return: New :py:class:`Producer` subclass.
         """
-        # prepare shifts_only
-        if shifts_only:
-            shifts_only = set(expand_shift_sources(shifts_only))
-
         def decorator(func: Callable) -> DerivableMeta:
             # create the class dict
             cls_dict = {
+                **kwargs,
                 "call_func": func,
                 "mc_only": mc_only,
                 "data_only": data_only,
                 "nominal_only": nominal_only,
                 "shifts_only": shifts_only,
             }
-            cls_dict.update(kwargs)
 
             # get the module name
             frame = inspect.stack()[1]
@@ -82,37 +78,67 @@ class Producer(TaskArrayFunction):
             # get the producer name
             cls_name = cls_dict.pop("cls_name", func.__name__)
 
-            # optionally add skip function
-            if mc_only and data_only:
-                raise Exception(f"producer {cls_name} received both mc_only and data_only")
-            if nominal_only and shifts_only:
-                raise Exception(f"producer {cls_name} received both nominal_only and shifts_only")
-            if mc_only or data_only or nominal_only or shifts_only:
-                if cls_dict.get("skip_func"):
+            # hook to update the class dict during class derivation
+            def update_cls_dict(cls_name, cls_dict, get_base_attr):
+                # helper to get in attr from either the cls_dict or a base class
+                def get_attr(attr):
+                    no_value = object()
+                    if attr in cls_dict:
+                        return cls_dict[attr]
+                    value = get_base_attr(attr, no_value)
+                    if value == no_value:
+                        raise AttributeError(f"attribute {attr} not found in {cls_name}")
+                    return value
+
+                mc_only = get_attr("mc_only")
+                data_only = get_attr("data_only")
+                nominal_only = get_attr("nominal_only")
+                shifts_only = get_attr("shifts_only")
+
+                # prepare shifts_only
+                if shifts_only:
+                    shifts_only_expanded = set(expand_shift_sources(shifts_only))
+                    if shifts_only_expanded != shifts_only:
+                        shifts_only = shifts_only_expanded
+                        cls_dict["shifts_only"] = shifts_only
+
+                # optionally add skip function
+                if mc_only and data_only:
+                    raise Exception(f"producer {cls_name} received both mc_only and data_only")
+                if nominal_only and shifts_only:
                     raise Exception(
-                        f"producer {cls_name} received custom skip_func, but either mc_only, "
-                        "data_only, nominal_only or shifts_only are set",
+                        f"producer {cls_name} received both nominal_only and shifts_only",
                     )
+                if mc_only or data_only or nominal_only or shifts_only:
+                    if cls_dict.get("skip_func"):
+                        raise Exception(
+                            f"producer {cls_name} received custom skip_func, but either mc_only, "
+                            "data_only, nominal_only or shifts_only are set",
+                        )
 
-                def skip_func(self):
-                    # check mc_only and data_only
-                    if getattr(self, "dataset_inst", None):
-                        if mc_only and not self.dataset_inst.is_mc:
-                            return True
-                        if data_only and not self.dataset_inst.is_data:
-                            return True
+                    def skip_func(self):
+                        # check mc_only and data_only
+                        if getattr(self, "dataset_inst", None):
+                            if mc_only and not self.dataset_inst.is_mc:
+                                return True
+                            if data_only and not self.dataset_inst.is_data:
+                                return True
 
-                    # check nominal_only and shifts_only
-                    if getattr(self, "global_shift_inst", None):
-                        if nominal_only and not self.global_shift_inst.is_nominal:
-                            return True
-                        if shifts_only and self.global_shift_inst.name not in shifts_only:
-                            return True
+                        # check nominal_only and shifts_only
+                        if getattr(self, "global_shift_inst", None):
+                            if nominal_only and not self.global_shift_inst.is_nominal:
+                                return True
+                            if shifts_only and self.global_shift_inst.name not in shifts_only:
+                                return True
 
-                    # in all other cases, do not skip
-                    return False
+                        # in all other cases, do not skip
+                        return False
 
-                cls_dict["skip_func"] = skip_func
+                    cls_dict["skip_func"] = skip_func
+
+                return cls_dict
+
+            cls_dict["update_cls_dict"] = update_cls_dict
 
             # create the subclass
             subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -74,20 +74,16 @@ class Selector(TaskArrayFunction):
             skipping all other shifts.
         :return: New :py:class:`Selector` subclass.
         """
-        # prepare shifts_only
-        if shifts_only:
-            shifts_only = set(expand_shift_sources(shifts_only))
-
         def decorator(func: Callable) -> DerivableMeta:
             # create the class dict
             cls_dict = {
+                **kwargs,
                 "call_func": func,
                 "mc_only": mc_only,
                 "data_only": data_only,
                 "nominal_only": nominal_only,
                 "shifts_only": shifts_only,
             }
-            cls_dict.update(kwargs)
 
             # get the module name
             frame = inspect.stack()[1]
@@ -96,37 +92,67 @@ class Selector(TaskArrayFunction):
             # get the selector name
             cls_name = cls_dict.pop("cls_name", func.__name__)
 
-            # optionally add skip function
-            if mc_only and data_only:
-                raise Exception(f"selector {cls_name} received both mc_only and data_only")
-            if nominal_only and shifts_only:
-                raise Exception(f"selector {cls_name} received both nominal_only and shifts_only")
-            if mc_only or data_only or nominal_only or shifts_only:
-                if cls_dict.get("skip_func"):
+            # hook to update the class dict during class derivation
+            def update_cls_dict(cls_name, cls_dict, get_base_attr):
+                # helper to get in attr from either the cls_dict or a base class
+                def get_attr(attr):
+                    no_value = object()
+                    if attr in cls_dict:
+                        return cls_dict[attr]
+                    value = get_base_attr(attr, no_value)
+                    if value == no_value:
+                        raise AttributeError(f"attribute {attr} not found in {cls_name}")
+                    return value
+
+                mc_only = get_attr("mc_only")
+                data_only = get_attr("data_only")
+                nominal_only = get_attr("nominal_only")
+                shifts_only = get_attr("shifts_only")
+
+                # prepare shifts_only
+                if shifts_only:
+                    shifts_only_expanded = set(expand_shift_sources(shifts_only))
+                    if shifts_only_expanded != shifts_only:
+                        shifts_only = shifts_only_expanded
+                        cls_dict["shifts_only"] = shifts_only
+
+                # optionally add skip function
+                if mc_only and data_only:
+                    raise Exception(f"selector {cls_name} received both mc_only and data_only")
+                if nominal_only and shifts_only:
                     raise Exception(
-                        f"selector {cls_name} received custom skip_func, but either mc_only, "
-                        "data_only, nominal_only or shifts_only are set",
+                        f"selector {cls_name} received both nominal_only and shifts_only",
                     )
+                if mc_only or data_only or nominal_only or shifts_only:
+                    if cls_dict.get("skip_func"):
+                        raise Exception(
+                            f"selector {cls_name} received custom skip_func, but either mc_only, "
+                            "data_only, nominal_only or shifts_only are set",
+                        )
 
-                def skip_func(self):
-                    # check mc_only and data_only
-                    if getattr(self, "dataset_inst", None):
-                        if mc_only and not self.dataset_inst.is_mc:
-                            return True
-                        if data_only and not self.dataset_inst.is_data:
-                            return True
+                    def skip_func(self):
+                        # check mc_only and data_only
+                        if getattr(self, "dataset_inst", None):
+                            if mc_only and not self.dataset_inst.is_mc:
+                                return True
+                            if data_only and not self.dataset_inst.is_data:
+                                return True
 
-                    # check nominal_only and shifts_only
-                    if getattr(self, "global_shift_inst", None):
-                        if nominal_only and not self.global_shift_inst.is_nominal:
-                            return True
-                        if shifts_only and self.global_shift_inst.name not in shifts_only:
-                            return True
+                        # check nominal_only and shifts_only
+                        if getattr(self, "global_shift_inst", None):
+                            if nominal_only and not self.global_shift_inst.is_nominal:
+                                return True
+                            if shifts_only and self.global_shift_inst.name not in shifts_only:
+                                return True
 
-                    # in all other cases, do not skip
-                    return False
+                        # in all other cases, do not skip
+                        return False
 
-                cls_dict["skip_func"] = skip_func
+                    cls_dict["skip_func"] = skip_func
+
+                return cls_dict
+
+            cls_dict["update_cls_dict"] = update_cls_dict
 
             # create the subclass
             subclass = cls.derive(cls_name, bases=bases, cls_dict=cls_dict, module=module)

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -710,6 +710,24 @@ class DerivableMeta(abc.ABCMeta):
         cls_dict = cls_dict.copy()
         cls_dict["_subclasses"] = {}
 
+        # helper to find an attribute among the bases
+        def get_base_attr(attr, default=None):
+            no_value = object()
+            for base in bases:
+                value = getattr(base, attr, no_value)
+                if value != no_value:
+                    return value
+            return default
+
+        # trigger the hook that updates the cls_dict
+        update_cls_dict = cls_dict.get("update_cls_dict")
+        if update_cls_dict is None:
+            update_cls_dict = get_base_attr("update_cls_dict")
+        else:
+            cls_dict["update_cls_dict"] = staticmethod(update_cls_dict)
+        if update_cls_dict is not None:
+            update_cls_dict(cls_name, cls_dict, get_base_attr)
+
         # create the class
         cls = super().__new__(metacls, cls_name, bases, cls_dict)
 
@@ -719,7 +737,6 @@ class DerivableMeta(abc.ABCMeta):
         # save the class in the class cache of all subclassable base classes
         for base in bases:
             if isinstance(base, metacls):
-                # TODO: is it safe to overwrite here? probably yes
                 base._subclasses[cls_name] = cls
 
         return cls
@@ -786,8 +803,8 @@ class DerivableMeta(abc.ABCMeta):
         cls,
         cls_name: str,
         bases: tuple = (),
-        cls_dict: Union[dict, None] = None,
-        module: Union[str, None] = None,
+        cls_dict: dict[str, Any] | None = None,
+        module: str | None = None,
     ) -> DerivableMeta:
         """Creates a subclass named *cls_name* inheriting from *this* class an
         additional, optional *bases*.


### PR DESCRIPTION
This PR includes an urgent fix of how attributes of calibrator / selector / producer (CSP) subclasses are created and inherited.

When subclassed through decorators (e.g. `@producer`), newly created classes are attached additional, dynamic attributes such as `skip_func`. However, when created through `sub_cls = parent_cls.derive(...)` and plain `class sub_cls(parent_cls)`, the subclass will not have these attributes.

This PR adjust the behavior of their meta class to call a hook `update_cls_dict` before the actual class creation. It is thereafter attached to the newly created class as a `staticmethod` which in turn passes it downstream for the proper mro lookup.