### PR TITLE
Add hooks to modify store parts on a per-task level.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -47,7 +47,7 @@ ana.x.cmssw_sandboxes = [
 # (used in wrapper_factory)
 ana.x.config_groups = {}
 
-# name hooks of functions that can modify store_parts of task outputs if needed
+# named function hooks that can modify store_parts of task outputs if needed
 ana.x.store_parts_modifiers = {}
 
 

--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -47,6 +47,9 @@ ana.x.cmssw_sandboxes = [
 # (used in wrapper_factory)
 ana.x.config_groups = {}
 
+# name hooks of functions that can modify store_parts of task outputs if needed
+ana.x.store_parts_modifiers = {}
+
 
 #
 # setup configs

--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -84,9 +84,11 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 # the config name, the task family, the dataset name, or the shift name
 # (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
 # values can have the following format:
-# for local targets : "local[, LOCAL_FS_NAME or STORE_PATH]"
-# for remote targets: "wlcg[, WLCG_FS_NAME]"
+# for local targets : "local[, LOCAL_FS_NAME or STORE_PATH][, store_parts_modifier]"
+# for remote targets: "wlcg[, WLCG_FS_NAME][, store_parts_modifier]"
 # (when WLCG_FS_NAME is empty, the tasks' "default_wlcg_fs" attribute is used)
+# the "store_parts_modifiers" can be the name of a function in the "store_parts_modifiers" aux dict
+# of the analysis instance, which is called with an output's store parts of an output to modify them
 # example:
 ; run3_2023__cf.CalibrateEvents__nomin*: local
 ; cf.CalibrateEvents: wlcg

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -703,7 +703,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         *path,
         store_parts_modifier: str | Callable[[AnalysisTask, dict], dict] | None = None,
         **kwargs,
-    ):
+    ) -> str:
         """ local_path(*path, store=None, fs=None, store_parts_modifier=None)
         Joins path fragments from *store* (defaulting to :py:attr:`default_store`),
         :py:meth:`store_parts` and *path* and returns the joined path. In case a *fs* is defined,

--- a/law.cfg
+++ b/law.cfg
@@ -84,9 +84,11 @@ lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirec
 # the config name, the task family, the dataset name, or the shift name
 # (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
 # values can have the following format:
-# for local targets : "local[, LOCAL_FS_NAME or STORE_PATH]"
-# for remote targets: "wlcg[, WLCG_FS_NAME]"
+# for local targets : "local[, LOCAL_FS_NAME or STORE_PATH][, store_parts_modifier]"
+# for remote targets: "wlcg[, WLCG_FS_NAME][, store_parts_modifier]"
 # (when WLCG_FS_NAME is empty, the tasks' "default_wlcg_fs" attribute is used)
+# the "store_parts_modifiers" can be the name of a function in the "store_parts_modifiers" aux dict
+# of the analysis instance, which is called with an output's store parts of an output to modify them
 # example:
 ; run3_2023__cf.CalibrateEvents__nomin*: local
 ; cf.CalibrateEvents: wlcg


### PR DESCRIPTION
This PR is a small extension to #449 and enables the modification of store parts on a per-task level, with options to apply these changes to very specific tasks using the introduced lookup mechanism.

In the `law.cfg` file, locations can be defined with, e.g.

```ini
[outputs]

cf.CalibrateEvents: wlcg[, wlcg_fs]
```

where the second value, the actual fs entry, is optional.

With the changes in *this* PR, a third value is possible:

```ini
[outputs]

cf.CalibrateEvents: wlcg[, wlcg_fs][, store_parts_modifier]
```

The `store_parts_modifier` can be the name of a function defined in the analysis' `store_parts_modifiers` auxiliary entry (a dict), which will receive the task instance and the current store parts, and that can modify the dictionary.

With that, all kinds of dynamic behaviors are possible, such as changing the paths to that of a different analysis, e.g. for sharing outputs.