### PR TITLE
Add mechanism to hook into histograms (e.g. for ABCD methods)

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -118,7 +118,6 @@ cfg.x.default_inference_model = "example"
 cfg.x.default_categories = ("incl",)
 cfg.x.default_variables = ("n_jet", "jet1_pt")
 
-
 # process groups for conveniently looping over certain processs
 # (used in wrapper_factory and during plotting)
 cfg.x.process_groups = {}
@@ -172,7 +171,6 @@ cfg.x.producer_groups = {}
 # ml_model groups for conveniently looping over certain ml_models
 # (used during the machine learning tasks)
 cfg.x.ml_model_groups = {}
-
 
 # custom method and sandbox for determining dataset lfns
 cfg.x.get_dataset_lfns = None
@@ -268,6 +266,9 @@ cfg.x.versions = {}
 # channels
 # (just one for now)
 cfg.add_channel(name="mutau", id=1)
+
+# histogramming hooks, invoked before creating plots when --hist-hook parameter set
+cfg.x.hist_hooks = {}
 
 # add categories using the "add_category" tool which adds auto-generated ids
 # the "selection" entries refer to names of categorizers, e.g. in categorization/example.py

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -309,7 +309,7 @@ class PlotCutflow(
 
     def plot_parts(self) -> law.util.InsertableDict:
         parts = super().plot_parts()
-        parts["category"] = self.branch_data
+        parts["category"] = f"cat_{self.branch_data}"
         return parts
 
     def output(self):

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -616,8 +616,8 @@ class PlotCutflowVariables1D(
 
     def plot_parts(self) -> law.util.InsertableDict:
         parts = super().plot_parts()
-        parts["category"] = self.branch_data.category
-        parts["variable"] = self.branch_data.variable
+        parts["category"] = f"cat_{self.branch_data.category}"
+        parts["variable"] = f"var_{self.branch_data.variable}"
         return parts
 
     def output(self):

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -711,8 +711,8 @@ class PlotCutflowVariables2D(
     def plot_parts(self) -> law.util.InsertableDict:
         parts = super().plot_parts()
         parts["processes"] = self.processes_repr
-        parts["category"] = self.branch_data.category
-        parts["variable"] = self.branch_data.variable
+        parts["category"] = f"cat_{self.branch_data.category}"
+        parts["variable"] = f"var_{self.branch_data.variable}"
         return parts
 
     def output(self):

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -307,21 +307,35 @@ class PlotCutflow(
             for d in self.datasets
         }
 
+    def plot_parts(self) -> law.util.InsertableDict:
+        parts = super().plot_parts()
+        parts["category"] = self.branch_data
+        return parts
+
     def output(self):
-        return {"plots": [
-            self.target(name)
-            for name in self.get_plot_names(f"cutflow__cat_{self.branch_data}")
-        ]}
+        return {
+            "plots": [self.target(name) for name in self.get_plot_names("cutflow")],
+        }
 
     @law.decorator.log
     @view_output_plots
     def run(self):
         import hist
 
+        # copy process instances once so that their auxiliary data fields can be used as a storage
+        # for process-specific plot parameters later on in plot scripts without affecting the
+        # original instances
+        fake_root = od.Process(
+            name=f"{hex(id(object()))[2:]}",
+            id="+",
+            processes=list(map(self.config_inst.get_process, self.processes)),
+        ).copy()
+        process_insts = list(fake_root.processes)
+        fake_root.processes.clear()
+
         # prepare config objects
         category_inst = self.config_inst.get_category(self.branch_data)
         leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
-        process_insts = list(map(self.config_inst.get_process, self.processes))
         sub_process_insts = {
             proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
             for proc in process_insts
@@ -343,28 +357,22 @@ class PlotCutflow(
                 # loop and extract one histogram per process
                 for process_inst in process_insts:
                     # skip when the dataset is already known to not contain any sub process
-                    if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
+                    if not any(
+                        dataset_inst.has_process(sub_process_inst.name)
+                        for sub_process_inst in sub_process_insts[process_inst]
+                    ):
                         continue
 
-                    # work on a copy
+                    # select processes and reduce axis
                     h = h_in.copy()
-
-                    # axis selections
                     h = h[{
                         "process": [
                             hist.loc(p.id)
                             for p in sub_process_insts[process_inst]
                             if p.id in h.axes["process"]
                         ],
-                        "category": [
-                            hist.loc(c.id)
-                            for c in leaf_category_insts
-                            if c.id in h.axes["category"]
-                        ],
                     }]
-
-                    # axis reductions
-                    h = h[{"process": sum, "category": sum, self.variable: sum}]
+                    h = h[{"process": sum}]
 
                     # add the histogram
                     if process_inst in hists:
@@ -376,11 +384,23 @@ class PlotCutflow(
             if not hists:
                 raise Exception("no histograms found to plot")
 
-            # sort hists by process order
-            hists = OrderedDict(
-                (process_inst.copy_shallow(), hists[process_inst])
-                for process_inst in sorted(hists, key=process_insts.index)
-            )
+            # axis selections and reductions, including sorting by process order
+            _hists = OrderedDict()
+            for process_inst in sorted(hists, key=process_insts.index):
+                h = hists[process_inst]
+                # selections
+                h = h[{
+                    "category": [
+                        hist.loc(c.id)
+                        for c in leaf_category_insts
+                        if c.id in h.axes["category"]
+                    ],
+                }]
+                # reductions
+                h = h[{"category": sum, self.variable: sum}]
+                # store
+                _hists[process_inst] = h
+            hists = _hists
 
             # call the plot function
             fig, _ = self.call_plot_func(
@@ -480,7 +500,18 @@ class PlotCutflowVariablesBase(
     def run(self):
         import hist
 
-        # prepare config objects
+        # copy process instances once so that their auxiliary data fields can be used as a storage
+        # for process-specific plot parameters later on in plot scripts without affecting the
+        # original instances
+        fake_root = od.Process(
+            name=f"{hex(id(object()))[2:]}",
+            id="+",
+            processes=list(map(self.config_inst.get_process, self.processes)),
+        ).copy()
+        process_insts = list(fake_root.processes)
+        fake_root.processes.clear()
+
+        # prepare other config objects
         variable_tuple = self.variable_tuples[self.branch_data.variable]
         variable_insts = [
             self.config_inst.get_variable(var_name)
@@ -488,25 +519,10 @@ class PlotCutflowVariablesBase(
         ]
         category_inst = self.config_inst.get_category(self.branch_data.category)
         leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
-        process_insts = list(map(self.config_inst.get_process, self.processes))
         sub_process_insts = {
-            proc: [sub for sub, _, _ in proc.walk_processes(include_self=True)]
-            for proc in process_insts
+            process_inst: [sub for sub, _, _ in process_inst.walk_processes(include_self=True)]
+            for process_inst in process_insts
         }
-
-        # copy process instances once so that their auxiliary data fields can be used as a storage
-        # for process-specific plot parameters later on in plot scripts without affecting the
-        # original instances
-        fake_root = od.Process(
-            name=f"{hex(id(object()))[2:]}",
-            id="+",
-            processes=process_insts,
-        ).copy()
-        process_inst_copies = {
-            process_inst.name: process_inst
-            for process_inst in fake_root.processes
-        }
-        fake_root.processes.clear()
 
         # histogram data per process copy
         hists = {}
@@ -524,46 +540,50 @@ class PlotCutflowVariablesBase(
                 # loop and extract one histogram per process
                 for process_inst in process_insts:
                     # skip when the dataset is already known to not contain any sub process
-                    if not any(map(dataset_inst.has_process, sub_process_insts[process_inst])):
+                    if not any(
+                        dataset_inst.has_process(sub_process_inst.name)
+                        for sub_process_inst in sub_process_insts[process_inst]
+                    ):
                         continue
 
-                    # work on a copy
+                    # select processes and reduce axis
                     h = h_in.copy()
-
-                    # axis selections
                     h = h[{
                         "process": [
                             hist.loc(p.id)
                             for p in sub_process_insts[process_inst]
                             if p.id in h.axes["process"]
                         ],
-                        "category": [
-                            hist.loc(c.id)
-                            for c in leaf_category_insts
-                            if c.id in h.axes["category"]
-                        ],
                     }]
+                    h = h[{"process": sum}]
 
-                    # axis reductions
-                    h = h[{"process": sum, "category": sum}]
-
-                    # add the histogram, stored using process instance copies as keys
-                    process_inst_copy = process_inst_copies[process_inst.name]
-                    if process_inst_copy in hists:
-                        hists[process_inst_copy] += h
+                    # add the histogram
+                    if process_inst in hists:
+                        hists[process_inst] += h
                     else:
-                        hists[process_inst_copy] = h
+                        hists[process_inst] = h
 
             # there should be hists to plot
             if not hists:
                 raise Exception("no histograms found to plot")
 
-            # sort hists by process order
-            process_order = list(process_inst_copies.values())
-            hists = OrderedDict(
-                (process_inst, hists[process_inst])
-                for process_inst in sorted(hists, key=process_order.index)
-            )
+            # axis selections and reductions, including sorting by process order
+            _hists = OrderedDict()
+            for process_inst in sorted(hists, key=process_insts.index):
+                h = hists[process_inst]
+                # selections
+                h = h[{
+                    "category": [
+                        hist.loc(c.id)
+                        for c in leaf_category_insts
+                        if c.id in h.axes["category"]
+                    ],
+                }]
+                # reductions
+                h = h[{"category": sum}]
+                # store
+                _hists[process_inst] = h
+            hists = _hists
 
             # call a postprocess function that produces outputs based on the implementation of the daughter task
             self.run_postprocess(
@@ -579,9 +599,8 @@ class PlotCutflowVariables1D(
 ):
     plot_function = PlotBase.plot_function.copy(
         default=law.NO_STR,
-        description=(
-            PlotBase.plot_function.description + "; the default is resolved based on the --per-plot parameter."
-        ),
+        description=PlotBase.plot_function.description + "; the default is resolved based on the "
+        "--per-plot parameter",
         allow_empty=True,
     )
     plot_function_processes = "columnflow.plotting.plot_functions_1d.plot_variable_per_process"
@@ -595,25 +614,32 @@ class PlotCutflowVariables1D(
         "default: processes",
     )
 
+    def plot_parts(self) -> law.util.InsertableDict:
+        parts = super().plot_parts()
+        parts["category"] = self.branch_data.category
+        parts["variable"] = self.branch_data.variable
+        return parts
+
     def output(self):
-        b = self.branch_data
         if self.per_plot == "processes":
-            return {"plots": law.SiblingFileCollection({
-                s: [
-                    self.local_target(name) for name in self.get_plot_names(
-                        f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}",
-                    )
-                ]
-                for i, s in enumerate(self.chosen_steps)
-            })}
-        else:  # per_plot == "steps"
-            return {"plots": law.SiblingFileCollection({
-                p: [
-                    self.local_target(name)
-                    for name in self.get_plot_names(f"plot__proc_{p}__cat_{b.category}__var_{b.variable}")
-                ]
+            return {
+                "plots": law.SiblingFileCollection({
+                    s: [
+                        self.local_target(name) for name in self.get_plot_names(
+                            f"plot__step{i}_{s}__proc_{self.processes_repr}",
+                        )
+                    ]
+                    for i, s in enumerate(self.chosen_steps)
+                }),
+            }
+
+        # per_plot == "steps"
+        return {
+            "plots": law.SiblingFileCollection({
+                p: [self.local_target(name) for name in self.get_plot_names(f"plot__proc_{p}")]
                 for p in self.processes
-            })}
+            }),
+        }
 
     def run_postprocess(self, hists, category_inst, variable_insts):
         # resolve plot function
@@ -682,16 +708,20 @@ class PlotCutflowVariables2D(
         add_default_to_description=True,
     )
 
+    def plot_parts(self) -> law.util.InsertableDict:
+        parts = super().plot_parts()
+        parts["processes"] = self.processes_repr
+        parts["category"] = self.branch_data.category
+        parts["variable"] = self.branch_data.variable
+        return parts
+
     def output(self):
-        b = self.branch_data
-        return {"plots": law.SiblingFileCollection({
-            s: [
-                self.local_target(name) for name in self.get_plot_names(
-                    f"plot__step{i}_{s}__proc_{self.processes_repr}__cat_{b.category}__var_{b.variable}",
-                )
-            ]
-            for i, s in enumerate(self.chosen_steps)
-        })}
+        return {
+            "plots": law.SiblingFileCollection({
+                s: [self.local_target(name) for name in self.get_plot_names(f"plot__step{i}_{s}")]
+                for i, s in enumerate(self.chosen_steps)
+            }),
+        }
 
     def run_postprocess(self, hists, category_inst, variable_insts):
         import hist

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -104,19 +104,29 @@ class PlotBase(ConfigTask):
         dict_add_strict(params, "custom_style_config", self.custom_style_config)
         return params
 
+    def plot_parts(self) -> law.util.InsertableDict:
+        """
+        Returns a sorted, insertable dictionary containing all parts that make up the name of a
+        plot file.
+        """
+        return law.util.InsertableDict()
+
     def get_plot_names(self, name: str) -> list[str]:
         """
         Returns a list of basenames for created plots given a file *name* for all configured file
         types, plus the additional plot suffix.
         """
-        suffix = ""
-        if self.plot_suffix and self.plot_suffix != law.NO_STR:
-            suffix = f"__{self.plot_suffix}"
+        # get plot parts
+        parts = self.plot_parts()
 
-        return [
-            f"{name}{suffix}.{ft}"
-            for ft in self.file_types
-        ]
+        # add the plot_suffix if not already present
+        if "suffix" not in parts and self.plot_suffix not in ("", law.NO_STR, None):
+            parts["suffix"] = self.plot_suffix
+
+        # build the full name
+        full_name = "__".join(map(str, [name] + list(parts.values())))
+
+        return [f"{full_name}.{ft}" for ft in self.file_types]
 
     def get_plot_func(self, func_name: str) -> Callable:
         """


### PR DESCRIPTION
This PR introduces a mechanism to hook into the creation (or rather usage) of histograms, with scenarios in mind that should cover ABCD methods.

In addition, the way that produced plot files are named is improved as well, since this was required by the addition of hist hooks (more below).

### Hist hooks

A hist hook can be defined in the new aux entry `hist_hooks` of the config.

```python
def example_hook(
    task: AnalysisTask,
    hists: dict[od.Process, hist.Hist],
) -> dict[od.Process, hist.Hist]:
    # add new objects to hists and return it
    return hists


cfg.x.hist_hooks = {
    "example": example_hook,
}
```

Now, all non-cutflow plot tasks support a parameter `--hist-hook NAME` which can trigger the specified hook right before the plotting function is invoked, and also right before certain axis are projected or selected. In the example of the `cf.PlotVariables1D`, the histograms being passed to the hook still contain the `category` and, optionally, the `shift` axes.

This way, hist hooks can easily be used to inject new histograms from data-driven background estimations based on existing histograms.

A trivial example in which a process "QCD" should be estimated as half of the "tt" contribution would look like:

```python
def example_hook(
    task: AnalysisTask,
    hists: dict[od.Process, hist.Hist],
) -> dict[od.Process, hist.Hist]:
    # create a new "QCD" process, if not already done in the config itself
    import order as od
    qcd = od.Process("qcd", id="+", label="QCD", color1=(244, 93, 66))

    # create the qcd shape
    tt_hist = hists[self.config_inst.processes.n.tt]
    hists[qcd] = tt_hist * 0.5

    return hists
```


### Plot parts

Since the above mechanism introduces yet another optional parameter that should be included in the output name when set, I added a `plot_parts()` interface, similar to what we already do with `store_parts()`. `plot_parts()`, however, only define which parts are written in the file name itself, separated by two underscores as was done manually before.