### PR TITLE
Improve process settings handling.

### DIFF
--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -57,7 +57,7 @@ def get_cms_label(ax: plt.Axes, llabel: str) -> dict:
 
 def apply_settings(
     instances: Iterable[od.AuxDataMixin],
-    settings: dict[dict, Any] | None,
+    settings: dict[str, Any] | None,
     parent_check: Callable[[od.AuxDataMixin, str], bool] | None = None,
 ) -> None:
     """
@@ -111,9 +111,9 @@ def apply_process_settings(
 
 
 def apply_variable_settings(
-        hists: dict,
-        variable_insts: list[od.Variable],
-        variable_settings: dict | None = None,
+    hists: dict,
+    variable_insts: list[od.Variable],
+    variable_settings: dict | None = None,
 ) -> dict:
     """
     applies settings from *variable_settings* dictionary to the *variable_insts*;

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -6,8 +6,6 @@ Some utils for plot functions.
 
 from __future__ import annotations
 
-from columnflow.types import Iterable, Any
-
 import operator
 import functools
 from collections import OrderedDict
@@ -15,12 +13,14 @@ from collections import OrderedDict
 import order as od
 
 from columnflow.util import maybe_import, try_int, try_complex
+from columnflow.types import Iterable, Any, Callable
 
 math = maybe_import("math")
 hist = maybe_import("hist")
 np = maybe_import("numpy")
 plt = maybe_import("matplotlib.pyplot")
 mplhep = maybe_import("mplhep")
+
 
 label_options = {
     "wip": "Work in progress",
@@ -55,7 +55,11 @@ def get_cms_label(ax: plt.Axes, llabel: str) -> dict:
     return cms_label_kwargs
 
 
-def apply_settings(containers: Iterable[od.AuxDataMixin], settings: dict[dict, Any] | None):
+def apply_settings(
+    instances: Iterable[od.AuxDataMixin],
+    settings: dict[dict, Any] | None,
+    parent_check: Callable[[od.AuxDataMixin, str], bool] | None = None,
+) -> None:
     """
     applies settings from `settings` dictionary to a list of order objects `containers`
 
@@ -64,17 +68,20 @@ def apply_settings(containers: Iterable[od.AuxDataMixin], settings: dict[dict, A
         to the name of a container and each value should be a dictionary. The inner dictionary contains
         keys and values that will be applied on the corresponding container either as an attribute
         or alternatively as an auxiliary.
+    :param parent_check: optional function that checks if a container has a parent with a given name
     """
     if not settings:
         return
 
-    for inst in containers:
-        inst_settings = settings.get(inst.name, {})
-        for setting_key, setting_value in inst_settings.items():
-            try:
-                setattr(inst, setting_key, setting_value)
-            except AttributeError:
-                inst.set_aux(setting_key, setting_value)
+    for inst in instances:
+        for name, inst_settings in (settings or {}).items():
+            if inst != name and not (callable(parent_check) and parent_check(inst, name)):
+                continue
+            for key, value in inst_settings.items():
+                try:
+                    setattr(inst, key, value)
+                except AttributeError:
+                    inst.set_aux(key, value)
 
 
 def apply_process_settings(
@@ -86,8 +93,11 @@ def apply_process_settings(
     the `scale` setting is directly applied to the histograms
     """
     # apply all settings on process insts
-    process_insts = hists.keys()
-    apply_settings(process_insts, process_settings)
+    apply_settings(
+        hists.keys(),
+        process_settings,
+        parent_check=(lambda proc, parent_name: proc.has_parent_process(parent_name)),
+    )
 
     # apply "scale" setting directly to the hists
     for proc_inst, h in hists.items():
@@ -95,8 +105,7 @@ def apply_process_settings(
         if try_int(scale_factor):
             scale_factor = int(scale_factor)
             hists[proc_inst] = h * scale_factor
-            # TODO: there might be a prettier way for the label
-            proc_inst.label = f"{proc_inst.label} x{scale_factor}"
+            proc_inst.label += f" x{scale_factor}"
 
     return hists
 

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -63,12 +63,11 @@ def apply_settings(
     """
     applies settings from `settings` dictionary to a list of order objects `containers`
 
-    :param containers: list of order objects
-    :param settings: dictionary of settings to apply on the *containers*. Each key should correspond
-        to the name of a container and each value should be a dictionary. The inner dictionary contains
-        keys and values that will be applied on the corresponding container either as an attribute
-        or alternatively as an auxiliary.
-    :param parent_check: optional function that checks if a container has a parent with a given name
+    :param instances: List of order instances to apply settings to.
+    :param settings: Dictionary of settings to apply on the instances. Each key should correspond
+        to the name of an instance and each value should be a dictionary with attributes that will
+        be set on the instance either as a attribute or as an auxiliary.
+    :param parent_check: Function that checks if an instance has a parent with a given name.
     """
     if not settings:
         return
@@ -78,9 +77,10 @@ def apply_settings(
             if inst != name and not (callable(parent_check) and parent_check(inst, name)):
                 continue
             for key, value in inst_settings.items():
+                # try attribute first, otherwise auxiliary entry
                 try:
                     setattr(inst, key, value)
-                except AttributeError:
+                except (AttributeError, ValueError):
                     inst.set_aux(key, value)
 
 

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -9,6 +9,7 @@ from abc import abstractmethod
 
 import law
 import luigi
+import order as od
 
 from columnflow.tasks.framework.base import Requirements, ShiftTask
 from columnflow.tasks.framework.mixins import (
@@ -91,7 +92,21 @@ class PlotVariablesBase(
             for proc in process_insts
         }
 
-        # histogram data per process
+        # copy process instances once so that their auxiliary data fields can be used as a storage
+        # for process-specific plot parameters later on in plot scripts without affecting the
+        # original instances
+        fake_root = od.Process(
+            name=f"{hex(id(object()))[2:]}",
+            id="+",
+            processes=process_insts,
+        ).copy()
+        process_inst_copies = {
+            process_inst.name: process_inst
+            for process_inst in fake_root.processes
+        }
+        fake_root.processes.clear()
+
+        # histogram data per process copy
         hists = {}
 
         with self.publish_step(f"plotting {self.branch_data.variable} in {category_inst.name}"):
@@ -130,24 +145,26 @@ class PlotVariablesBase(
                     # axis reductions
                     h = h[{"process": sum, "category": sum}]
 
-                    # add the histogram
-                    if process_inst in hists:
-                        hists[process_inst] += h
+                    # add the histogram, stored using process instance copies as keys
+                    process_inst_copy = process_inst_copies[process_inst.name]
+                    if process_inst_copy in hists:
+                        hists[process_inst_copy] += h
                     else:
-                        hists[process_inst] = h
+                        hists[process_inst_copy] = h
 
             # there should be hists to plot
             if not hists:
                 raise Exception(
-                    "no histograms found to plot; possible reasons:\n" +
-                    "  - requested variable requires columns that were missing during histogramming\n" +
+                    "no histograms found to plot; possible reasons:\n"
+                    "  - requested variable requires columns that were missing during histogramming\n"
                     "  - selected --processes did not match any value on the process axis of the input histogram",
                 )
 
             # sort hists by process order
+            process_order = list(process_inst_copies.values())
             hists = OrderedDict(
-                (process_inst.copy_shallow(), hists[process_inst])
-                for process_inst in sorted(hists, key=process_insts.index)
+                (process_inst, hists[process_inst])
+                for process_inst in sorted(hists, key=process_order.index)
             )
 
             # call the plot function

--- a/docs/user_guide/plotting.md
+++ b/docs/user_guide/plotting.md
@@ -89,7 +89,7 @@ the task parameters are discussed in separate sections for each type of plotting
 Per default, the ```PlotVariables1D``` task creates one plot
 per variable with all Monte Carlo processes being included
 in a stack and data being shown as separate points. The bottom subplot shows the ratio between signal
-and all processes included in the stack and can be disabled via the ```--skip_ratio``` parameter.
+and all processes included in the stack and can be disabled via the ```--skip-ratio``` parameter.
 To change the text next to the label, you can add the ```--cms-label``` parameter.
 :::{dropdown} What are the ```cms-label``` options?
 In general, this parameter accepts all types of strings, but there is a set of shortcuts for commonly
@@ -300,9 +300,9 @@ law run cf.PlotCutflowVariables1D --version v1 \
 :::
 ::::
 
-The ```per-plot``` parameter defines whether to produce one plot per selector step
-(```per-plot processes```) or one plot per process (```per-plot steps```).
-For the ```per-plot steps``` option, try the following task call:
+The ```--per-plot``` parameter defines whether to produce one plot per selector step
+(```--per-plot processes```) or one plot per process (```--per-plot steps```).
+For the ```--per-plot steps``` option, try the following task call:
 
 ```shell
 law run cf.PlotCutflowVariables1D --version v1 \
@@ -325,7 +325,7 @@ law run cf.PlotCutflowVariables1D --version v1 \
 ## Creating plots for different shifts
 
 Like most tasks, our plotting tasks also contain the ```--shift``` parameter that allows requesting
-the outputs for a certain type of systematic variation. Per default, the ```shift``` parameter is set
+the outputs for a certain type of systematic variation. Per default, the ```--shift``` parameter is set
 to "nominal", but you could also produce your plot with a certain systematic uncertainty varied
 up or down, e.g. via running
 ```shell


### PR DESCRIPTION
This PR slightly changes how process settings are applied during plotting.

Currently, the process name used in the process settings parameter for plotting, e.g. `--process-settings "hh_ggf_hbb_htt_kl1_kt1,unstack"`, requires that the process name matches exactly the name of the process that is plotted.

However, it would be nice if we could rely on the processes' parent-child relations to assign these settings, especially not to be forced to always remember the sometimes long-ish process names. In the example above, if one knows that there's no other hh processes contributing to the plot, a simple `--process-settings "hh,unstack"` should do the trick.

With the changes in this PR, this is now possible.