### PR TITLE
Allow columns to be skipped in 'keep_columns' definitions.

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -242,14 +242,16 @@ cfg.x.reduced_file_size = 512.0
 cfg.x.keep_columns = DotDict.wrap({
     "cf.ReduceEvents": {
         # general event info, mandatory for reading files with coffea
-        ColumnCollection.MANDATORY_COFFEA,  # additional columns can be added as strings, similar to object info
+        # additional columns can be added as strings, similar to object info
+        ColumnCollection.MANDATORY_COFFEA,
         # object info
         "Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass", "Jet.btagDeepFlavB", "Jet.hadronFlavour",
         "Muon.pt", "Muon.eta", "Muon.phi", "Muon.mass", "Muon.pfRelIso04_all",
         "MET.pt", "MET.phi", "MET.significance", "MET.covXX", "MET.covXY", "MET.covYY",
         "PV.npvs",
-        # all columns added during selection using a ColumnCollection flag
+        # all columns added during selection using a ColumnCollection flag, but skip cutflow ones
         ColumnCollection.ALL_FROM_SELECTOR,
+        skip_column("cutflow.*"),
     },
     "cf.MergeSelectionMasks": {
         "cutflow.*",

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1946,7 +1946,7 @@ def tagged_column(
     """
     Takes one or several objects *routes* whose type can be anything that is accepted by the
     :py:class:`~.Route` constructor, and returns a single or a set of route objects being tagged
-    *tag*, which can be a single tag, a sequence of a set of tags.
+    *tag*, which can be a single tag, a sequence, or a set of tags.
     """
     if not routes:
         raise Exception("at least one route argument must be given")

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -6,14 +6,7 @@ Helpers and utilities for working with columnar libraries.
 
 from __future__ import annotations
 
-__all__ = [
-    "mandatory_coffea_columns", "ColumnCollection", "EMPTY_INT", "EMPTY_FLOAT",
-    "Route", "RouteFilter", "ArrayFunction", "TaskArrayFunction", "ChunkedIOHandler",
-    "eval_item", "get_ak_routes", "has_ak_column", "set_ak_column", "remove_ak_column",
-    "add_ak_alias", "add_ak_aliases", "update_ak_array", "flatten_ak_array", "sort_ak_fields",
-    "sorted_ak_to_parquet", "sorted_ak_to_root", "attach_behavior", "layout_ak_array",
-    "flat_np_view", "ak_copy", "fill_hist", "deferred_column", "optional_column",
-]
+__all__ = []
 
 import os
 import gc
@@ -1946,20 +1939,21 @@ class ArrayFunction(Derivable):
 deferred_column = ArrayFunction.DeferredColumn.deferred_column
 
 
-def optional_column(
+def tagged_column(
+    tag: str | Sequence[str] | set[str],
     *routes: Route | Any | set[Route | Any],
 ) -> Route | set[Route]:
     """
     Takes one or several objects *routes* whose type can be anything that is accepted by the
     :py:class:`~.Route` constructor, and returns a single or a set of route objects being tagged
-    ``"optional"``.
+    *tag*, which can be a single tag, a sequence of a set of tags.
     """
     if not routes:
         raise Exception("at least one route argument must be given")
 
-    def opt_route(r):
+    def tagged_route(r):
         route = Route(r)
-        route.add_tag("optional")
+        route.add_tag(tag)
         return route
 
     # determine if multple objects are given and handle the case where a single set is given
@@ -1971,7 +1965,29 @@ def optional_column(
         multiple = True
 
     # create multiple or a single tagged route
-    return set(map(opt_route, routes)) if multiple else opt_route(list(routes)[0])
+    return set(map(tagged_route, routes)) if multiple else tagged_route(list(routes)[0])
+
+
+def optional_column(
+    *routes: Route | Any | set[Route | Any],
+) -> Route | set[Route]:
+    """
+    Takes one or several objects *routes* whose type can be anything that is accepted by the
+    :py:class:`~.Route` constructor, and returns a single or a set of route objects being tagged
+    ``"optional"``.
+    """
+    return tagged_column("optional", *routes)
+
+
+def skip_column(
+    *routes: Route | Any | set[Route | Any],
+) -> Route | set[Route]:
+    """
+    Takes one or several objects *routes* whose type can be anything that is accepted by the
+    :py:class:`~.Route` constructor, and returns a single or a set of route objects being tagged
+    ``"skip"``.
+    """
+    return tagged_column("skip", *routes)
 
 
 class TaskArrayFunction(ArrayFunction):

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -435,7 +435,7 @@ class MergeSelectionMasks(
             )
 
         # define columns that will be written
-        write_columns: set[Route] = set(map(Route, mandatory_coffea_columns))
+        write_columns: set[Route] = set()
         skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, []):
             for r in (self.find_keep_columns(c) if isinstance(c, ColumnCollection) else {Route(c)}):
@@ -447,6 +447,8 @@ class MergeSelectionMasks(
             r for r in write_columns
             if not law.util.multi_match(r.column, skip_columns, mode=any)
         }
+        # add some mandatory columns
+        write_columns |= set(map(Route, mandatory_coffea_columns))
         write_columns |= set(map(Route, {"category_ids", "process_id", "normalization_weight"}))
         route_filter = RouteFilter(write_columns)
 

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -103,12 +103,18 @@ class UniteColumns(
         tmp_dir.touch()
 
         # define columns that will be written
-        write_columns = set()
+        write_columns: set[Route] = set()
+        skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, ["*"]):
-            if isinstance(c, ColumnCollection):
-                write_columns |= self.find_keep_columns(c)
-            else:
-                write_columns.add(Route(c))
+            for r in (self.find_keep_columns(c) if isinstance(c, ColumnCollection) else {Route(c)}):
+                if r.has_tag("skip"):
+                    skip_columns.add(r.column)
+                else:
+                    write_columns.add(r)
+        write_columns = {
+            r for r in write_columns
+            if not law.util.multi_match(r.column, skip_columns, mode=any)
+        }
         route_filter = RouteFilter(write_columns)
 
         # define columns that need to be read


### PR DESCRIPTION
We define columns to keep in the `ReduceEvents`, `MergeSelectionMasks`, and `UniteColumns` tasks through the config aux entry `keep_columns: dict[task_family, set]`. A while ago, we introduced `CollumnCollection`'s, which allow to mark all columns created by e.g. the selector as being kept. However, now we ran into cases where we want to store all columns **except** some specific ones.

We treat columns as `Route` objects that can have tags, and we already consider these tags when e.g. defining "optional" columns (in CSP's `uses` and `produces` sets). This PR adds a helper to create routes being tagged `"skip"`. Simultaneously, the three tasks mentioned above now take these tagged routes into account when evaluating the set of columns to actually keep.