### PR TITLE
add checks to ensure proper event and object masks

### DIFF
--- a/tests/test_selectionresults.py
+++ b/tests/test_selectionresults.py
@@ -25,6 +25,7 @@ masks = [
     np.array([[True, False]]),
     np.array([[2, 3]]),
     ak.Array([[2, 3], [1, None]])[:, 0],
+    ak.Array([[1, 0], [1, 1]])
 ]
 s = SelectionResult(objects={"Muon": {f"m{i}": m for i, m in enumerate(masks)}})
 
@@ -51,7 +52,22 @@ for i, wr in enumerate(wrong):
         print(wr, "\033[92m", "no error?")
     except AssertionError as e:
         print(wr, "\033[91m", e)
-print(end="")
+
+print("\n\033[95mpotentially problematic object mask tests:")
+masks = [
+    (
+        ak.Array([[1, 0], [1, 1, True]])[:, :2],
+       "mask is of union type but in fact only contains integer 0's and 1's. " \
+       "This will lead to conversion to True and False. But seems unlikely to happen."
+    )
+]
+s = SelectionResult(objects={"Muon": {f"m{i}": m for i, (m, _) in enumerate(masks)}})
+
+for i, (m, discussion) in enumerate(masks):
+    new_m = s.objects["Muon"][f"m{i}"]
+    print(m, "\033[92m", new_m)
+    print("\033[94m", ak.Array(m).type, "\033[92m", new_m.type)
+    print(discussion)
 
 print("\n\033[95mcorrect event mask tests:")
 masks = [

--- a/tests/test_selectionresults.py
+++ b/tests/test_selectionresults.py
@@ -25,7 +25,7 @@ masks = [
     np.array([[True, False]]),
     np.array([[2, 3]]),
     ak.Array([[2, 3], [1, None]])[:, 0],
-    ak.Array([[1, 0], [1, 1]])
+    ak.Array([[1, 0], [1, 1]]),
 ]
 s = SelectionResult(objects={"Muon": {f"m{i}": m for i, m in enumerate(masks)}})
 
@@ -57,9 +57,9 @@ print("\n\033[95mpotentially problematic object mask tests:")
 masks = [
     (
         ak.Array([[1, 0], [1, 1, True]])[:, :2],
-       "mask is of union type but in fact only contains integer 0's and 1's. " \
-       "This will lead to conversion to True and False. But seems unlikely to happen."
-    )
+        "mask is of union type but in fact only contains integer 0's and 1's. "
+        "This will lead to conversion to True and False. But seems unlikely to happen.",
+    ),
 ]
 s = SelectionResult(objects={"Muon": {f"m{i}": m for i, (m, _) in enumerate(masks)}})
 

--- a/tests/test_selectionresults.py
+++ b/tests/test_selectionresults.py
@@ -1,0 +1,102 @@
+import awkward as ak
+import numpy as np
+
+import law
+from columnflow.selection import SelectionResult
+
+logger = law.logger.get_logger(__name__)
+
+
+def col_neutral_print(print_func):
+    def new_print(*args, **kwargs):
+        kwargs["end"] = kwargs.get("end", "\n") + "\033[0m"
+        print_func(*args, **kwargs)
+    return new_print
+
+
+print = col_neutral_print(print)
+
+print("\n\033[95mcorrect object mask tests:")
+masks = [
+    ak.Array([[2, 3], [1]]),
+    ak.Array([[2], [1, None]])[:, :1],
+    ak.Array([[1], [True, False]]),
+    ak.Array([[1, 0, None], [True, False]])[:, :2],
+    np.array([[True, False]]),
+    np.array([[2, 3]]),
+    ak.Array([[2, 3], [1, None]])[:, 0],
+]
+s = SelectionResult(objects={"Muon": {f"m{i}": m for i, m in enumerate(masks)}})
+
+for i, m in enumerate(masks):
+    new_m = s.objects["Muon"][f"m{i}"]
+    print(m, "\033[92m", new_m)
+    print("\033[94m", ak.Array(m).type, "\033[92m", new_m.type)
+
+
+print("\n\033[95mwrong object mask tests:")
+wrong = [
+    ak.Array([[2, 3], [1, True]]),
+    ak.Array([[1, 2], None]),
+    ak.Array([[True, False], [None]]),
+    ak.Array([[True, False], None]),
+    ak.Array([[True, False], None])[:1],
+    ak.Array([True, False]),
+    ak.Array([1, 2, True]),
+]
+
+for i, wr in enumerate(wrong):
+    try:
+        SelectionResult(objects={"Muon": {f"Muon{i}": wr}})
+        print(wr, "\033[92m", "no error?")
+    except AssertionError as e:
+        print(wr, "\033[91m", e)
+print(end="")
+
+print("\n\033[95mcorrect event mask tests:")
+masks = [
+    ak.Array([1, 0, 0, None])[:-1],
+    ak.Array([1, 0, 0, 1]),
+    ak.Array([0, True, 0, False]),
+    ak.Array([True, True, None])[:-1],
+    ak.Array([True, True, False]),
+    np.array([True, True, False]),
+]
+for m in masks:
+    new_m = SelectionResult(event=m).event
+    print(m, "\033[92m", new_m)
+    print("\033[94m", ak.Array(m).type, "\033[92m", new_m.type)
+
+print("\n\033[95mwrong event mask tests:")
+wrong = [
+    ak.Array([True, True, None]),
+    ak.Array([[True, False], [True]]),
+    ak.Array([[True, False]]),
+    ak.Array([[True], [False]]),
+    np.array([[True], [False]]),
+    ak.Array([0, 2, True]),
+    ak.Array([False, 2, True]),
+]
+
+for i, wr in enumerate(wrong):
+    try:
+        SelectionResult(event=wr)
+        print(wr, "\033[92m", "no error?")
+    except AssertionError as e:
+        print(wr, "\033[91m", e)
+
+print("\n\033[95mcorrect step mask tests:")
+s = SelectionResult(steps={f"s{i}": m for i, m in enumerate(masks)})
+
+for i, m in enumerate(masks):
+    new_m = s.steps[f"s{i}"]
+    print(m, "\033[92m", new_m)
+    print("\033[94m", ak.Array(m).type, "\033[92m", new_m.type)
+
+print("\n\033[95mwrong step mask tests:")
+for i, wr in enumerate(wrong):
+    try:
+        SelectionResult(steps={"s": wr})
+        print(wr, "\033[92m", "no error?")
+    except AssertionError as e:
+        print(wr, "\033[91m", e)


### PR DESCRIPTION
I added checks to the SelectionResult class which ensure that the following conditions when passing event masks or object mask to it:
- event mask should be a 1d Array of booleans
- object masks should be:
  -  a 2d Array of booleans
  - a 2d or 1d Array of integers 

All mask are checked for the presence of Nones (raising an error if found) and converted to pure type (no ? or option in the type).

Integer object masks are converted to be
- two dimensional (if original 1d, the user is notified about the conversion)
- jagged (type is of form <N * var * ... >, not <N * M * ... >)

These checks avoid errors like the following:
- objects mask is 1d integer: the object mask will be interpreted as an event index instead of an object index
- object mask is 2d integer, but of fixed dimensions (not jagged): the object mask might again be interpreted as selecting events, not obejcts
- event mask is a single boolean. For instance, when doing smth like ak.sum(leptons.pdgId == 11) == 1, which wil sum over all electrons in the entire sample because the axis=1 is omitted. The mask will most probably evaluate to False and kill all your events.
- object mask is of mixed type in only one (part of a) datafile, but pure in others (because of rare none values), resulting in merging issues.