### PR TITLE
Refactor pinning of output versions and locations.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -256,13 +256,9 @@ cfg.x.keep_columns = DotDict.wrap({
     },
 })
 
-# versions per task family, either referring to strings or to callables receving the invoking
-# task instance and parameters to be passed to the task family
-cfg.x.versions = {
-    # "cf.CalibrateEvents": "prod1",
-    # "cf.SelectEvents": (lambda cls, inst, params: "prod1" if params.get("selector") == "default" else "dev1"),
-    # ...
-}
+# pinned versions
+# (see [versions] in law.cfg for more info)
+cfg.x.versions = {}
 
 # channels
 # (just one for now)

--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -29,6 +29,7 @@ calibration_modules: columnflow.calibration.cms.{jets,met}, __cf_module_name__.c
 selection_modules: columnflow.selection.{empty}, columnflow.selection.cms.{json_filter, met_filters}, __cf_module_name__.selection.example
 production_modules: columnflow.production.{categories,normalization,processes}, columnflow.production.cms.{btag,electron,mc_weight,muon,pdf,pileup,scale,seeds}, __cf_module_name__.production.example
 categorization_modules: __cf_module_name__.categorization.example
+weight_production_modules: columnflow.weight.{empty,all_weights}, __cf_module_name__.weight.example
 ml_modules: columnflow.ml, __cf_module_name__.ml.example
 inference_modules: columnflow.inference, __cf_module_name__.inference.example
 
@@ -74,12 +75,31 @@ wlcg_file_systems: wlcg_fs, wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 
 # output locations per task family
+# the key can consist of multple underscore-separated parts, that can each be patterns or regexes
+# these parts are used for the lookup from within tasks and can contain (e.g.) the analysis name,
+# the config name, the task family, the dataset name, or the shift name
+# (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
+# values can have the following format:
 # for local targets : "local[, LOCAL_FS_NAME or STORE_PATH]"
 # for remote targets: "wlcg[, WLCG_FS_NAME]"
 # (when WLCG_FS_NAME is empty, the tasks' "default_wlcg_fs" attribute is used)
-# examples:
-# cf.CalibrateEvents: wlcg
-# cf.SelectEvents: local
+# example:
+; run3_2023__cf.CalibrateEvents__nomin*: local
+; cf.CalibrateEvents: wlcg
+
+
+[versions]
+
+# default versions of specific tasks to pin
+# the key can consist of multple underscore-separated parts, that can each be patterns or regexes
+# these parts are used for the lookup from within tasks and can contain (e.g.) the analysis name,
+# the config name, the task family, the dataset name, or the shift name
+# (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
+# note:
+# this lookup is skipped if the lookup based on the config instance's auxiliary data succeeded
+# example:
+; run3_2023__cf.CalibrateEvents__nomin*: prod1
+; cf.CalibrateEvents: prod2
 
 
 [job]

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -12,6 +12,8 @@ import importlib
 import itertools
 import inspect
 import functools
+import collections
+import copy
 
 import luigi
 import law
@@ -19,7 +21,7 @@ import order as od
 
 from columnflow.types import Sequence, Callable, Any
 from columnflow.columnar_util import mandatory_coffea_columns, Route, ColumnCollection
-from columnflow.util import DotDict
+from columnflow.util import is_regex, DotDict
 
 
 # default analysis and config related objects
@@ -87,6 +89,10 @@ class AnalysisTask(BaseTask, law.SandboxTask):
     default_wlcg_fs = law.config.get_expanded("target", "default_wlcg_fs", "wlcg_fs")
     default_output_location = "config"
 
+    # cached and parsed sections of the law config for faster lookup
+    _cfg_outputs_dict = None
+    _cfg_versions_dict = None
+
     @classmethod
     def modify_param_values(cls, params: dict) -> dict:
         params = super().modify_param_values(params)
@@ -138,50 +144,191 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         # build the params
         params = super().req_params(inst, **kwargs)
 
-        # overwrite the version when set in the config
+        # use a default version when not explicitly set in kwargs
         if isinstance(getattr(cls, "version", None), luigi.Parameter) and "version" not in kwargs:
-            config_version = cls.get_version_map_value(inst, params)
-            if config_version:
-                params["version"] = config_version
+            default_version = cls.get_default_version(inst, params)
+            if default_version and default_version != law.NO_STR:
+                params["version"] = default_version
 
         return params
 
     @classmethod
-    def get_version_map(cls, task: AnalysisTask) -> dict[str, str | Callable]:
-        return task.analysis_inst.get_aux("versions", {})
+    def _structure_cfg_items(cls, items: list[tuple[str, Any]]) -> dict:
+        if not items:
+            return {}
+
+        # breakup keys at double underscores and create a nested dictionary
+        items_dict = {}
+        for key, value in items:
+            if not value:
+                continue
+            d = items_dict
+            parts = key.split("__")
+            for i, part in enumerate(parts):
+                if i < len(parts) - 1:
+                    # fill intermediate structure
+                    if part not in d:
+                        d[part] = {}
+                    elif not isinstance(d[part], dict):
+                        d[part] = {"*": d[part]}
+                    d = d[part]
+                else:
+                    # assign value to the last nesting level
+                    if part in d and isinstance(d[part], dict):
+                        d[part]["*"] = value
+                    else:
+                        d[part] = value
+
+        return items_dict
 
     @classmethod
-    def get_version_map_value(
+    def _get_cfg_outputs_dict(cls):
+        if cls._cfg_outputs_dict is None and law.config.has_section("outputs"):
+            # collect config item pairs
+            skip_keys = {"wlcg_file_systems", "lfn_sources"}
+            items = [
+                (key, law.config.get_expanded("outputs", key, None, split_csv=True))
+                for key, value in law.config.items("outputs")
+                if value and key not in skip_keys
+            ]
+            cls._cfg_outputs_dict = cls._structure_cfg_items(items)
+
+        return cls._cfg_outputs_dict
+
+    @classmethod
+    def _get_cfg_versions_dict(cls):
+        if cls._cfg_versions_dict is None and law.config.has_section("versions"):
+            # collect config item pairs
+            items = [
+                (key, value)
+                for key, value in law.config.items("versions")
+                if value
+            ]
+            cls._cfg_versions_dict = cls._structure_cfg_items(items)
+
+        return cls._cfg_versions_dict
+
+    @classmethod
+    def get_default_version(cls, inst: AnalysisTask, params: dict[str, Any]) -> str | None:
+        """
+        Determines the default version for instances of *this* task class when created through
+        :py:meth:`req` from another task *inst* given parameters *params*.
+
+        :param inst: The task instance from which *this* task should be created via :py:meth:`req`.
+        :param params: The parameters that are passed to the task instance.
+        :return: The default version, or *None* if no default version can be defined.
+        """
+        # get different attributes by which the default version might be looked up
+        keys = cls.get_config_lookup_keys(params)
+
+        # forward to lookup implementation
+        version = cls._get_default_version(inst, params, keys)
+
+        # after a version is found, it can still be an exectuable taking the same arguments
+        return version(cls, inst, params) if callable(version) else version
+
+    @classmethod
+    def _get_default_version(
         cls,
         inst: AnalysisTask,
-        params: dict,
-        version_map: dict[str, str | Callable] | None = None,
+        params: dict[str, Any],
+        keys: law.util.InsertableDict,
     ) -> str | None:
-        if version_map is None:
-            version_map = cls.get_version_map(inst)
+        # try to lookup the version in the analysis's auxiliary data
+        analysis_inst = params.get("analysis_inst") or getattr(inst, "analysis_inst", None)
+        if analysis_inst:
+            version = cls._dfs_key_lookup(keys, analysis_inst.x("versions", {}))
+            if version:
+                return version
 
-        # the task family must be in the version map
-        version = version_map.get(cls.task_family)
-        if not version:
-            return None
+        # try to find it in the analysis section in the law config
+        if law.config.has_section("versions"):
+            versions_dict = cls._get_cfg_versions_dict()
+            if versions_dict:
+                version = cls._dfs_key_lookup(keys, versions_dict)
+                if version:
+                    return version
 
-        # when version is a callable, invoke it
-        if callable(version):
-            version = version(cls, inst, params)
+        # no default version found
+        return None
 
-        # at this point, version must be a string
-        if not isinstance(version, str):
-            raise TypeError(
-                f"version map entry for '{cls.task_family}' must be a string, but got {version}",
-            )
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: AnalysisTask | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        """
+        Returns a dictionary with keys that can be used to lookup state specific values in a config
+        or dictionary, such as default task versions or output locations.
 
-        return version
+        :param inst_or_params: The tasks instance or its parameters.
+        :return: A dictionary with keys that can be used for nested lookup.
+        """
+        keys = law.util.InsertableDict()
+
+        get = (
+            inst_or_params.get
+            if isinstance(inst_or_params, dict)
+            else lambda attr: (getattr(inst_or_params, attr, None))
+        )
+
+        # add the analysis name
+        analysis = get("analysis")
+        if analysis not in {law.NO_STR, None, ""}:
+            keys["analysis"] = analysis
+
+        # add the task family
+        keys["task_family"] = cls.task_family
+
+        return keys
+
+    @classmethod
+    def _dfs_key_lookup(
+        cls,
+        keys: law.util.InsertableDict[str, str] | Sequence[str],
+        nested_dict: dict[str, Any],
+        empty_value: Any = None,
+    ) -> str | Callable | None:
+        # opinionated nested dictionary lookup alongside in ordered sequence of (optional) keys,
+        # that allows for patterns in the keys and, interpreting the nested dict as a tree, finds
+        # matches in a depth-first (dfs) manner
+        if not nested_dict:
+            return empty_value
+
+        # the keys to use for the lookup are the values of the keys dict
+        keys = collections.deque(keys.values() if isinstance(keys, dict) else keys)
+
+        # start tree traversal using a queue lookup consisting of names and values of tree nodes,
+        # as well as the remaining keys (as a deferred function) to compare for that particular path
+        lookup = collections.deque([tpl + ((lambda: keys.copy()),) for tpl in nested_dict.items()])
+        while lookup:
+            pattern, obj, keys_func = lookup.popleft()
+
+            # create the copy of comparison keys on demand
+            # (the original sequence is living once on the previous stack until now)
+            _keys = keys_func()
+
+            # check if the pattern matches any key
+            regex = is_regex(pattern)
+            while _keys:
+                key = _keys.popleft()
+                if law.util.multi_match(key, pattern, regex=regex):
+                    # when obj is not a dict, we found the value
+                    if not isinstance(obj, dict):
+                        return obj
+                    # go one level deeper and stop the current iteration
+                    keys_func = (lambda _keys: (lambda: _keys.copy()))(_keys)
+                    lookup.extendleft(tpl + (keys_func,) for tpl in reversed(obj.items()))
+                    break
+
+        # at this point, no value could be found
+        return empty_value
 
     @classmethod
     def get_known_shifts(cls, config_inst: od.Config, params: dict) -> tuple[set[str], set[str]]:
         """
-        Returns two sets of shifts in a tuple: shifts implemented by _this_ task, and depdenent
-        shifts implemented by upstream tasks.
+        Returns two sets of shifts in a tuple: shifts implemented by _this_ task, and dependent
+        shifts that are implemented by upstream tasks.
         """
         # get shifts from upstream dependencies, consider both their own and upstream shifts as one
         upstream_shifts = set()
@@ -622,7 +769,9 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         if isinstance(location, str):
             location = OutputLocation[location]
         if location == OutputLocation.config:
-            location = law.config.get_expanded("outputs", self.task_family, None, split_csv=True)
+            lookup_keys = self.get_config_lookup_keys(self)
+            outputs_dict = self._get_cfg_outputs_dict()
+            location = copy.deepcopy(self._dfs_key_lookup(lookup_keys, outputs_dict))
             if not location:
                 self.logger.debug(
                     f"no option 'outputs::{self.task_family}' found in law.cfg to obtain target "
@@ -690,11 +839,40 @@ class ConfigTask(AnalysisTask):
         return params
 
     @classmethod
-    def get_version_map(cls, task):
-        if isinstance(task, ConfigTask):
-            return task.config_inst.get_aux("versions", {})
+    def _get_default_version(
+        cls,
+        inst: AnalysisTask,
+        params: dict[str, Any],
+        keys: law.util.InsertableDict,
+    ) -> str | None:
+        # try to lookup the version in the config's auxiliary data
+        config_inst = params.get("config_inst") or getattr(inst, "config_inst", None)
+        if config_inst:
+            version = cls._dfs_key_lookup(keys, config_inst.x("versions", {}))
+            if version:
+                return version
 
-        return super().get_version_map(task)
+        return super()._get_default_version(inst, params, keys)
+
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: ConfigTask | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        get = (
+            inst_or_params.get
+            if isinstance(inst_or_params, dict)
+            else lambda attr: (getattr(inst_or_params, attr, None))
+        )
+
+        # add the config name in front of the task family
+        config = get("config")
+        if config not in {law.NO_STR, None, ""}:
+            keys.insert_before("task_family", "config", config)
+
+        return keys
 
     @classmethod
     def get_array_function_kwargs(cls, task=None, **params):
@@ -835,6 +1013,26 @@ class ShiftTask(ConfigTask):
 
         return kwargs
 
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: ShiftTask | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        get = (
+            inst_or_params.get
+            if isinstance(inst_or_params, dict)
+            else lambda attr: (getattr(inst_or_params, attr, None))
+        )
+
+        # add the (global) shift name
+        shift = get("shift")
+        if shift not in {law.NO_STR, None, ""}:
+            keys["shift"] = shift
+
+        return keys
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -890,6 +1088,26 @@ class DatasetTask(ShiftTask):
                 upstream_shifts |= set(dataset_inst.info.keys())
 
         return shifts, upstream_shifts
+
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: DatasetTask | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        get = (
+            inst_or_params.get
+            if isinstance(inst_or_params, dict)
+            else lambda attr: (getattr(inst_or_params, attr, None))
+        )
+
+        # add the dataset name before the shift name
+        dataset = get("dataset")
+        if dataset not in {law.NO_STR, None, ""}:
+            keys.insert_before("shift", "dataset", dataset)
+
+        return keys
 
     @classmethod
     def get_array_function_kwargs(cls, task=None, **params):

--- a/docs/user_guide/best_practices.md
+++ b/docs/user_guide/best_practices.md
@@ -1,42 +1,140 @@
 # Best practices
 
+## Selecting output locations
+
+Tasks usually define their output targets using the generic `self.target()` method, defined by the {py:class}`~columnflow.tasks.framework.base.AnalysisTask` base class.
+Depending on specific choices made in the `law.cfg` file (see below), this methods then either calls {py:meth}`~columnflow.tasks.framework.base.AnalysisTask.local_target` or {py:meth}`~columnflow.tasks.framework.base.AnalysisTask.wlcg_target` with appropriate settings, to create either a target acessible on the local file system, or a remote target on a non-local storage system.
+
+The lookup of output locations can be defined in the `law.cfg` file.
+
+```ini
+[outputs]
+
+TASK_IDENTIFIER: LOCATION
+```
+
+`LOCATION` refers to the output location and can take comma-separated values.
+
+- `local` refers to the default local file system.
+- `local, LOCAL_FS_NAME` refers to a specific local file system named `LOCAL_FS_NAME` that should be defined in the `law.cfg` file.
+For convenience, if no file system with that name was defined, `LOCAL_FS_NAME` is interpreted as the base path of such a file system.
+- `wlcg` refers to the default remote storage system.
+- `wlcg, WLCG_FS_NAME` refers to a specific remote storage system named `WLCG_FS_NAME` that should be defined in the `law.cfg` file.
+
+`TASK_IDENTIFIER` identifies the task the location should apply to.
+It can be a simple task family such as `cf.CalibrateEvents`, but for larger analyses a more fine grained selection is required.
+For this purpose, `TASK_IDENTIFIER` can be a `__`-separated sequence of so-called lookup keys, e.g.
+
+```ini
+[outputs]
+
+run3_23__cf.CalibrateEvents__nominal: wlcg, wlcg_fs_run3_23
+```
+
+Here, three keys are defined, making use of the config name, the task family, and the name of a systematic shift.
+The exact selection of possible keys and their resolution order is defined by the task itself in {py:meth}:`~columnflow.tasks.framework.base.AnalysisTask.get_config_lookup_keys` (and subclasses).
+Most tasks, however, define their lookup keys as:
+
+1. analysis name
+2. config name
+3. task family
+4. dataset name
+5. shift name
+
+When defining `TASK_IDENTIFIER`'s, not all keys need to be specified, and patterns or regular expressions (`^EXPR$`) can be used.
+The definition order is **important** as the first matching definition is used.
+This way, output locations are highly customizable.
+
+```ini
+[outputs]
+
+# store all run3 outputs on a specific fs, and all other outputs locally
+run3_*__cf.CalibrateEvents: wlcg, wlcg_fs_run3
+cf.CalibrateEvents: local
+```
+
+## Controlling versions of upstream tasks
+
+Just as for the definition of output locations, pinning versions of produced output targets is an important feature to ensure reproducibility and reusability of previous, intermediate analysis results.
+In general, versions are defined by passing a `--version VALUE` parameter on the command line to the task to run, which then passes this value upstream to its dependencies.
+
+There are two ways of controlling the version of upstream tasks if the standard way of using the same value everywhere is not desired.
+Their order of priority is:
+
+1. Task family specific parameters
+2. Pinned versions in the analysis config or `law.cfg` file
+3. `--version` command line parameter
+
+### Task family specific parameters
+
+On the command line, versions of upstream tasks can be controlled by `--cf.UPSTREAMTASK-version OTHER_VAUE` if desired.
+For example, if a task `B` that depends on task `A` is started from the command line via
+
+```bash
+law run B --version v2 --A-version v1
+```
+
+the instantiation of task class `A` in the definition of `requires()` in task class `B` will prefer version `v1` over `v2`.
+As a result, all tasks upsstream of `A` will, as well, be instantiated with version `v1`.
+This is particularly useful if a certain part of an analysis workflow is to be rerun, while keeping upstream parts fixed at a specific version.
+
+### Pinned versions in the analysis config or `law.cfg` file
+
+Versions of tasks can be pinned through an auxiliary entry `config_inst.x.version` in the configuration object or `analysis_inst.x.version` in the analysis object itself, or the `[versions]` section in the `law.cfg` file.
+The priority is defined along this order and the lookup is done in the same way as described above for output locations using a `TASK_IDENTIFIER`.
+
+Consider the following two examples for defining versions, one via auxiliary config entries and the other via the `law.cfg` file:
+
+```python
+cfg.x.versions = {
+    "run3_*": {
+        "cf.CalibrateEvents": "v2",
+    },
+    "cf.CalibrateEvents": "v1",
+}
+```
+
+```ini
+[versions]
+
+run3_*__cf.CalibrateEvents: v2
+cf.CalibrateEvents: v1
+```
+
+They are **equivalent** since the `__`-separated `TASK_IDENTIFIER`'s in the `law.cfg` are internallly converted to the same nested dictionary structure.
+
+As described above, the exact selection of possible keys and their resolution order is defined in {py:meth}:`~columnflow.tasks.framework.base.AnalysisTask.get_config_lookup_keys` (and subclasses), not all keys need to be specified when defining versions, and they are allowed to be patterns or regular expressions (`^EXPR$`).
 
 ## Columnflow convenience tools
 
-- Columnflow defines {py:attr}`~columnflow.columnar_util.EMPTY_FLOAT`, a float variable
-containing the value ```-99999.0```. This variable is typically used to replace null values
-in awkward arrays.
+- Columnflow defines {py:attr}`~columnflow.columnar_util.EMPTY_FLOAT`, a float variable containing the value `-99999.0`.
+This variable is typically used to replace null values in awkward arrays.
 
-- In many cases, one wants to access an object that does not exist for every event (e.g. accessing
-the transverse momentum of the 3rd jet ```events.Jet[:, 2].pt```, even though some events may only
-contain two jets). In that case, the {py:class}`~columnflow.columnar_util.Route` class and its
-{py:meth}`~columnflow.columnar_util.Route.apply` function can be used to access this object by
-replacing missing values with the given value, e.g.
-```jet3_pt = Route("Jet.pt[:, 2]").apply(events, null_value=EMPTY_FLOAT)```.
+- In many cases, one wants to access an object that does not exist for every event (e.g. accessing the transverse momentum of the 3rd jet `events.Jet[:, 2].pt`, even though some events may only contain two jets).
+In that case, the {py:class}`~columnflow.columnar_util.Route` class and its {py:meth}`~columnflow.columnar_util.Route.apply` function can be used to access this object by replacing missing values with the given value, e.g. `jet3_pt = Route("Jet.pt[:, 2]").apply(events, null_value=EMPTY_FLOAT)`.
 
-- Columnflow allows the use of some fields out of the ```events``` array, like the ```Jet``` field,
-as a Lorentz vector to apply operations on. For this purpose, you might use the
-{py:func}`~columnflow.production.util.attach_coffea_behavior` function. This
-function can be applied on the ```events``` array using
+- Columnflow allows the use of some fields out of the `events` array, like the `Jet` field, as a Lorentz vector to apply operations on.
+For this purpose, you might use the {py:func}`~columnflow.production.util.attach_coffea_behavior` function.
+This function can be applied on the `events` array using
+
 ```python
 events = self[attach_coffea_behavior](events, **kwargs)
 ```
-If the name of the field does not correspond to a standard coffea field name, e.g. "BtaggedJets",
-which should provide the same behaviour as a normal jet, the behaviour can still be set, using
+
+If the name of the field does not correspond to a standard coffea field name, e.g. "BtaggedJets", which should provide the same behaviour as a normal jet, the behaviour can still be set, using
+
 ```python
 collections = {x: {"type_name": "Jet"} for x in ["BtaggedJets"]}
 events = self[attach_coffea_behavior](events, collections=collections, **kwargs)
 ```
 
-
-- shortcuts / winning strategies / walktrough guides e.g. pilot parameter
-TODO
+- shortcuts / winning strategies / walktrough guides e.g. pilot parameter: TODO
 
 - config utils: TODO
 
 - categorization
-   - mutually exclusive leaf categories
-TODO
+  - mutually exclusive leaf categories
+  - TODO
 
 ## General advices
 
@@ -44,15 +142,13 @@ TODO
 columns only after the reduction, using the {py:class}`~columnflow.tasks.production.ProduceColumns`
 task.
 
-
-
 ## Using python scripts removed from the standard workflow
 
 - Use a particular cf_sandbox for a python script not implemented in the columnflow workflow: Write
-```cf_sandbox venv_columnar_dev bash ``` on the command line.
+`cf_sandbox venv_columnar_dev bash` on the command line.
 
 - Call tasks objects in a python script removed from the standard workflow: An imported task can
-be run through the ```law_run()``` command, its output can be accessed through the "output"
+be run through the `law_run()` command, its output can be accessed through the "output"
 function of the task. An example is given in the following code snippet.
 
 ```python
@@ -65,9 +161,3 @@ task.law_run()
 # do something with the output
 output = task.output()["collection"]
 ```
-
-
-
-
-
-

--- a/law.cfg
+++ b/law.cfg
@@ -75,10 +75,31 @@ wlcg_file_systems: wlcg_fs, wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 
 # output locations per task family
+# the key can consist of multple underscore-separated parts, that can each be patterns or regexes
+# these parts are used for the lookup from within tasks and can contain (e.g.) the analysis name,
+# the config name, the task family, the dataset name, or the shift name
+# (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
+# values can have the following format:
 # for local targets : "local[, LOCAL_FS_NAME or STORE_PATH]"
 # for remote targets: "wlcg[, WLCG_FS_NAME]"
 # (when WLCG_FS_NAME is empty, the tasks' "default_wlcg_fs" attribute is used)
-; cf.CalibrateEvents: wlcg, wlcg_fs_...
+# example:
+; run3_2023__cf.CalibrateEvents__nomin*: local
+; cf.CalibrateEvents: wlcg
+
+
+[versions]
+
+# default versions of specific tasks to pin
+# the key can consist of multple underscore-separated parts, that can each be patterns or regexes
+# these parts are used for the lookup from within tasks and can contain (e.g.) the analysis name,
+# the config name, the task family, the dataset name, or the shift name
+# (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
+# note:
+# this lookup is skipped if the lookup based on the config instance's auxiliary data succeeded
+# example:
+; run3_2023__cf.CalibrateEvents__nomin*: prod1
+; cf.CalibrateEvents: prod2
 
 
 [job]


### PR DESCRIPTION
This is a rather extensive PR that refactors the way that locations and versions of specific outputs can be pinned through the `law.cfg` or the `config_inst`'s and `analysis_inst`'s auxiliary entries.

This would solve a long-standing discussion about sharing outputs among analyzers and also across analyses.

I added sections on the scope and purpose of this feature to the documentation already built the branch: https://columnflow.readthedocs.io/en/feature-pinned_versions_and_locations/user_guide/best_practices.html

---

### Summary for versions

- Pinned versions have priority over what is passed upstream via `Task.req(self)` as part of the overlap between `Task` and `self`, but not over class-level CLI parameters if given (e.g. `--cf.Task-version ...`).
- Versions are looked up (in this order) at
  - `config_inst.x.versions`
  - `analysis_inst.x.versions`
  - `[versions]` section in `law.cfg`
- The lookup logic is described below.

### Summary for locations

- Pinned locations are chosen when tasks are defined by `self.target()` (which then defers to `self.local_target()` or `self.wlcg_target()` with the correct arguments).
- For the lookup, as before, locations are defined in the `[outputs]` section of the `law.cfg`.
- The lookup logic is described below.

### Lookup logic

The lookup of either locations or versions happens through nested dictionaries which can be defined in the config, analysis or `law.cfg` file. When defined in the `law.cfg`, this nested dictionary is constructed by splitting the option names at double underscores `__`. Hence, these two variants would be identical:

```python
cfg.x.versions = {
    "run3_*": {
        "cf.CalibrateEvents": "v2",
    },
    "cf.CalibrateEvents": "v1",
}
```

```ini
[versions]

run3_*__cf.CalibrateEvents: v2
cf.CalibrateEvents: v1
```

Now, tasks can define the keys that can be used to find specific values in these nested dictionaries (which can be considered trees for easier nomenclature). This is done through a new method `get_config_lookup_keys()`, implemented by the analysis base task, and extended by inheriting classes. For most of our tasks though, the keys will contain (in this order):

1. analysis name
2. config name
3. task family
4. dataset name
5. shift name

The lookup is done according to these keys using three rules:

- Not all keys have to match and can be skipped if they don't match
  - e.g. in the example above, only the *config name* and *task family* are defined
- Keys (non-leaf-nodes) in the tree can be patterns or regular expressions
- The lookup order is depth-first-search
  - i.e., the first matching node is explored first, and the first matching value is returned.

This way, definitions of pinned versions and locations can be very flexible.

Some examples:

```python
cfg.x.versions = {
    "cf.CalibrateEvents": {
        "nominal": "prod1",        # nominal shift at prod1
        "^.*(up|down)$": "prod2",  # all variations at prod2
    },
    "run3_22pre_*": {
        "cf.SelectEvents": {
            "tt_sl_powheg": "prod1",  # ttbar sl at prod1 in 22pre era
            "*": "prod2",             # rest at prod2
        },
    },
    "cf.SelectEvents": "prod2",  # prod2 for all other eras
}
```