### PR TITLE
correct bug in normalization setup when no cross section is available for a process

### DIFF
--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -111,8 +111,10 @@ def normalization_weights_setup(
         sum_weights_table[0, int(process_id)] = sum_weights
     self.sum_weights_table = sum_weights_table
 
-    # create a cross section lookup table with all known processes
+    # create a cross section lookup table with all known processes with a cross section
     xs_table = sp.sparse.lil_matrix((1, max_id + 1), dtype=np.float32)
     for process_inst in process_insts:
+        if self.config_inst.campaign.ecm not in process_inst.xsecs.keys():
+            continue
         xs_table[0, process_inst.id] = process_inst.get_xsec(self.config_inst.campaign.ecm).nominal
     self.xs_table = xs_table


### PR DESCRIPTION
add process to lookup table only if process has a cross section