### PR TITLE
Option to remove reduced events after merging.

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -38,6 +38,10 @@ cf_task_namespace: cf
 # default sandbox for main tasks with standard packages for columnar processing
 default_columnar_sandbox: bash::$CF_BASE/sandboxes/venv_columnar.sh
 
+# whether MergeReducedEvents should keep its inputs from ReduceEvents by default
+# (otherwise they are removed after merging)
+default_keep_reduced_events: True
+
 # wether or not the ensure_proxy decorator should be skipped, even if used by task's run methods
 skip_ensure_proxy: False
 

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -464,8 +464,8 @@ class MergeReducedEvents(
             self, inputs, output["events"], writer_opts=self.get_parquet_writer_opts(),
         )
 
-        # optionally remove inputs
-        if not self.keep_reduced_events:
+        # optionally remove initial inputs
+        if not self.keep_reduced_events and self.is_leaf():
             with self.publish_step("removing reduced inputs ..."):
                 for inp in inputs:
                     inp.remove()

--- a/law.cfg
+++ b/law.cfg
@@ -35,6 +35,10 @@ cf_task_namespace: cf
 # default sandbox for main tasks with standard packages for columnar processing
 default_columnar_sandbox: bash::$CF_BASE/sandboxes/venv_columnar.sh
 
+# whether MergeReducedEvents should keep its inputs from ReduceEvents by default
+# (otherwise they are removed after merging)
+default_keep_reduced_events: True
+
 # wether or not the ensure_proxy decorator should be skipped, even if used by task's run methods
 skip_ensure_proxy: False
 


### PR DESCRIPTION
When merging reduced events, the output of `cf.MergeReducedEvents` contains the exact same event content as its input `cf.ReduceEvents`, though - obviously - merging into fewer files. Since this effectively doubles the file size, it should be possible to remove the outputs of `cf.ReduceEvents` right away after merging.

This PR adds an option `--keep-reduced-events` to `cf.MergeReducedEvents`. Its default can be controlled through the `law.cfg` and is set to `True` there, but can be changed by analyses.