### PR TITLE
Add markdown linting to CI

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Lint 🔍
         run: |
           source setup.sh ""
-          ./tests/run_docs lint
+          ./tests/run_docs lint || true
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive
 
       - name: Setup python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -29,17 +29,40 @@ jobs:
           source setup.sh ""
           ./tests/run_linting
 
-  test:
+  lint_docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive
 
       - name: Setup python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies ☕️
+        run: |
+          source setup.sh ""
+
+      - name: Lint 🔍
+        run: |
+          source setup.sh ""
+          ./tests/run_docs lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup python 🐍
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -56,13 +79,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive
 
       - name: Setup python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -83,13 +106,13 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: recursive
 
       - name: Setup python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -104,7 +127,7 @@ jobs:
           ls -al
 
       - name: Upload report 🔝
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           flags: unittests
           files: coverage_test_util.xml,coverage_test_columnar_util.xml

--- a/.markdownlint
+++ b/.markdownlint
@@ -1,0 +1,4 @@
+plugins:
+  # disable max line length
+  md013:
+    enabled: False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-# version 8
+# version 7
 
 # documentation packages
 sphinx~=6.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-# version 7
+# version 8
 
 # documentation packages
 sphinx~=6.2.1
@@ -9,7 +9,7 @@ sphinx-book-theme~=1.0.1
 sphinx-lfs-content~=1.1.3,!=1.1.5
 autodocsumm~=0.2.11
 myst-parser~=2.0.0
-sphinxcontrib-mermaid==0.9.2
+sphinxcontrib-mermaid~=0.9.2
 
 # prod packages
 -r ../sandboxes/cf.txt

--- a/sandboxes/dev.txt
+++ b/sandboxes/dev.txt
@@ -1,4 +1,4 @@
-# version 7
+# version 8
 
 ipython~=8.8
 pytest~=7.1
@@ -7,3 +7,4 @@ flake8~=5.0
 flake8-commas~=2.1
 flake8-quotes~=3.3
 pipdeptree~=2.13
+pymarkdownlnt~=0.9.20

--- a/tests/run_docs
+++ b/tests/run_docs
@@ -3,7 +3,8 @@
 # Script that builds and checks the documentation.
 #
 # Arguments:
-#   1. The mode. When "clean", previously created docs are removed first. No default.
+#   1. The mode. When "clean", previously created docs are removed first. When "lint", only the
+#      markdown linting checks are performed. No default.
 
 action() {
     local shell_is_zsh=$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )
@@ -14,16 +15,32 @@ action() {
     # get arguments
     local mode="${1}"
 
-    # clean first if requested
+    # keep track of immediate and global return values
+    local gret="0"
+    local ret
+
+    # markdown linting
+    pymarkdown --config "${cf_dir}/.markdownlint" scan --recurse "${cf_dir/README.md}" "${cf_dir/docs}"
+    ret="$?"
+    [ "${gret}" = "0" ] && gret="${ret}"
+
+    # stop here when only linting
+    [ "${mode}" = "lint" ] && return "${gret}"
+
+    # clean built docs first if requested
     if [ "${mode}" = "clean" ]; then
         ( cd "${cf_dir}/docs" && make clean ) || return "$?"
     fi
 
-    # build
+    # build docs
     (
         source "${cf_dir}/sandboxes/venv_docs_dev.sh" "" && \
         cd "${cf_dir}/docs" && \
         make html
-    ) || return "$?"
+    )
+    ret="$?"
+    [ "${gret}" = "0" ] && gret="${ret}"
+
+    return "${gret}"
 }
 action "$@"


### PR DESCRIPTION
On the way towards polishing the docs, we should make sure that the markdown files are properly formatted. For this purposes, this PR adds a "lint_docs" step to the CI that is based on a normal markdown linting tool that I added to the dev sandbox. It is now also part of the local documentation build process and can be triggered without building the docs at all.

The test runs already, but the CI will continue to not fail for now. In a second PR, the docs should be linted and the `|| true` part in the CI removed consequently.