### PR TITLE
Linting the docs :)

### DIFF
--- a/.markdownlint
+++ b/.markdownlint
@@ -2,3 +2,9 @@ plugins:
   # disable max line length
   md013:
     enabled: False
+  md033:
+    allowed_elements: "!--,![CDATA[,!DOCTYPE,table,h1,p,img"
+  md026:
+    punctuation: ".,;!。，；！"
+  md001:
+    enabled: False

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
-<!-- marker-before-logo -->
-
-<p align="center">
+<h1 align="center">
   <img src="https://media.githubusercontent.com/media/columnflow/columnflow/master/assets/logo_dark.png#gh-light-mode-only" width="480" />
   <img src="https://media.githubusercontent.com/media/columnflow/columnflow/master/assets/logo_bright.png#gh-dark-mode-only" width="480" />
-</p>
-
-<!-- marker-after-logo -->
+</h1>
 
 <!-- marker-before-badges -->
 
@@ -68,7 +64,7 @@ bash -c "$(curl -Ls https://raw.githubusercontent.com/columnflow/columnflow/mast
 
 At the end of the setup, you will see further instructions and suggestions to run your first analysis tasks (example below).
 
-```
+```text
 Setup successfull! The next steps are:
 
 1. Setup the repository and install the environment.
@@ -107,7 +103,6 @@ Setup successfull! The next steps are:
 
 For a better overview of the tasks that are triggered by the commands below, checkout the current (yet stylized) [task graph](https://github.com/columnflow/columnflow/wiki#default-task-graph).
 
-
 ## Projects using columnflow
 
 - [hh2bbtautau](https://github.com/uhh-cms/hh2bbtautau): HH → bb𝜏𝜏 analysis with CMS.
@@ -115,7 +110,6 @@ For a better overview of the tasks that are triggered by the commands below, che
 - [topmass](https://github.com/uhh-cms/topmass): Top quark mass measurement with CMS.
 - [mttbar](https://github.com/uhh-cms/mttbar): Search for heavy resonances in ttbar events with CMS.
 - [analysis playground](https://github.com/uhh-cms/analysis_playground): A testing playground for HEP analyses.
-
 
 ## Contributors
 
@@ -150,7 +144,6 @@ For a better overview of the tasks that are triggered by the commands below, che
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.
-
 
 ## Development
 

--- a/analysis_templates/cms_minimal/README.md
+++ b/analysis_templates/cms_minimal/README.md
@@ -1,6 +1,5 @@
 # __cf_analysis_name__ Analysis
 
-
 ### Resources
 
 - [columnflow](https://github.com/uhh-cms/columnflow)

--- a/analysis_templates/cms_minimal/README.md
+++ b/analysis_templates/cms_minimal/README.md
@@ -2,7 +2,7 @@
 
 ### Resources
 
-- [columnflow](https://github.com/uhh-cms/columnflow)
+- [columnflow](https://github.com/columnflow/columnflow/)
 - [law](https://github.com/riga/law)
 - [order](https://github.com/riga/order)
 - [luigi](https://github.com/spotify/luigi)

--- a/docs/api/plotting/index.rst
+++ b/docs/api/plotting/index.rst
@@ -6,3 +6,12 @@
    :autosummary:
    :members:
    :undoc-members:
+
+
+.. toctree::
+   :maxdepth: 1
+
+   plot_all
+   plot_functions_1d
+   plot_functions_2d
+   plot_util

--- a/docs/api/production/cms.rst
+++ b/docs/api/production/cms.rst
@@ -1,7 +1,0 @@
-``production.cms``
-==================
-
-.. toctree:: 
-   :maxdepth: 1
-   
-   muon

--- a/docs/api/production/muon.rst
+++ b/docs/api/production/muon.rst
@@ -1,8 +1,0 @@
-``muon``
-========
-
-.. currentmodule:: columnflow.production.cms.muon
-.. automodule:: columnflow.production.cms.muon
-    :autosummary:
-    :members:
-    :undoc-members:

--- a/docs/task_overview/introduction.md
+++ b/docs/task_overview/introduction.md
@@ -36,50 +36,50 @@ the name of the dataset to be searched for, as defined in the analysis config is
 task to run.
 
 - {py:class}`~columnflow.tasks.calibration.CalibrateEvents`: Task to implement corrections to be
-applied on the datasets, e.g. jet-energy corrections. This task uses objects of the
-{py:class}`~columnflow.calibration.Calibrator` class to apply the calibration. The argument
-```--calibrator``` followed by the name of the Calibrator
-object to be run is needed for this task to run. A default value for this argument can be set in
-the analysis config. Similarly, the ```--shift``` argument can be given, in order to choose which
-corrections are to be used, e.g. which variation (up, down, nominal) of the jet-energy corrections
-are to be used.
+    applied on the datasets, e.g. jet-energy corrections. This task uses objects of the
+    {py:class}`~columnflow.calibration.Calibrator` class to apply the calibration. The argument
+    ```--calibrator``` followed by the name of the Calibrator
+    object to be run is needed for this task to run. A default value for this argument can be set in
+    the analysis config. Similarly, the ```--shift``` argument can be given, in order to choose which
+    corrections are to be used, e.g. which variation (up, down, nominal) of the jet-energy corrections
+    are to be used.
 
 - {py:class}`~columnflow.tasks.selection.SelectEvents`: Task to implement selections to be applied
-on the datssets. This task uses objects of the {py:class}`~columnflow.selection.Selector` class to
-apply the selection. The output are masks for the events and objects to be selected, saved in a
-parquet file, and some additional parameters stored in a dictionary format, like the statistics of
-the selection (which are needed for the plotting tasks further down the task tree), saved in a json
-file. The mask are not applied to the columns during this task.
-The argument ```--selector``` followed by the name of the
-Selector object to be run is needed for this task to run.
-A default value for this argument can be set in the analysis config. From this task on, the
-```--calibrator``` argument is replaced by ```--calibrators```.
+    on the datssets. This task uses objects of the {py:class}`~columnflow.selection.Selector` class to
+    apply the selection. The output are masks for the events and objects to be selected, saved in a
+    parquet file, and some additional parameters stored in a dictionary format, like the statistics of
+    the selection (which are needed for the plotting tasks further down the task tree), saved in a json
+    file. The mask are not applied to the columns during this task.
+    The argument ```--selector``` followed by the name of the
+    Selector object to be run is needed for this task to run.
+    A default value for this argument can be set in the analysis config. From this task on, the
+    ```--calibrator``` argument is replaced by ```--calibrators```.
 
 - {py:class}`~columnflow.tasks.reduction.ReduceEvents`: Task to apply the masks created in
-{py:class}`~columnflow.tasks.selection.SelectEvents` on the datasets. All
-tasks below ReduceEvents in the task graph use the parquet
-file resulting from ReduceEvents to work on, not the
-original dataset. The columns to be conserved after
-ReduceEvents are to be given in the analysis config under
-the ```config.x.keep_columns``` argument in a ```DotDict``` structure
-(from {py:mod}`~columnflow.util`).
+    {py:class}`~columnflow.tasks.selection.SelectEvents` on the datasets. All
+    tasks below ReduceEvents in the task graph use the parquet
+    file resulting from ReduceEvents to work on, not the
+    original dataset. The columns to be conserved after
+    ReduceEvents are to be given in the analysis config under
+    the ```config.x.keep_columns``` argument in a ```DotDict``` structure
+    (from {py:mod}`~columnflow.util`).
 
 - {py:class}`~columnflow.tasks.production.ProduceColumns`: Task to produce additional columns for
-the reduced datasets, e.g. for new high level variables. This task uses objects of the
-{py:class}`~columnflow.production.Producer` class to create the new columns. The new columns are
-saved in a parquet file that can be used by the task below on the task graph. The argument
-```--producer``` followed by the name of the Producer object
-to be run is needed for this task to run. A default value for this argument can be set in the
-analysis config.
+    the reduced datasets, e.g. for new high level variables. This task uses objects of the
+    {py:class}`~columnflow.production.Producer` class to create the new columns. The new columns are
+    saved in a parquet file that can be used by the task below on the task graph. The argument
+    ```--producer``` followed by the name of the Producer object
+    to be run is needed for this task to run. A default value for this argument can be set in the
+    analysis config.
 
 - {py:class}`~columnflow.tasks.ml.PrepareMLEvents`, {py:class}`~columnflow.tasks.ml.MLTraining`,
-{py:class}`~columnflow.tasks.ml.MLEvaluation`: Tasks to
-train, evaluate neural networks and plot (to be implemented) their results.
+    {py:class}`~columnflow.tasks.ml.MLEvaluation`: Tasks to
+    train, evaluate neural networks and plot (to be implemented) their results.
 
 - {py:class}`~columnflow.tasks.histograms.CreateHistograms`: Task to create histograms with the
-python package [Hist](https://hist.readthedocs.io/en/latest/) which can be used by the tasks below
-in the task graph. From this task on, the ```--producer``` argument is replaced by
-```--producers```. The histograms are saved in a pickle file.
+    python package [Hist](https://hist.readthedocs.io/en/latest/) which can be used by the tasks below
+    in the task graph. From this task on, the ```--producer``` argument is replaced by
+    ```--producers```. The histograms are saved in a pickle file.
 
 - {py:class}`~columnflow.tasks.cms.inference.CreateDatacards`: TODO
 

--- a/docs/task_overview/introduction.md
+++ b/docs/task_overview/introduction.md
@@ -2,98 +2,69 @@
 
 This page gives a small overview of the current tasks available by default in columnflow.
 
-In general (at least for people working in the CMS experiment),
-using columnflow requires a grid proxy, as the
-dataset files are accessed through it. The grid proxy should be activated after the setup of the
-default environment. It is however possible to create a custom law config file to be used by people
-without a grid certificate, although someone with a grid proxy must run the tasks
-{py:class}`~columnflow.tasks.external.GetDatasetLFNs` (and potentially the cms-specific
-{py:class}`~columnflow.tasks.cms.external.CreatePileUpWeights`) for them. Once these
-tasks are done, the local task outputs can be used without grid certificate by other users if
-they are able to access them with the storage location declared in the custom law config file.
-An example for such a custom config file can be found in the {doc}`examples` section of this
-documentation.
+In general (at least for people working in the CMS experiment), using columnflow requires a grid proxy, as the dataset files are accessed through it.
+The grid proxy should be activated after the setup of the default environment.
+It is however possible to create a custom law config file to be used by people without a grid certificate, although someone with a grid proxy must run the tasks {py:class}`~columnflow.tasks.external.GetDatasetLFNs` (and potentially the cms-specific {py:class}`~columnflow.tasks.cms.external.CreatePileUpWeights`) for them.
+Once these tasks are done, the local task outputs can be used without grid certificate by other users if they are able to access them with the storage location declared in the custom law config file.
+An example for such a custom config file can be found in the {doc}`examples` section of this documentation.
 
-While the name of each task is fairly descriptive of its purpose, a short introduction of the most
-important facts and parameters about each task group is provided below. As some tasks require
-others to run, the arguments for a task higher in the tree will also be required for tasks below
-in the tree (sometimes in a slightly different version, e.g. with an "s" if the task allows several
-instances of the parameter to be given at once (e.g. several dataset**s**)).
+While the name of each task is fairly descriptive of its purpose, a short introduction of the most important facts and parameters about each task group is provided below.
+As some tasks require others to run, the arguments for a task higher in the tree will also be required for tasks below in the tree (sometimes in a slightly different version, e.g. with an "s" if the task allows several instances of the parameter to be given at once (e.g. several dataset**s**)).
 
-It should be mentioned that in your analysis, the command line argument for running the columnflow
-tasks described below will contain an additional "cf."-prefix
-before the name of the task, as these are columnflow tasks and not new tasks created explicitely
-for your analysis. For example, running the {py:class}`~columnflow.tasks.selection.SelectEvents`
-task will require the following syntax:
+It should be mentioned that in your analysis, the command line argument for running the columnflow tasks described below will contain an additional "cf."-prefix before the name of the task, as these are columnflow tasks and not new tasks created explicitely for your analysis.
+For example, running the {py:class}`~columnflow.tasks.selection.SelectEvents` task will require the following syntax:
 
 ```shell
 law run cf.SelectEvents --your-parameters parameter_value
 ```
 
-- {py:class}`~columnflow.tasks.external.GetDatasetLFNs`: This task looks for the logical file names
-of the datasets to be used and saves them in a json file. The argument ```--dataset``` followed by
-the name of the dataset to be searched for, as defined in the analysis config is needed for this
-task to run.
+- {py:class}`~columnflow.tasks.external.GetDatasetLFNs`:
+This task looks for the logical file names of the datasets to be used and saves them in a json file.
+The argument ```--dataset``` followed by the name of the dataset to be searched for, as defined in the analysis config is needed for this task to run.
 
-- {py:class}`~columnflow.tasks.calibration.CalibrateEvents`: Task to implement corrections to be
-    applied on the datasets, e.g. jet-energy corrections. This task uses objects of the
-    {py:class}`~columnflow.calibration.Calibrator` class to apply the calibration. The argument
-    ```--calibrator``` followed by the name of the Calibrator
-    object to be run is needed for this task to run. A default value for this argument can be set in
-    the analysis config. Similarly, the ```--shift``` argument can be given, in order to choose which
-    corrections are to be used, e.g. which variation (up, down, nominal) of the jet-energy corrections
-    are to be used.
+- {py:class}`~columnflow.tasks.calibration.CalibrateEvents`:
+Task to implement corrections to be applied on the datasets, e.g. jet-energy corrections.
+This task uses objects of the {py:class}`~columnflow.calibration.Calibrator` class to apply the calibration.
+The argument ```--calibrator``` followed by the name of the Calibrator object to be run is needed for this task to run.
+A default value for this argument can be set in the analysis config.
+Similarly, the ```--shift``` argument can be given, in order to choose which corrections are to be used, e.g. which variation (up, down, nominal) of the jet-energy corrections are to be used.
 
-- {py:class}`~columnflow.tasks.selection.SelectEvents`: Task to implement selections to be applied
-    on the datssets. This task uses objects of the {py:class}`~columnflow.selection.Selector` class to
-    apply the selection. The output are masks for the events and objects to be selected, saved in a
-    parquet file, and some additional parameters stored in a dictionary format, like the statistics of
-    the selection (which are needed for the plotting tasks further down the task tree), saved in a json
-    file. The mask are not applied to the columns during this task.
-    The argument ```--selector``` followed by the name of the
-    Selector object to be run is needed for this task to run.
-    A default value for this argument can be set in the analysis config. From this task on, the
-    ```--calibrator``` argument is replaced by ```--calibrators```.
+- {py:class}`~columnflow.tasks.selection.SelectEvents`:
+Task to implement selections to be applied on the datssets.
+This task uses objects of the {py:class}`~columnflow.selection.Selector` class to apply the selection.
+The output are masks for the events and objects to be selected, saved in a parquet file, and some additional parameters stored in a dictionary format, like the statistics of the selection (which are needed for the plotting tasks further down the task tree), saved in a json file.
+The mask are not applied to the columns during this task.
+The argument ```--selector``` followed by the name of the Selector object to be run is needed for this task to run.
+A default value for this argument can be set in the analysis config.
+From this task on, the ```--calibrator``` argument is replaced by ```--calibrators```.
 
-- {py:class}`~columnflow.tasks.reduction.ReduceEvents`: Task to apply the masks created in
-    {py:class}`~columnflow.tasks.selection.SelectEvents` on the datasets. All
-    tasks below ReduceEvents in the task graph use the parquet
-    file resulting from ReduceEvents to work on, not the
-    original dataset. The columns to be conserved after
-    ReduceEvents are to be given in the analysis config under
-    the ```config.x.keep_columns``` argument in a ```DotDict``` structure
-    (from {py:mod}`~columnflow.util`).
+- {py:class}`~columnflow.tasks.reduction.ReduceEvents`:
+Task to apply the masks created in {py:class}`~columnflow.tasks.selection.SelectEvents` on the datasets.
+All tasks below ReduceEvents in the task graph use the parquet file resulting from ReduceEvents to work on, not the original dataset.
+The columns to be conserved after ReduceEvents are to be given in the analysis config under the ```config.x.keep_columns``` argument in a ```DotDict``` structure (from {py:mod}`~columnflow.util`).
 
-- {py:class}`~columnflow.tasks.production.ProduceColumns`: Task to produce additional columns for
-    the reduced datasets, e.g. for new high level variables. This task uses objects of the
-    {py:class}`~columnflow.production.Producer` class to create the new columns. The new columns are
-    saved in a parquet file that can be used by the task below on the task graph. The argument
-    ```--producer``` followed by the name of the Producer object
-    to be run is needed for this task to run. A default value for this argument can be set in the
-    analysis config.
+- {py:class}`~columnflow.tasks.production.ProduceColumns`:
+Task to produce additional columns for the reduced datasets, e.g. for new high level variables.
+This task uses objects of the {py:class}`~columnflow.production.Producer` class to create the new columns.
+The new columns are saved in a parquet file that can be used by the task below on the task graph.
+The argument ```--producer``` followed by the name of the Producer object to be run is needed for this task to run.
+A default value for this argument can be set in the analysis config.
 
-- {py:class}`~columnflow.tasks.ml.PrepareMLEvents`, {py:class}`~columnflow.tasks.ml.MLTraining`,
-    {py:class}`~columnflow.tasks.ml.MLEvaluation`: Tasks to
-    train, evaluate neural networks and plot (to be implemented) their results.
+- {py:class}`~columnflow.tasks.ml.PrepareMLEvents`, {py:class}`~columnflow.tasks.ml.MLTraining`, {py:class}`~columnflow.tasks.ml.MLEvaluation`:
+Tasks to train, evaluate neural networks and plot (to be implemented) their results.
 
-- {py:class}`~columnflow.tasks.histograms.CreateHistograms`: Task to create histograms with the
-    python package [Hist](https://hist.readthedocs.io/en/latest/) which can be used by the tasks below
-    in the task graph. From this task on, the ```--producer``` argument is replaced by
-    ```--producers```. The histograms are saved in a pickle file.
+- {py:class}`~columnflow.tasks.histograms.CreateHistograms`:
+Task to create histograms with the python package [Hist](https://hist.readthedocs.io/en/latest/) which can be used by the tasks below in the task graph.
+From this task on, the ```--producer``` argument is replaced by ```--producers```. The histograms are saved in a pickle file.
 
 - {py:class}`~columnflow.tasks.cms.inference.CreateDatacards`: TODO
 
-- ```Merge``` tasks (e.g. {py:class}`~columnflow.tasks.reduction.MergeReducedEvents`,
-{py:class}`~columnflow.tasks.histograms.MergeHistograms`): Tasks to merge the local outputs from
-the various occurences of the corresponding tasks.
+- ```Merge``` tasks (e.g. {py:class}`~columnflow.tasks.reduction.MergeReducedEvents`,{py:class}`~columnflow.tasks.histograms.MergeHistograms`):
+Tasks to merge the local outputs from the various occurences of the corresponding tasks.
 
-There are also CMS-specialized tasks, like
-{py:class}`~columnflow.tasks.cms.external.CreatePileUpWeights`, which are described in the
-{ref}`CMS specializations section <cms_specializations_section>`. As a note, the CreatePileUpWeights task is
-interesting from a workflow point of view as it is an example of a task required through an object
-of the {py:class}`~columnflow.production.Producer` class. This behaviour can be observed in the
-{py:meth}`~columnflow.production.cms.pileup.pu_weight_requires` method.
+There are also CMS-specialized tasks, like {py:class}`~columnflow.tasks.cms.external.CreatePileUpWeights`, which are described in the {ref}`CMS specializations section <cms_specializations_section>`.
+As a note, the CreatePileUpWeights task is interesting from a workflow point of view as it is an example of a task required through an object of the {py:class}`~columnflow.production.Producer` class.
+This behaviour can be observed in the {py:meth}`~columnflow.production.cms.pileup.pu_weight_requires` method.
 
-TODO: maybe interesting to have examples e.g. for the usage of the
-parameters for the 2d plots. Maybe in the example section, or after the next subsection, such that
-all parameters are explained? If so, at least to be mentioned here.
+TODO: maybe interesting to have examples e.g. for the usage of the parameters for the 2d plots.
+Maybe in the example section, or after the next subsection, such that all parameters are explained? If so, at least to be mentioned here.

--- a/docs/task_overview/plotting.md
+++ b/docs/task_overview/plotting.md
@@ -1,3 +1,5 @@
+# Plotting tasks
+
 ```{mermaid}
 :name: plotting-tasks
 :theme: forest
@@ -66,14 +68,13 @@ classDiagram
     }
 ```
 
-# Plotting tasks
-
 The following tasks are dedicated to plotting.
 For more information, check out the [plotting user guide](../user_guide/plotting.md)
 
- {doc}`Plotting <plotting documentation>`.
+ {doc}`Plotting <plotting documentation>`. #TODO should probably be a link to the user guide
 
 (PlotVariablesTasks)=
+
 - ```PlotVariables*```, ```PlotShiftedVariables*``` (e.g.
 {py:class}`~columnflow.tasks.plotting.PlotVariables1D`,
 {py:class}`~columnflow.tasks.plotting.PlotVariables2D`,
@@ -90,7 +91,6 @@ be plotted, as defined in the analysis config. For the ```PlotShiftedVariables*`
 argument ```shift-sources``` is needed and replaces the argument ```shift```. The output format for
 these plots can be given with the ```--file-types``` argument. It is possible to set a default for the
 variables in the analysis config.
-
 
 - ```PlotCutflow*``` (e.g. {py:class}`~columnflow.tasks.cutflow.PlotCutflow`,
 {py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D`): Tasks to plot the histograms created

--- a/docs/task_overview/plotting.rst
+++ b/docs/task_overview/plotting.rst
@@ -1,2 +1,2 @@
-.. include:: plotting.md
+.. include:: plotting_tasks.md
    :parser: myst_parser.sphinx_

--- a/docs/task_overview/plotting_tasks.md
+++ b/docs/task_overview/plotting_tasks.md
@@ -71,32 +71,19 @@ For more information, check out the [plotting user guide](../user_guide/plotting
 
 (PlotVariablesTasks)=
 
-- ```PlotVariables*```, ```PlotShiftedVariables*``` (e.g.
-{py:class}`~columnflow.tasks.plotting.PlotVariables1D`,
-{py:class}`~columnflow.tasks.plotting.PlotVariables2D`,
-{py:class}`~columnflow.tasks.plotting.PlotShiftedVariables1D`): Tasks to plot the histograms created by
-{py:class}`~columnflow.tasks.histograms.CreateHistograms` using the python package
-[matplotlib](https://matplotlib.org/) with [mplhep](https://mplhep.readthedocs.io/en/latest/) style.
-Several plot types are possible, including
-plots of variables for different physical processes or plots of variables for a single physical
-process but different shifts (e.g. jet-energy correction variations). The argument ```--variables```
-followed by the name of the variables defined in the analysis config, separated by a comma, is
-needed for these tasks to run. It is also possible to replace the ```--datasets``` argument
-for these tasks by the ```--processes``` argument followed by the name of the physical processes to
-be plotted, as defined in the analysis config. For the ```PlotShiftedVariables*``` plots, the
-argument ```shift-sources``` is needed and replaces the argument ```shift```. The output format for
-these plots can be given with the ```--file-types``` argument. It is possible to set a default for the
-variables in the analysis config.
+- ```PlotVariables*```, ```PlotShiftedVariables*``` (e.g. {py:class}`~columnflow.tasks.plotting.PlotVariables1D`, {py:class}`~columnflow.tasks.plotting.PlotVariables2D`, {py:class}`~columnflow.tasks.plotting.PlotShiftedVariables1D`):
+Tasks to plot the histograms created by {py:class}`~columnflow.tasks.histograms.CreateHistograms` using the python package [matplotlib](https://matplotlib.org/) with [mplhep](https://mplhep.readthedocs.io/en/latest/) style.
+Several plot types are possible, including plots of variables for different physical processes or plots of variables for a single physical process but different shifts (e.g. jet-energy correction variations).
+The argument ```--variables``` followed by the name of the variables defined in the analysis config, separated by a comma, is needed for these tasks to run.
+It is also possible to replace the ```--datasets``` argument for these tasks by the ```--processes``` argument followed by the name of the physical processes to be plotted, as defined in the analysis config.
+For the ```PlotShiftedVariables*``` plots, the argument ```shift-sources``` is needed and replaces the argument ```shift```.
+The output format for these plots can be given with the ```--file-types``` argument.
+It is possible to set a default for the variables in the analysis config.
 
-- ```PlotCutflow*``` (e.g. {py:class}`~columnflow.tasks.cutflow.PlotCutflow`,
-{py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D`): Tasks to plot the histograms created
-by {py:class}`~columnflow.tasks.cutflow.CreateCutflowHistograms`. The
-{py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D` are plotted in a similar way to the
-[PlotVariables*](PlotVariablesTasks) tasks. The difference is that these plots show the selection
-yields of the different selection steps defined in
-{py:class}`~columnflow.tasks.selection.SelectEvents` instead of only after the
-{py:class}`~columnflow.tasks.reduction.ReduceEvents` procedure. The selection steps to be shown
-can be chosen with the ```--selector-steps``` argument. Without further argument, the outputs are
-as much plots as the number of selector steps given. On the other hand, the
-PlotCutflow task gives a single histograms containing only
-the total event yields for each selection step given.
+- ```PlotCutflow*``` (e.g. {py:class}`~columnflow.tasks.cutflow.PlotCutflow`, {py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D`):
+Tasks to plot the histograms created by {py:class}`~columnflow.tasks.cutflow.CreateCutflowHistograms`.
+The {py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D` are plotted in a similar way to the [PlotVariables*](PlotVariablesTasks) tasks.
+The difference is that these plots show the selection yields of the different selection steps defined in {py:class}`~columnflow.tasks.selection.SelectEvents` instead of only after the {py:class}`~columnflow.tasks.reduction.ReduceEvents` procedure.
+The selection steps to be shown can be chosen with the ```--selector-steps``` argument.
+Without further argument, the outputs are as much plots as the number of selector steps given.
+On the other hand, the PlotCutflow task gives a single histograms containing only the total event yields for each selection step given.

--- a/docs/task_overview/plotting_tasks.md
+++ b/docs/task_overview/plotting_tasks.md
@@ -69,8 +69,6 @@ classDiagram
 The following tasks are dedicated to plotting.
 For more information, check out the [plotting user guide](../user_guide/plotting.md)
 
- {doc}`Plotting <../user_guide/plotting>`. #TODO should probably be a link to the user guide
-
 (PlotVariablesTasks)=
 
 - ```PlotVariables*```, ```PlotShiftedVariables*``` (e.g.
@@ -94,7 +92,7 @@ variables in the analysis config.
 {py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D`): Tasks to plot the histograms created
 by {py:class}`~columnflow.tasks.cutflow.CreateCutflowHistograms`. The
 {py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D` are plotted in a similar way to the
-["PlotVariables*"](PlotVariablesTasks) tasks. The difference is that these plots show the selection
+[PlotVariables*](PlotVariablesTasks) tasks. The difference is that these plots show the selection
 yields of the different selection steps defined in
 {py:class}`~columnflow.tasks.selection.SelectEvents` instead of only after the
 {py:class}`~columnflow.tasks.reduction.ReduceEvents` procedure. The selection steps to be shown

--- a/docs/task_overview/plotting_tasks.md
+++ b/docs/task_overview/plotting_tasks.md
@@ -1,8 +1,6 @@
 # Plotting tasks
 
 ```{mermaid}
-:name: plotting-tasks
-:theme: forest
 :zoom:
 :align: center
 :caption: Class diagram of all plotting tasks
@@ -71,7 +69,7 @@ classDiagram
 The following tasks are dedicated to plotting.
 For more information, check out the [plotting user guide](../user_guide/plotting.md)
 
- {doc}`Plotting <plotting documentation>`. #TODO should probably be a link to the user guide
+ {doc}`Plotting <../user_guide/plotting>`. #TODO should probably be a link to the user guide
 
 (PlotVariablesTasks)=
 

--- a/docs/user_guide/best_practices.md
+++ b/docs/user_guide/best_practices.md
@@ -138,18 +138,14 @@ events = self[attach_coffea_behavior](events, collections=collections, **kwargs)
 
 ## General advices
 
-- When storage space is a limiting factor, it is good practice to produce and store (if possible)
-columns only after the reduction, using the {py:class}`~columnflow.tasks.production.ProduceColumns`
-task.
+- When storage space is a limiting factor, it is good practice to produce and store (if possible) columns only after the reduction, using the {py:class}`~columnflow.tasks.production.ProduceColumns` task.
 
 ## Using python scripts removed from the standard workflow
 
-- Use a particular cf_sandbox for a python script not implemented in the columnflow workflow: Write
-`cf_sandbox venv_columnar_dev bash` on the command line.
+- Use a particular cf_sandbox for a python script not implemented in the columnflow workflow: Write `cf_sandbox venv_columnar_dev bash` on the command line.
 
-- Call tasks objects in a python script removed from the standard workflow: An imported task can
-be run through the `law_run()` command, its output can be accessed through the "output"
-function of the task. An example is given in the following code snippet.
+- Call tasks objects in a python script removed from the standard workflow: An imported task can be run through the `law_run()` command, its output can be accessed through the "output" function of the task.
+An example is given in the following code snippet.
 
 ```python
 from columnflow.tasks.selection import SelectEvents

--- a/docs/user_guide/building_blocks/categories.md
+++ b/docs/user_guide/building_blocks/categories.md
@@ -1,9 +1,9 @@
-Work in Progess! This guide has not been finalized and the presented code has not yet been tested.
-
-TODO: make the code testable
+# Categories
 
 (categories)=
-# Categories
+
+> Work in Progess! This guide has not been finalized and the presented code has not yet been tested.
+> TODO: make the code testable
 
 In columnflow, there are many tools to create a complex and flexible categorization of all analysed
 events.
@@ -13,14 +13,13 @@ be either run individually or combined into more complex categories.
 This guide presents how to implement a set of categories in columnflow and shows how to use the
 resulting categories via the {py:class}`~columnflow.tasks.yields.CreateYieldTable` task.
 
-
-
 ## Create a category
 
 If you used the analysis template to setup your analysis, there are already two categories
 included, named ```incl``` and ```2j```.
 To test that the categories are properly implemented,
 we can use the CreateYieldTable task:
+
 ```shell
 law run cf.CreateYieldTable --version v1 \
     --calibrators example --selector example --producers example \
@@ -31,22 +30,27 @@ When all tasks are finished, this should create a table presenting the event yie
 for all categories. To create new categories, we essentially need three ingredients:
 
 1. We need to define our categories as {external+order:py:class}`order.category.Category` instances in the config
-```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
-:language: python
-:start-at: add_category(
-:end-at: )
-```
+
+    ```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+    :language: python
+    :start-at: add_category(
+    :end-at: )
+    ```
+
 2. We need to write a {py:class}`~columnflow.categorization.Categorizer` that defines which events
-to select for each category. The name of the Categorizer needs to be the same as the "selection"
-attribute of the category inst.
-```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/categorization/example.py
-:language: python
-```
-Keep in mind that the module in which your define your Categorizer needs to be included in the law config
+    to select for each category. The name of the Categorizer needs to be the same as the "selection"
+    attribute of the category inst.
+
+    ```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/categorization/example.py
+    :language: python
+    ```
+
+    Keep in mind that the module in which your define your Categorizer needs to be included in the law config
 
 3. We need to run the {py:class}`~columnflow.production.categories.category_ids` Producer to create
 the ```category_ids``` column. This is directly included via the ```--producers category_ids```,
 but you could also run the ```category_ids``` Producer as part of another Selector or Producer.
+
 ```python
 @producer(
     uses={category_ids},
@@ -82,7 +86,6 @@ You can also store a list of strings in the `category_inst.selection` field. In 
 category.
 :::
 
-
 :::{dropdown} And where are the ```category_ids``` actually used?
 The `category_ids` column is primarily used when creating our histograms (e.g. in the
 {py:class}`~columnflow.tasks.histograms.CreateHistograms` task).
@@ -95,7 +98,6 @@ axis with categories to obtain all entries from the histogram corresponding to t
 that is requested via the `--categories` parameter. When the given category is not a leaf category
 but contains categories itself, the ids of all its leaf categories combined are used for the category.
 :::
-
 
 ## Creation of nested categories
 
@@ -163,7 +165,6 @@ law run cf.CreateYieldTable --version v1 \
     --processes tt,st --categories "*"
 ```
 
-
 As a next step, one might want to combine these categories to categorize based on the number of
 jets and leptons simutaneously. You could simply create all combinations by hand. The following code
 snippet shows how to combine the "2jet" and the "1lep" category:
@@ -213,7 +214,6 @@ smallest units of categories (commonly called "leaf categories") to build our pa
 example, the `2jet` category consists of the leaf categories `1e__2jet` and `1mu__2jet`. To select
 events corresponding to `2jet`, we will add all events with category ids corresponding to either
 `1e__2jet` or `1mu__2jet`.
-
 
 :::{note} We might add unexpected selections by combining categorization.
 
@@ -279,10 +279,12 @@ non_orthogonal_cat = config.add_category(
 non_orthogonal_cat.add_category(cat_2jet)
 non_orthogonal_cat.add_category(cat_geq2jet)
 ```
+
 :::::
 :::
 
 (categorization_multiple_layers)=
+
 ## Categorization with multiple layers
 
 But what should you do when the number of category combinations is getting large? For example, you might
@@ -408,7 +410,6 @@ law run cf.CreateYieldTable --version v1 \
     --processes tt,st --categories "*"
 ```
 
-
 :::{note} This categorization is not inclusive!
 
 Since we only store leaf category ids, all the events that are not considered by one of the category
@@ -418,7 +419,6 @@ as we use one of these categories.
 
 TODO: it might be more instructive to build this example such that our categorization is inclusive.
 :::
-
 
 ## Extend your categorization as part of a Producer
 
@@ -484,14 +484,12 @@ def my_categorization_producer_init(self: Producer) -> None:
     )
 ```
 
-
 ## Helper functions for categories
 
 ### get_events_from_categories
 
 To obtain the events of a certain category (or categories) of an akward array `events` that contains the
 `category_ids` column, you can use the  {py:func}`~columnflow.util.get_events_from_categories` function.
-
 
 ```python
 from columnflow.util import get_events_from_cateogries
@@ -509,7 +507,6 @@ selected_events = get_events_from_cateogries(events, ["cat1", "cat2"], config_in
 
 This function automatically consideres category ids of all leaf categories from the requested
 categories. This is especially helpful when your category contains multiple leaf categories.
-
 
 ## Key points (TL; DR)
 

--- a/docs/user_guide/building_blocks/categories.md
+++ b/docs/user_guide/building_blocks/categories.md
@@ -5,20 +5,15 @@
 > Work in Progess! This guide has not been finalized and the presented code has not yet been tested.
 > TODO: make the code testable
 
-In columnflow, there are many tools to create a complex and flexible categorization of all analysed
-events.
+In columnflow, there are many tools to create a complex and flexible categorization of all analysed events.
 Generally, this categorization can be layered.
-We refer to the smallest building block of these layers as **leaf categories**, which can subsequently
-be either run individually or combined into more complex categories.
-This guide presents how to implement a set of categories in columnflow and shows how to use the
-resulting categories via the {py:class}`~columnflow.tasks.yields.CreateYieldTable` task.
+We refer to the smallest building block of these layers as **leaf categories**, which can subsequently be either run individually or combined into more complex categories.
+This guide presents how to implement a set of categories in columnflow and shows how to use the resulting categories via the {py:class}`~columnflow.tasks.yields.CreateYieldTable` task.
 
 ## Create a category
 
-If you used the analysis template to setup your analysis, there are already two categories
-included, named ```incl``` and ```2j```.
-To test that the categories are properly implemented,
-we can use the CreateYieldTable task:
+If you used the analysis template to setup your analysis, there are already two categories included, named ```incl``` and ```2j```.
+To test that the categories are properly implemented, we can use the CreateYieldTable task:
 
 ```shell
 law run cf.CreateYieldTable --version v1 \
@@ -26,8 +21,8 @@ law run cf.CreateYieldTable --version v1 \
     --processes tt,st --categories incl,2j
 ```
 
-When all tasks are finished, this should create a table presenting the event yield of each process
-for all categories. To create new categories, we essentially need three ingredients:
+When all tasks are finished, this should create a table presenting the event yield of each process for all categories.
+To create new categories, we essentially need three ingredients:
 
 1. We need to define our categories as {external+order:py:class}`order.category.Category` instances in the config
 
@@ -37,9 +32,8 @@ for all categories. To create new categories, we essentially need three ingredie
     :end-at: )
     ```
 
-2. We need to write a {py:class}`~columnflow.categorization.Categorizer` that defines which events
-    to select for each category. The name of the Categorizer needs to be the same as the "selection"
-    attribute of the category inst.
+2. We need to write a {py:class}`~columnflow.categorization.Categorizer` that defines which events to select for each category.
+    The name of the Categorizer needs to be the same as the "selection" attribute of the category inst.
 
     ```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/categorization/example.py
     :language: python
@@ -47,9 +41,8 @@ for all categories. To create new categories, we essentially need three ingredie
 
     Keep in mind that the module in which your define your Categorizer needs to be included in the law config
 
-3. We need to run the {py:class}`~columnflow.production.categories.category_ids` Producer to create
-the ```category_ids``` column. This is directly included via the ```--producers category_ids```,
-but you could also run the ```category_ids``` Producer as part of another Selector or Producer.
+3. We need to run the {py:class}`~columnflow.production.categories.category_ids` Producer to create the ```category_ids``` column.
+    This is directly included via the ```--producers category_ids```, but you could also run the ```category_ids``` Producer as part of another Selector or Producer.
 
 ```python
 @producer(
@@ -67,48 +60,34 @@ def my_producer(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 ```
 
 :::{dropdown} But how does this actually work?
-The `category_ids` Producer loads all category instances from your config. For each leaf category inst
-(which is the "smallest unit" of categories),
-it maps the `category_inst.selection` string to a `Categorizer` and adds it the to the `uses` and
-`produces`, meaning that columns required (produced) by the `Categorizer` will automatically be
-loaded (stored) when running the `category_ids` Producer.
+The `category_ids` Producer loads all category instances from your config.
+For each leaf category inst (which is the "smallest unit" of categories), it maps the `category_inst.selection` string to a `Categorizer` and adds it the to the `uses` and `produces`, meaning that columns required (produced) by the `Categorizer` will automatically be loaded (stored) when running the `category_ids` Producer.
 
-During the event processing, the `Categorizer` of each leaf category is evaluated to generate
-a mask, which defines, whether the event is part of this category or not.
-The mask is then transformed to an array of ids (either the `category_inst.id` if True, and
-`None` for False entries).t
+During the event processing, the `Categorizer` of each leaf category is evaluated to generate a mask, which defines, whether the event is part of this category or not.
+The mask is then transformed to an array of ids (either the `category_inst.id` if True, and `None` for False entries).
 
-In the end, we return a jagged array of category ids, which allows us to categorize one event
-into multiple different types of categories.
+In the end, we return a jagged array of category ids, which allows us to categorize one event into multiple different types of categories.
 
-You can also store a list of strings in the `category_inst.selection` field. In that case, the logical
-`and` of all masks obtained by the `Categorizer` is used to define the mask corresponding to this
-category.
+You can also store a list of strings in the `category_inst.selection` field. In that case, the logical `and` of all masks obtained by the `Categorizer` is used to define the mask corresponding to this category.
 :::
 
 :::{dropdown} And where are the ```category_ids``` actually used?
-The `category_ids` column is primarily used when creating our histograms (e.g. in the
-{py:class}`~columnflow.tasks.histograms.CreateHistograms` task).
-The created histograms always contain one axis for categories, using the values from the `category_ids`
-column. Since this column is a jagged array, it is possible to fill events either never or multiple
-times in a histogram.
+The `category_ids` column is primarily used when creating our histograms (e.g. in the {py:class}`~columnflow.tasks.histograms.CreateHistograms` task).
+The created histograms always contain one axis for categories, using the values from the `category_ids` column.
+Since this column is a jagged array, it is possible to fill events either never or multiple times in a histogram.
 
-Other tasks such as {py:class}`~columnflow.tasks.plotting.PlotVariables1D` are then using this
-axis with categories to obtain all entries from the histogram corresponding to the category
-that is requested via the `--categories` parameter. When the given category is not a leaf category
-but contains categories itself, the ids of all its leaf categories combined are used for the category.
+Other tasks such as {py:class}`~columnflow.tasks.plotting.PlotVariables1D` are then using this axis with categories to obtain all entries from the histogram corresponding to the category that is requested via the `--categories` parameter.
+When the given category is not a leaf category but contains categories itself, the ids of all its leaf categories combined are used for the category.
 :::
 
 ## Creation of nested categories
 
 :::{note}
-The following section is mostly included for didactic purposes. To implement a set of nested
-categories, it is recommended to follow the section
-{ref}`Categorization with multiple layers <categorization_multiple_layers>`.
+The following section is mostly included for didactic purposes.
+To implement a set of nested categories, it is recommended to follow the section {ref}`Categorization with multiple layers <categorization_multiple_layers>`.
 :::
 
-Often times, there are multiple layers of categorization. For example, we might want to categorize
-based on the number of leptons and the number of jets.
+Often times, there are multiple layers of categorization. For example, we might want to categorize based on the number of leptons and the number of jets.
 
 ```python
 # do 0 lepton vs >= 1 lepton instead?
@@ -165,9 +144,8 @@ law run cf.CreateYieldTable --version v1 \
     --processes tt,st --categories "*"
 ```
 
-As a next step, one might want to combine these categories to categorize based on the number of
-jets and leptons simutaneously. You could simply create all combinations by hand. The following code
-snippet shows how to combine the "2jet" and the "1lep" category:
+As a next step, one might want to combine these categories to categorize based on the number of jets and leptons simutaneously.
+You could simply create all combinations by hand. The following code snippet shows how to combine the "2jet" and the "1lep" category:
 
 ```python
 cat_2jet = config.get_category("2jet")
@@ -209,17 +187,15 @@ cat_1mu.add_category(cat_1mu__2jet)
 cat_1mu.add_category(cat_1mu__3jet)
 ```
 
-We now created categories with dependencies between each other. In columnflow, we always use the
-smallest units of categories (commonly called "leaf categories") to build our parent categories. For
-example, the `2jet` category consists of the leaf categories `1e__2jet` and `1mu__2jet`. To select
-events corresponding to `2jet`, we will add all events with category ids corresponding to either
-`1e__2jet` or `1mu__2jet`.
+We now created categories with dependencies between each other.
+In columnflow, we always use the smallest units of categories (commonly called "leaf categories") to build our parent categories.
+For example, the `2jet` category consists of the leaf categories `1e__2jet` and `1mu__2jet`.
+To select events corresponding to `2jet`, we will add all events with category ids corresponding to either `1e__2jet` or `1mu__2jet`.
 
 :::{note} We might add unexpected selections by combining categorization.
 
-In this example, the `cat_1e` and `cat_1mu` Categorizer only select events with exactly one lepton
-(either electron or muon). This means, that events with zero or multiple leptons will not be considered
-in our categorization, even when building e.g. the `2jet` category.
+In this example, the `cat_1e` and `cat_1mu` Categorizer only select events with exactly one lepton (either electron or muon).
+This means, that events with zero or multiple leptons will not be considered in our categorization, even when building e.g. the `2jet` category.
 :::
 
 Let's test if our leaf categories are working as intended:
@@ -230,14 +206,13 @@ law run cf.CreateYieldTable --version v1 \
     --processes tt,st --categories 1e,2jet,1e__2jet,1e__3jet,1mu__2jet,1mu__3jet
 ```
 
-We should see that the yield of the `2jet` category is the same as the `1e__2jet` and `1mu__2jet`
-categories combined. This is to be expected, since the `2jet` category will be built by combining
-histograms from all of their leaf categories.
+We should see that the yield of the `2jet` category is the same as the `1e__2jet` and `1mu__2jet` categories combined.
+This is to be expected, since the `2jet` category will be built by combining histograms from all of their leaf categories.
 
 :::{note} Take care to define your categories orthogonal!
 
-There is no mechanism that automatically prevents double counting. It is therefore essential to define
-categories such that there is no overlap between leaf categories of any defined category.
+There is no mechanism that automatically prevents double counting.
+It is therefore essential to define categories such that there is no overlap between leaf categories of any defined category.
 
 :::::{dropdown} Example of what NOT to do
 We might have two categories selecting either exactly two or at least two jets.
@@ -265,10 +240,8 @@ def cat_geq2jet(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array
     return events, ak.num(events.Jet.pt, axis=1) >= 2
 ```
 
-This can be done without any issues since these two categories are independent of each other
-(they will each produce their own category id).
-However, if we now add a parent category that contains both `2jet` and `geq2jet`, this will result
-in couting all events twice that contain exactly two jets.
+This can be done without any issues since these two categories are independent of each other (they will each produce their own category id).
+However, if we now add a parent category that contains both `2jet` and `geq2jet`, this will result in couting all events twice that contain exactly two jets.
 
 ```python
 non_orthogonal_cat = config.add_category(
@@ -287,9 +260,8 @@ non_orthogonal_cat.add_category(cat_geq2jet)
 
 ## Categorization with multiple layers
 
-But what should you do when the number of category combinations is getting large? For example, you might
-want to define categories based on the number of leptons, the number of jets, and based on a simple
-obervable such as ```HT```:
+But what should you do when the number of category combinations is getting large?
+For example, you might want to define categories based on the number of leptons, the number of jets, and based on a simple obervable such as ```HT```:
 
 ```python
 jet_categories = (2, 3, 4, 5, 6)
@@ -297,8 +269,8 @@ lep_categories = (1, 2, 3)
 ht_categories = ((0, 200), (200, 400), (400, 600))
 ```
 
-If you want to build all combinations of this set of 5+3+3 categories, you end up with 5 x 3 x 3 = 45
-leaf categories. To build all of them by hand is very tedious, unflexible, and error prone.
+If you want to build all combinations of this set of 5+3+3 categories, you end up with 5 x 3 x 3 = 45 leaf categories.
+To build all of them by hand is very tedious, unflexible, and error prone.
 Luckily, columnflow provides all necessary tools to build combinations of categories automatically.
 To use these tools, we first need to create our base categories and their corresponding Categorizers.
 
@@ -350,9 +322,8 @@ for ht_down, ht_up in ht_categories:
         return events, ((ht > ht_down) & (ht <= ht_up))
 ```
 
-This will only create the (5+3+3) parent categories. To create all possible combinations of
-these categories, we can use the {py:func}`~columnflow.config_util.create_category_combinations`
-function that will do most of the work for us:
+This will only create the (5+3+3) parent categories.
+To create all possible combinations of these categories, we can use the {py:func}`~columnflow.config_util.create_category_combinations` function that will do most of the work for us:
 
 ```python
 def name_fn(root_cats):
@@ -412,24 +383,20 @@ law run cf.CreateYieldTable --version v1 \
 
 :::{note} This categorization is not inclusive!
 
-Since we only store leaf category ids, all the events that are not considered by one of the category
-blocks will not be considered at all. For this set of categories it means that we implicitly added cuts
-on the number of jets (>= 2 and <= 6), the number of leptons (>= 1 and <= 3), and HT (<= 600) as soon
-as we use one of these categories.
+Since we only store leaf category ids, all the events that are not considered by one of the category blocks will not be considered at all.
+For this set of categories it means that we implicitly added cuts on the number of jets (>= 2 and <= 6), the number of leptons (>= 1 and <= 3), and HT (<= 600) as soon as we use one of these categories.
 
 TODO: it might be more instructive to build this example such that our categorization is inclusive.
 :::
 
 ## Extend your categorization as part of a Producer
 
-Some of your categories might need some computationally expensive reconstructed observables
-and can therefore only be called after certain requirements are met.
+Some of your categories might need some computationally expensive reconstructed observables and can therefore only be called after certain requirements are met.
 In these cases, it might be beneficial to first produce columns and then load these columns when necessary.
 To streamline this, you can set these dependencies as part of the Producer instance that creates the category ids (i.e. via the `category_ids` producer).
 
-To properly set this up, add the category instances as part of the `Producer.init`. Columns from
-custom requirements can be added to a Producer via the `Producer.requires` in combination
-with the `Producer.setup`.
+To properly set this up, add the category instances as part of the `Producer.init`.
+Columns from custom requirements can be added to a Producer via the `Producer.requires` in combination with the `Producer.setup`.
 
 ```python
 @producer(
@@ -488,8 +455,7 @@ def my_categorization_producer_init(self: Producer) -> None:
 
 ### get_events_from_categories
 
-To obtain the events of a certain category (or categories) of an akward array `events` that contains the
-`category_ids` column, you can use the  {py:func}`~columnflow.util.get_events_from_categories` function.
+To obtain the events of a certain category (or categories) of an akward array `events` that contains the `category_ids` column, you can use the  {py:func}`~columnflow.util.get_events_from_categories` function.
 
 ```python
 from columnflow.util import get_events_from_cateogries
@@ -505,18 +471,16 @@ selected_events = get_events_from_cateogries(events, config_inst.get_category("m
 selected_events = get_events_from_cateogries(events, ["cat1", "cat2"], config_inst)
 ```
 
-This function automatically consideres category ids of all leaf categories from the requested
-categories. This is especially helpful when your category contains multiple leaf categories.
+This function automatically consideres category ids of all leaf categories from the requested categories.
+This is especially helpful when your category contains multiple leaf categories.
 
 ## Key points (TL; DR)
 
 - Categories are {external+order:py:class}`order.category.Category` instances defined in the config.
 - We can add categories to each other; the "smallest unit" of category is referred to as "leaf category".
 - We build each category by combining all of it's leaf categories (both in columns and in histograms).
-- Leaf categories need to define one or multiple {py:class}`~columnflow.categorization.Categorizer`,
-which is a function that defines whether or not an event belongs in this category.
-- The `category_ids` column is produced via the
-{py:class}`~columnflow.production.categories.category_ids` Producer.
+- Leaf categories need to define one or multiple {py:class}`~columnflow.categorization.Categorizer`, which is a function that defines whether or not an event belongs in this category.
+- The `category_ids` column is produced via the {py:class}`~columnflow.production.categories.category_ids` Producer.
 - Make sure that for each category, all of its leaf categories are defined orthogonal to prevent double counting.
 - Groups of categories can be combined via {py:func}`~columnflow.config_util.create_category_combinations`.
 - Combining categories can impact your parent categories; this can be prevented by defining

--- a/docs/user_guide/building_blocks/config_objects.md
+++ b/docs/user_guide/building_blocks/config_objects.md
@@ -10,9 +10,11 @@ The three main classes needed to define your analysis are {external+order:py:cla
 Their purpose and definition can be found in [the Analysis, Campaign and Config section](https://python-order.readthedocs.io/en/latest/quickstart.html#analysis-campaign-and-config) of the Quickstart section of the order documentation.
 
 After defining your Analysis object and your Campaign object(s), you can use the command
+
 ```python
 cfg = analysis.add_config(campaign, name=your_config_name, id=your_config_id)
 ```
+
 to create the new Config object `cfg`, which will be associated to both the Analysis object and the Campaign object needed for its creation.
 As the Config object should contain the analysis-dependent information related to a certain campaign, it should contain most of the information needed for running your analysis.
 Therefore, in this section, the Config parameters required by Columnflow and some convenience parameters will be presented.
@@ -20,7 +22,6 @@ Therefore, in this section, the Config parameters required by Columnflow and som
 To start your analysis, do not forget to use the already existing analysis template in the
 `analysis_templates/cms_minimal` Git directory and its
 [config](https://github.com/columnflow/columnflow/blob/master/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py).
-
 
 The Config saves information under two general formats: the objects from the order package, which are necessary for your analysis to run in columnflow, and the additional parameters, which are saved under the auxiliary key, accessible through the "x" key.
 In principle, the auxiliary field can contain any parameter the user wants to save and reuse for parts of the analysis.
@@ -30,12 +31,10 @@ These two general formats are presented below.
 Additionally, please note that some columnflow objects, like some Calibrators and Producers, require specific information that is needed to be accessible with predefined keywords.
 As explained in the {ref}`object-specific variables section <object-specific_variables_section>`, please check the documentation of these objects before using them.
 
-
 It is generally advised to use functions to set up Config objects.
 This enables easy and reliable reusage of parts of your analysis that are the same or similar between Campaigns (e.g. parts of the uncertainty model).
 Additionally, other parts of the analysis that might be changed quite often, e.g. the definition of variables, can be defined separately, thus improving the overall organization and readability of your code.
 An example of such a separation can be found in the existing [hh2bbtautau analysis](https://github.com/uhh-cms/hh2bbtautau).
-
 
 ## Parameters from the order package (required)
 
@@ -57,8 +56,8 @@ Examples of information carried by a process could be the cross section of the p
 An example of a Process definition is given in the {ref}`Analysis, Campaign and Config <analysis_campaign_config>` section of the columnflow documentation.
 More information about processes can be found in the {external+order:py:class}`order.process.Process` and the {external+order:doc}`quickstart` sections of the order documentation.
 
-
 (datasets_docu_section)=
+
 ### Datasets
 
 The actual datasets to be processed in the analysis.
@@ -72,12 +71,14 @@ An example is given in the columnflow analysis template:
 :start-at: dataset_names = [
 :end-at: dataset = cfg.add_dataset(campaign.get_dataset(dataset_name))
 ```
+
 The Dataset objects should contain for example information about the number of files and number of events present in a Dataset as well as its keys (= the identifiers or origins of a dataset, used by the `cfg.x.get_dataset_lfns` parameter presented below in {ref}`the section on custom retrieval of datasets <custom_retrieval_of_dataset_files_section>`) and wether it contains observed or simulated data.
 
 It is also possible to change information of a dataset in the config script.
 An example would be reducing the number of files to process for test purposes in a specific test config.
 This could be done with the following lines of code:
 e.g.
+
 ```python
 n_files_max = 5
 for info in dataset.info.values():
@@ -87,7 +88,6 @@ for info in dataset.info.values():
 Once the processes and datasets have both been added to the config, one can check that the root process of all datasets is part of any of the registered processes, using the columnflow function {py:func}`~columnflow.config_util.verify_config_processes`.
 
 An example of a Dataset definition is given in the {ref}`Analysis, Campaign and Config <analysis_campaign_config>` section of the columnflow documentation.
-
 
 ### Variables
 
@@ -146,7 +146,6 @@ An example is given in the columnflow analysis template:
 :end-at: cfg.add_shift(name="nominal", id=0)
 ```
 
-
 Often, shifts are related to auxiliary parameters of the Config, like the name of the scale factors involved, or the paths of source files in case the shift requires external information.
 
 <!--
@@ -188,6 +187,7 @@ An example is given below:
 ```
 
 (custom_retrieval_of_dataset_files_section)=
+
 ### Custom retrieval of dataset files
 
 The Columnflow task {py:class}`~columnflow.tasks.external.GetDatasetLFNs` obtains by default the logical file names of the datasets based on the `keys` argument of the corresponding order Dataset.
@@ -261,6 +261,7 @@ Showing how to require the BundleExternalFiles task to have run in the example o
 :start-at: "@muon_weights.requires"
 :end-at: reqs["external_files"] = BundleExternalFiles.req(self.task)
 ```
+
 :::
 
 ### Luminosity
@@ -276,7 +277,6 @@ cfg.x.luminosity = Number(41480, {
     "lumi_13TeV_correlated": 0.009j,
 })
 ```
-
 
 ### Defaults
 
@@ -301,7 +301,6 @@ This is done with the `cfg.x.{parameter}_group` arguments.
 The expected format of the group is a dictionary containing the custom name of the groups as keys and the list of the parameter values as values.
 The name of the group can then be given as command-line argument instead of the single values.
 An example with a selector_steps group is given below.
-
 
 ```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
 :language: python
@@ -343,6 +342,7 @@ cfg.x.reduced_file_size = 512.0
 ```
 
 (object-specific_variables_section)=
+
 ### Object-specific variables
 
 Other than the variables mentioned above, several might be needed for specific Producers for example.
@@ -354,7 +354,6 @@ Since the {py:class}`~columnflow.production.cms.muon.muon_weights` Producer was 
 As for the CMS-specific objects, an example could be the task {py:class}`~columnflow.tasks.cms.external.CreatePileupWeights`, which requires for example the minimum bias cross sections `cfg.x.minbias_xs` and the `pu` entry in the external files.
 
 Examples of these entries in the Config objects can be found in already existing CMS-analyses working with columnflow, for example the [hh2bbtautau analysis](https://github.com/uhh-cms/hh2bbtautau) or the [hh2bbww analysis](https://github.com/uhh-cms/hh2bbww) from UHH.
-
 
 ### Other examples of auxiliaries in the Config object
 
@@ -368,7 +367,3 @@ To give an idea of the kind of variables an analysis might want to include in th
 - MET filters
 
 For applications of these examples, you can look at already existing columnflow analyses, for example the [hh2bbtautau analysis](https://github.com/uhh-cms/hh2bbtautau) from UHH.
-
-
-
-

--- a/docs/user_guide/building_blocks/producers.md
+++ b/docs/user_guide/building_blocks/producers.md
@@ -73,11 +73,13 @@ def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
 To call a Producer in an other
 Producer/Calibrator/
 Selector, the following expression might be used:
+
 ```python
 events = self[producer_name](arguments_of_the_producer, **kwargs)
 ```
 
 Hence, a complete example would be:
+
 ```python
 # import the Producer class and the producer method
 from columnflow.production import Producer, producer
@@ -127,6 +129,7 @@ The ```all_features``` producer creates therefore two new columns, the ```HT``` 
 level, and the ```pt_squared``` column for each object of the ```Jet``` collection.
 
 Notes:
+
 - If you want to use an exposed Producer in a task call, and if
 this new Producer is created in a new file, you need to include this file in the ```law.cfg``` file
 under the ```production_modules``` argument. A more detailed explanation of the law config file
@@ -137,7 +140,6 @@ columns only after the reduction, using the ProduceColumns task.
 
 - Other useful functions (e.g. for easier handling of columns) can be found in the
 {doc}`../best_practices` section of this documentation.
-
 
 ## ProduceColumns task
 
@@ -164,4 +166,3 @@ It is to be mentioned that this task is run after the
 {py:class}`~columnflow.tasks.calibration.CalibrateEvents`
 tasks and therefore uses the default arguments for the ```--calibrators``` and the ```--selector```
 if not specified otherwise.
-

--- a/docs/user_guide/building_blocks/producers.md
+++ b/docs/user_guide/building_blocks/producers.md
@@ -3,43 +3,23 @@
 ## Introduction
 
 In columnflow, event/object based information (weights, properties, ...) is stored in columns.
-The creation of new columns is managed by instances of the
-{py:class}`~columnflow.production.Producer` class. Producers can
-be called in other classes (e.g. {py:class}`~columnflow.calibration.Calibrator` and
-{py:class}`~columnflow.selection.Selector`), or directly through the
-{py:class}`~columnflow.tasks.production.ProduceColumns` task. It is also possible to create new
-columns directly within Calibrators and
-Selectors, without using instances of the
-Producer class, but the process is
-the same as for the Producer class. Therefore, the
-Producer class, which main purpose is the creation of new
-columns, will be used to describe the process. The new columns are saved in a parquet file. If the
-column were created before the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task and are
-still needed afterwards, they should be included in the ```keep_columns```
-auxiliary of the config, as they would otherwise not be saved in the output file of the task. If
-the columns are created further down the task tree, e.g. in
-ProduceColumns, they will be stored in another parquet
-file, namely as the output of the corresponding task, but these parquet files will be loaded
-similarly to the outputs from ReduceEvents. It should be mentioned that the parquet files for tasks
-after ProduceColumns are opened in the following order: first the parquet file from ReduceEvents,
-then the different parquet files from the different Producers called with the `--producers` argument
-in the same order as they are given on the command line. Therefore, in the case of several
-columns with the exact same name in different parquet files (e.g. a new column `Jet.pt` was
-created in some producer used in ProduceColumns after the creation of the reduced `Jet.pt` column in
-ReduceEvents), the tasks after ProduceColumns will open all the parquet file and overwrite the
-values in this column with the values from the last opened parquet file, according to the previously
-mentioned ordering.
+The creation of new columns is managed by instances of the {py:class}`~columnflow.production.Producer` class.
+Producers can be called in other classes (e.g. {py:class}`~columnflow.calibration.Calibrator` and {py:class}`~columnflow.selection.Selector`), or directly through the {py:class}`~columnflow.tasks.production.ProduceColumns` task.
+It is also possible to create new columns directly within Calibrators and Selectors, without using instances of the Producer class, but the process is the same as for the Producer class.
+Therefore, the Producer class, which main purpose is the creation of new columns, will be used to describe the process.
+The new columns are saved in a parquet file.
+If the column were created before the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task and are still needed afterwards, they should be included in the ```keep_columns``` auxiliary of the config, as they would otherwise not be saved in the output file of the task.
+If the columns are created further down the task tree, e.g. in ProduceColumns, they will be stored in another parquet file, namely as the output of the corresponding task, but these parquet files will be loaded similarly to the outputs from ReduceEvents.
+It should be mentioned that the parquet files for tasks after ProduceColumns are opened in the following order: first the parquet file from ReduceEvents, then the different parquet files from the different Producers called with the `--producers` argument in the same order as they are given on the command line.
+Therefore, in the case of several columns with the exact same name in different parquet files (e.g. a new column `Jet.pt` was created in some producer used in ProduceColumns after the creation of the reduced `Jet.pt` column in ReduceEvents), the tasks after ProduceColumns will open all the parquet file and overwrite the values in this column with the values from the last opened parquet file, according to the previously mentioned ordering.
 
 ## Usage
 
-To create new columns, the {py:class}`~columnflow.production.Producer` instance will need to load
-the columns needed for the production of the new columns from the dataset/parquet files. This is
-given by the ```uses``` set of the instance of the Producer
-class. Similarly, the newly created columns within the producer need to be declared in the
-```produces``` set of the instance of the Producer class to be
-stored in the output parquet file. The Producer instance only
-needs to return the ```events``` array with the additional columns. New columns can be set using
-the function {py:func}`~columnflow.columnar_util.set_ak_column`.
+To create new columns, the {py:class}`~columnflow.production.Producer` instance will need to load the columns needed for the production of the new columns from the dataset/parquet files.
+This is given by the ```uses``` set of the instance of the Producer class.
+Similarly, the newly created columns within the producer need to be declared in the ```produces``` set of the instance of the Producer class to be stored in the output parquet file.
+The Producer instance only needs to return the ```events``` array with the additional columns.
+New columns can be set using the function {py:func}`~columnflow.columnar_util.set_ak_column`.
 
 An example of a Producer for the ```HT```variable is given below:
 
@@ -70,9 +50,7 @@ def features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     return events
 ```
 
-To call a Producer in an other
-Producer/Calibrator/
-Selector, the following expression might be used:
+To call a Producer in an other Producer/Calibrator/Selector, the following expression might be used:
 
 ```python
 events = self[producer_name](arguments_of_the_producer, **kwargs)
@@ -125,31 +103,22 @@ def all_features(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     return events
 ```
 
-The ```all_features``` producer creates therefore two new columns, the ```HT``` column on event
-level, and the ```pt_squared``` column for each object of the ```Jet``` collection.
+The ```all_features``` producer creates therefore two new columns, the ```HT``` column on event level, and the ```pt_squared``` column for each object of the ```Jet``` collection.
 
 Notes:
 
-- If you want to use an exposed Producer in a task call, and if
-this new Producer is created in a new file, you need to include this file in the ```law.cfg``` file
-under the ```production_modules``` argument. A more detailed explanation of the law config file
-can be found in the {ref}`Law config section <law_config_section>`.
+- If you want to use an exposed Producer in a task call, and if this new Producer is created in a new file, you need to include this file in the ```law.cfg``` file under the ```production_modules``` argument.
+A more detailed explanation of the law config file can be found in the {ref}`Law config section <law_config_section>`.
 
-- When storage space is a limiting factor, it is good practice to produce and store (if possible)
-columns only after the reduction, using the ProduceColumns task.
+- When storage space is a limiting factor, it is good practice to produce and store (if possible) columns only after the reduction, using the ProduceColumns task.
 
-- Other useful functions (e.g. for easier handling of columns) can be found in the
-{doc}`../best_practices` section of this documentation.
+- Other useful functions (e.g. for easier handling of columns) can be found in the {doc}`../best_practices` section of this documentation.
 
 ## ProduceColumns task
 
-The {py:class}`~columnflow.tasks.production.ProduceColumns` task runs a specific instance of the
-{py:class}`~columnflow.production.Producer` class and stores the additional columns created in a
-parquet file.
+The {py:class}`~columnflow.tasks.production.ProduceColumns` task runs a specific instance of the {py:class}`~columnflow.production.Producer` class and stores the additional columns created in a parquet file.
 
-While it is possible to see all the arguments and their explanation for this task using
-```law run cf.ProduceColumns --help```, the only argument created specifically for this task is the
-```--producer``` argument, through which the Producer to be used
+While it is possible to see all the arguments and their explanation for this task using ```law run cf.ProduceColumns --help```, the only argument created specifically for this task is the ```--producer``` argument, through which the Producer to be used
 can be chosen.
 
 An example of how to run this task for an analysis with several datasets and configs is given below:
@@ -161,8 +130,4 @@ law run cf.ProduceColumns --version name_of_your_version \
                           --dataset name_of_the_dataset_to_be_run
 ```
 
-It is to be mentioned that this task is run after the
-{py:class}`~columnflow.tasks.selection.SelectEvents` and
-{py:class}`~columnflow.tasks.calibration.CalibrateEvents`
-tasks and therefore uses the default arguments for the ```--calibrators``` and the ```--selector```
-if not specified otherwise.
+It is to be mentioned that this task is run after the {py:class}`~columnflow.tasks.selection.SelectEvents` and {py:class}`~columnflow.tasks.calibration.CalibrateEvents` tasks and therefore uses the default arguments for the ```--calibrators``` and the ```--selector``` if not specified otherwise.

--- a/docs/user_guide/building_blocks/selectors.md
+++ b/docs/user_guide/building_blocks/selectors.md
@@ -4,20 +4,14 @@
 
 In columnflow, selections are defined through the {py:class}`~columnflow.selection.Selector` class.
 This class allows for arbitrary selection criteria on event level as well as object level using masks.
-The results of the selection (which events or objects are to be conserved) are saved in an instance
-of the {py:class}`~columnflow.selection.SelectionResult` class. Similar to
-{py:class}`~columnflow.production.Producer`s, it is possible to create new columns in
-Selectors. In the original columnflow setup,
-Selectors are being run in the
-{py:class}`~columnflow.tasks.selection.SelectEvents` task.
+The results of the selection (which events or objects are to be conserved) are saved in an instance of the {py:class}`~columnflow.selection.SelectionResult` class.
+Similar to {py:class}`~columnflow.production.Producer`s, it is possible to create new columns in Selectors.
+In the original columnflow setup, Selectors are being run in the {py:class}`~columnflow.tasks.selection.SelectEvents` task.
 
 ## Create an instance of the Selector class
 
-Similar to {py:class}`~columnflow.production.Producer`s, {py:class}`~columnflow.selection.Selector`s
-need to declare which columns are to be used (produced) by the
-Selector instance in order for them to be taken out of the parquet files
-(saved in the new parquet files). An example for this structure is given below (Similar to the
-Selector documentation.):
+Similar to {py:class}`~columnflow.production.Producer`s, {py:class}`~columnflow.selection.Selector`s need to declare which columns are to be used (produced) by the Selector instance in order for them to be taken out of the parquet files (saved in the new parquet files).
+An example for this structure is given below (Similar to the Selector documentation.):
 
 ```python
 
@@ -53,30 +47,19 @@ def jet_selection(self: Selector, events: ak.Array, **kwargs) -> tuple[ak.Array,
     return events, SelectionResult()
 ```
 
-The structure of the arguments for the returned {py:class}`~columnflow.selection.SelectionResult`
-instance are discussed below in {ref}`SelectionResult`.
+The structure of the arguments for the returned {py:class}`~columnflow.selection.SelectionResult` instance are discussed below in {ref}`SelectionResult`.
 
 ### Exposed and internal Selectors
 
-{py:class}`~columnflow.selection.Selector`s can be either available directly from the command line
-or only internally, through other selectors. To make a Selector
-available from the command line, it should be declared with the ```exposed=True``` argument.
-To call a fully functional Selector (in the following referred
-as Selector_int) from an other Selector (in the following referred
-to as Selector_ext), several steps are required:
+{py:class}`~columnflow.selection.Selector`s can be either available directly from the command line or only internally, through other selectors.
+To make a Selector available from the command line, it should be declared with the ```exposed=True``` argument. To call a fully functional Selector (in the following referred as Selector_int) from an other Selector (in the following referred to as Selector_ext), several steps are required:
 
 - If defined in an other file, Selector_int should be imported in the Selector_ext script,
-- The columns needed for Selector_int should be declared in the ```uses``` argument of Selector_ext
-    (it is possible to simply write the name of the Selector_int in the ```uses``` set, the content of
-    the ```uses``` set from Selector_int will be added to the ```uses``` set of Selector_ext, see below)
-- Selector_int must be run in Selector_ext, e.g. with the
-    ```self[Selector_int](events, **kwargs)``` call.
+- The columns needed for Selector_int should be declared in the ```uses``` argument of Selector_ext (it is possible to simply write the name of the Selector_int in the ```uses``` set, the content of the ```uses``` set from Selector_int will be added to the ```uses``` set of Selector_ext, see below)
+- Selector_int must be run in Selector_ext, e.g. with the ```self[Selector_int](events, **kwargs)``` call.
 
-An example of an exposed Selector_ext with the ```jet_selection```
-Selector defined above as Selector_int, assuming the
-```jet_selection``` exists in ```analysis/selection/jet.py``` is given below. It should be mentioned
-that a few details must be changed for this selector to work within the worklow, the full version
-can be found in the {ref}`"Complete Example" <complete_example>` section.
+An example of an exposed Selector_ext with the ```jet_selection``` Selector defined above as Selector_int, assuming the ```jet_selection``` exists in ```analysis/selection/jet.py``` is given below.
+It should be mentioned that a few details must be changed for this selector to work within the worklow, the full version can be found in the {ref}`"Complete Example" <complete_example>` section.
 
 ```python
 
@@ -125,41 +108,24 @@ def Selector_ext(self: Selector, events: ak.Array, **kwargs) -> tuple[ak.Array, 
 
 ### SelectionResult
 
-The result of a {py:class}`~columnflow.selection.Selector` is propagated through an instance of the
-{py:class}`~columnflow.selection.SelectionResult` class. The
-SelectionResult object is instantiated using a dictionary for each
-argument. There are four arguments that may be set, which contain:
+The result of a {py:class}`~columnflow.selection.Selector` is propagated through an instance of the {py:class}`~columnflow.selection.SelectionResult` class.
+The SelectionResult object is instantiated using a dictionary for each argument.
+There are four arguments that may be set, which contain:
 
-- Boolean masks to select the events to be kept in the analysis, which is saved under the
-    ```steps``` argument. Several selection steps may be defined in a single Selector, each with a unique
-    name being the key of the dictionary for the corresponding mask.
-- Several index masks for specific objects in a double dictionary structure, saved under the
-    ```objects``` argument. The double dictionary structure in the ```objects``` defines the source
-    column/field from which the indices are to be taken (first dimension of the dictionary) and the name of
-    the new column/field to be created with only these objects (second dimension of the dictionary). If the
-    name of the column/field to be created is the same as the name of an already existing column/field, the original
-    column/field will be overwritten by the new one!
-- Additional informations to be used by other Selectors, saved
-    under the ```aux``` argument.
-- A combined boolean mask of all steps used, which is saved under the ```event``` argument. An
-example with this argument will be shown in the section
-{ref}`"Complete Example" <complete_example>`. The final
-SelectionResult object to be returned by the exposed selector must
-have this field.
+- Boolean masks to select the events to be kept in the analysis, which is saved under the ```steps``` argument.
+Several selection steps may be defined in a single Selector, each with a unique name being the key of the dictionary for the corresponding mask.
+- Several index masks for specific objects in a double dictionary structure, saved under the ```objects``` argument.
+The double dictionary structure in the ```objects``` defines the source column/field from which the indices are to be taken (first dimension of the dictionary) and the name of the new column/field to be created with only these objects (second dimension of the dictionary).
+If the name of the column/field to be created is the same as the name of an already existing column/field, the original column/field will be overwritten by the new one!
+- Additional informations to be used by other Selectors, saved under the ```aux``` argument.
+- A combined boolean mask of all steps used, which is saved under the ```event``` argument.
+An example with this argument will be shown in the section {ref}`"Complete Example" <complete_example>`.
+The final SelectionResult object to be returned by the exposed selector must have this field.
 
-While the arguments in the ```aux``` dictionary are discarded after the
-{py:class}`~columnflow.tasks.reduction.ReduceEvents` task and are
-only used for short-lived saving of internal information that might be needed by other
-Selectors, the ```steps``` and ```objects``` arguments are
-specifically used by the ReduceEvents task to apply the
-given masks to the nanoAOD files (potentially with additional columns). As described above, the
-```steps``` argument is used to reduce the number of events to be processed further down the task
-tree according to the selections, while the ```objects``` argument is used to select which objects
-are to be kept for further processing and creates new columns/fields containing specific selected
-objects.
+While the arguments in the ```aux``` dictionary are discarded after the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task and are only used for short-lived saving of internal information that might be needed by other Selectors, the ```steps``` and ```objects``` arguments are specifically used by the ReduceEvents task to apply the given masks to the nanoAOD files (potentially with additional columns).
+As described above, the ```steps``` argument is used to reduce the number of events to be processed further down the task tree according to the selections, while the ```objects``` argument is used to select which objects are to be kept for further processing and creates new columns/fields containing specific selected objects.
 
-Below is an example of a fully written internal Selector with its
-SelectionResult object without ```event``` argument.
+Below is an example of a fully written internal Selector with its SelectionResult object without ```event``` argument.
 
 ```python
 
@@ -233,13 +199,8 @@ def jet_selection_with_result(self: Selector, events: ak.Array, **kwargs) -> tup
 
 ### Selection using several selection steps
 
-In order for the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task to apply the final event
-selection to all events, it is necessary to input the resulting boolean array in the ```event```
-argument of the returned {py:class}`~columnflow.selection.SelectionResult` by the exposed
-{py:class}`~columnflow.selection.Selector`.
-When several selection steps do appear in the selection, it is necessary to combine all the masks
-from all the steps in order to obtain the final boolean array to be given to the ```event``` argument
-of the SelectionResult and for it to be applied to the events.
+In order for the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task to apply the final event selection to all events, it is necessary to input the resulting boolean array in the ```event``` argument of the returned {py:class}`~columnflow.selection.SelectionResult` by the exposed {py:class}`~columnflow.selection.Selector`.
+When several selection steps do appear in the selection, it is necessary to combine all the masks from all the steps in order to obtain the final boolean array to be given to the ```event``` argument of the SelectionResult and for it to be applied to the events.
 This can be achieved in two steps:
 
 - Combining the results from the different selections to a single
@@ -252,8 +213,7 @@ results += jet_results
 results += fatjet_results
 ```
 
-- Reducing the different steps to a single boolean array and give it to the ```event``` argument of
-the SelectionResult object.
+- Reducing the different steps to a single boolean array and give it to the ```event``` argument of the SelectionResult object.
 
 ```python
 # import the functions to combine the selection masks
@@ -267,30 +227,18 @@ results.event = event_sel
 
 ### Selection stats
 
-In order to use the correct values for the weights to be applied to the Monte Carlo samples while
-plotting, it is necessary to save some information which would be lost after the
-{py:class}`~columnflow.tasks.reduction.ReduceEvents`
-task. An example for that would be the sum of all the Monte Carlo weights in a simulation, which is
-needed for the normalization weights. In order to propagate this information to tasks further down
-the tree, the ```stats.json``` file is created. As it is a json file, it contains a
-dictionary with the key corresponding to the name of the information to be saved, while the value
-for the key is the information itself. The dictionary is created in the
-{py:class}`~columnflow.tasks.selection.SelectEvents` task and
-updated in place in a {py:class}`~columnflow.selection.Selector`. Depending on the weights to be
-used, various additional information might need to be saved in the ```stats``` object.
+In order to use the correct values for the weights to be applied to the Monte Carlo samples while plotting, it is necessary to save some information which would be lost after the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task.
+An example for that would be the sum of all the Monte Carlo weights in a simulation, which is needed for the normalization weights.
+In order to propagate this information to tasks further down the tree, the ```stats.json``` file is created.
+As it is a json file, it contains a dictionary with the key corresponding to the name of the information to be saved, while the value for the key is the information itself.
+The dictionary is created in the {py:class}`~columnflow.tasks.selection.SelectEvents` task and updated in place in a {py:class}`~columnflow.selection.Selector`.
+Depending on the weights to be used, various additional information might need to be saved in the ```stats``` object.
 
-The keys ```"num_events"```, ```"num_events_selected"```, ```"sum_mc_weight"```,
-```"sum_mc_weight_selected"``` get printed by the
-SelectEvents task along with the
-corresponding efficiency. If they are not set, the default value for floats will be printed instead.
+The keys ```"num_events"```, ```"num_events_selected"```, ```"sum_mc_weight"```, ```"sum_mc_weight_selected"``` get printed by the SelectEvents task along with the corresponding efficiency. If they are not set, the default value for floats will be printed instead.
 
-Below is an example of such a Selector updating the ```stats```
-dictionary in place. This dictionary will be saved in the ```stats.json``` file. For convenience,
-the weights were saved in a weight_map dictionary along with the mask before the sum of the weights
-was saved in the ```stats``` dictionary. In this example, the keys to be printed by the
-SelectEvents task and the sum of the Monte Carlo weights
-per process (needed for correct normalization of the number of Monte Carlo events in the plots)
-are saved.
+Below is an example of such a Selector updating the ```stats``` dictionary in place.
+This dictionary will be saved in the ```stats.json``` file. For convenience, the weights were saved in a weight_map dictionary along with the mask before the sum of the weights was saved in the ```stats``` dictionary.
+In this example, the keys to be printed by the SelectEvents task and the sum of the Monte Carlo weights per process (needed for correct normalization of the number of Monte Carlo events in the plots) are saved.
 
 ```python
 from columnflow.selection import Selector, selector
@@ -355,20 +303,11 @@ def custom_increment_stats(
     return events, results
 ```
 
-Columnflow also provides a helper Selector called
-{py:class}`~columnflow.selection.stats.increment_stats`, which calculates and inputs directly the
-number of events (the name of the feature should start with "num") for given masks
-(`Ellipsis` should be given if no mask is to be used) or sum of
-specific columns (usually weights, the name of the feature should start by "sum") for given columns
-and masks, using a "weight map". These calculations can also be specified for subgroups of objects
-using a "group map". An example of such a call using the number of jets and the processes as
-subgroups is given below, with `results.event` the event selection mask after all selections and
-having saved during the selection the number of valid jets in each event in the auxiliary field of
-the SelectionResult object under the name `n_jets`. This example stems from the cms_minimal example
-of the analysis templates present in the columnflow repository, more specifically in the
-example.py script under the selection directory. In this script, the increment_stats method from
-columnflow was imported (using `from columnflow.selection.stats import increment_stats`) and its
-`uses` columns were declared in the `uses` set of the Selector.
+Columnflow also provides a helper Selector called {py:class}`~columnflow.selection.stats.increment_stats`, which calculates and inputs directly the number of events (the name of the feature should start with "num") for given masks (`Ellipsis` should be given if no mask is to be used) or sum of specific columns (usually weights, the name of the feature should start by "sum") for given columns and masks, using a "weight map".
+These calculations can also be specified for subgroups of objects using a "group map".
+An example of such a call using the number of jets and the processes as subgroups is given below, with `results.event` the event selection mask after all selections and having saved during the selection the number of valid jets in each event in the auxiliary field of the SelectionResult object under the name `n_jets`.
+This example stems from the cms_minimal example of the analysis templates present in the columnflow repository, more specifically in the example.py script under the selection directory.
+In this script, the increment_stats method from columnflow was imported (using `from columnflow.selection.stats import increment_stats`) and its `uses` columns were declared in the `uses` set of the Selector.
 
 ```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
 :language: python
@@ -380,8 +319,7 @@ columnflow was imported (using `from columnflow.selection.stats import increment
 
 ### Complete example
 
-Overall, creating an exposed {py:class}`~columnflow.selection.Selector` with several selections steps
-might look like this:
+Overall, creating an exposed {py:class}`~columnflow.selection.Selector` with several selections steps might look like this:
 
 ```python
 # coding: utf-8
@@ -606,39 +544,23 @@ def Selector_ext(
 ```
 
 Notes:
-- If you want to use an exposed Selector in a task call, and if
-this new Selector is created in a new file, you need to include this file in the ```law.cfg``` file
-under the ```selection_modules``` argument. A more detailed explanation of the law config file
-can be found in the {ref}`Law config section <law_config_section>`.
+- If you want to use an exposed Selector in a task call, and if this new Selector is created in a new file, you need to include this file in the ```law.cfg``` file under the ```selection_modules``` argument.
+A more detailed explanation of the law config file can be found in the {ref}`Law config section <law_config_section>`.
 
-- The actual creation of the weights to be applied in the histogramms after the selection might be
-done in the {py:class}`~columnflow.tasks.production.ProduceColumns` task, using the stats object
-created in this task if needed.
+- The actual creation of the weights to be applied in the histogramms after the selection might be done in the {py:class}`~columnflow.tasks.production.ProduceColumns` task, using the stats object created in this task if needed.
 
-- Other useful functions (e.g. for easier handling of columns) can be found in the
-{doc}`../best_practices` section of this documentation.
+- Other useful functions (e.g. for easier handling of columns) can be found in the {doc}`../best_practices` section of this documentation.
 
 ## Running the SelectEvents task
 
-The {py:class}`~columnflow.tasks.selection.SelectEvents` task runs a specific selection script and
-saves the created masks for event and objects selections in a parquet file, as well as the
-statistics of the selection in a json file.
+The {py:class}`~columnflow.tasks.selection.SelectEvents` task runs a specific selection script and saves the created masks for event and objects selections in a parquet file, as well as the statistics of the selection in a json file.
 
-While it is possible to see all the arguments and their explanation for this task using
-```law run cf.SelectEvents --help```, the only argument created specifically for this task is the
-```--selector``` argument, through which the exposed {py:class}`~columnflow.selection.Selector` to
-be used can be chosen.
+While it is possible to see all the arguments and their explanation for this task using ```law run cf.SelectEvents --help```, the only argument created specifically for this task is the ```--selector``` argument, through which the exposed {py:class}`~columnflow.selection.Selector` to be used can be chosen.
 
-The masks created by this task are then used by the
-{py:class}`~columnflow.tasks.reduction.ReduceEvents` task to reduce the number of
-events (see the ```steps``` argument for the {py:class}`~columnflow.selection.SelectionResult`) and
-create/update new columns/fields with only the selected objects (see the ```objects``` argument for
-the SelectionResult). The saved statistics are used e.g. for the
-weights needed for plotting.
+The masks created by this task are then used by the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task to reduce the number of events (see the ```steps``` argument for the {py:class}`~columnflow.selection.SelectionResult`) and create/update new columns/fields with only the selected objects (see the ```objects``` argument for the SelectionResult).
+The saved statistics are used e.g. for the weights needed for plotting.
 
-It should not be forgotten that any column created in this task should be included in the
-```keep_columns``` argument of the config file, as only columns explicitely required to be kept in
-this dictionary will be loaded and then saved in the reduced parquet file.
+It should not be forgotten that any column created in this task should be included in the ```keep_columns``` argument of the config file, as only columns explicitely required to be kept in this dictionary will be loaded and then saved in the reduced parquet file.
 
 An example of how to run this task for an analysis with several datasets and configs is given below:
 
@@ -649,12 +571,7 @@ law run cf.SelectEvents --version name_of_your_version \
                         --dataset name_of_the_dataset_to_be_run
 ```
 
-It is to be mentioned that this task is run after the
-{py:class}`~columnflow.tasks.calibration.CalibrateEvents` task and therefore uses
-the default argument for the ```--calibrators``` if not specified otherwise.
+It is to be mentioned that this task is run after the {py:class}`~columnflow.tasks.calibration.CalibrateEvents` task and therefore uses the default argument for the ```--calibrators``` if not specified otherwise.
 
 Notes:
-- Running the exposed Selector from the
-{ref}`"Complete Example" <complete_example>`
-section would simply require you to give the name ```Selector_ext``` in the ```--selector```
-argument.
+- Running the exposed Selector from the {ref}`"Complete Example" <complete_example>` section would simply require you to give the name ```Selector_ext``` in the ```--selector``` argument.

--- a/docs/user_guide/building_blocks/selectors.md
+++ b/docs/user_guide/building_blocks/selectors.md
@@ -64,12 +64,13 @@ available from the command line, it should be declared with the ```exposed=True`
 To call a fully functional Selector (in the following referred
 as Selector_int) from an other Selector (in the following referred
 to as Selector_ext), several steps are required:
+
 - If defined in an other file, Selector_int should be imported in the Selector_ext script,
 - The columns needed for Selector_int should be declared in the ```uses``` argument of Selector_ext
-(it is possible to simply write the name of the Selector_int in the ```uses``` set, the content of
-the ```uses``` set from Selector_int will be added to the ```uses``` set of Selector_ext, see below)
+    (it is possible to simply write the name of the Selector_int in the ```uses``` set, the content of
+    the ```uses``` set from Selector_int will be added to the ```uses``` set of Selector_ext, see below)
 - Selector_int must be run in Selector_ext, e.g. with the
-```self[Selector_int](events, **kwargs)``` call.
+    ```self[Selector_int](events, **kwargs)``` call.
 
 An example of an exposed Selector_ext with the ```jet_selection```
 Selector defined above as Selector_int, assuming the
@@ -128,17 +129,18 @@ The result of a {py:class}`~columnflow.selection.Selector` is propagated through
 {py:class}`~columnflow.selection.SelectionResult` class. The
 SelectionResult object is instantiated using a dictionary for each
 argument. There are four arguments that may be set, which contain:
+
 - Boolean masks to select the events to be kept in the analysis, which is saved under the
-```steps``` argument. Several selection steps may be defined in a single Selector, each with a unique
-name being the key of the dictionary for the corresponding mask.
+    ```steps``` argument. Several selection steps may be defined in a single Selector, each with a unique
+    name being the key of the dictionary for the corresponding mask.
 - Several index masks for specific objects in a double dictionary structure, saved under the
-```objects``` argument. The double dictionary structure in the ```objects``` defines the source
-column/field from which the indices are to be taken (first dimension of the dictionary) and the name of
-the new column/field to be created with only these objects (second dimension of the dictionary). If the
-name of the column/field to be created is the same as the name of an already existing column/field, the original
-column/field will be overwritten by the new one!
+    ```objects``` argument. The double dictionary structure in the ```objects``` defines the source
+    column/field from which the indices are to be taken (first dimension of the dictionary) and the name of
+    the new column/field to be created with only these objects (second dimension of the dictionary). If the
+    name of the column/field to be created is the same as the name of an already existing column/field, the original
+    column/field will be overwritten by the new one!
 - Additional informations to be used by other Selectors, saved
-under the ```aux``` argument.
+    under the ```aux``` argument.
 - A combined boolean mask of all steps used, which is saved under the ```event``` argument. An
 example with this argument will be shown in the section
 {ref}`"Complete Example" <complete_example>`. The final
@@ -229,8 +231,6 @@ def jet_selection_with_result(self: Selector, events: ak.Array, **kwargs) -> tup
     )
 ```
 
-
-
 ### Selection using several selection steps
 
 In order for the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task to apply the final event
@@ -243,7 +243,9 @@ of the SelectionResult and for it to be applied to the events.
 This can be achieved in two steps:
 
 - Combining the results from the different selections to a single
+
 SelectionResult object:
+
 ```python
 results = SelectionResult()
 results += jet_results
@@ -252,6 +254,7 @@ results += fatjet_results
 
 - Reducing the different steps to a single boolean array and give it to the ```event``` argument of
 the SelectionResult object.
+
 ```python
 # import the functions to combine the selection masks
 from operator import and_
@@ -263,7 +266,6 @@ results.event = event_sel
 ```
 
 ### Selection stats
-
 
 In order to use the correct values for the weights to be applied to the Monte Carlo samples while
 plotting, it is necessary to save some information which would be lost after the
@@ -289,7 +291,6 @@ was saved in the ```stats``` dictionary. In this example, the keys to be printed
 SelectEvents task and the sum of the Monte Carlo weights
 per process (needed for correct normalization of the number of Monte Carlo events in the plots)
 are saved.
-
 
 ```python
 from columnflow.selection import Selector, selector
@@ -376,10 +377,12 @@ columnflow was imported (using `from columnflow.selection.stats import increment
 ```
 
 (complete_example)=
+
 ### Complete example
 
 Overall, creating an exposed {py:class}`~columnflow.selection.Selector` with several selections steps
 might look like this:
+
 ```python
 # coding: utf-8
 
@@ -614,8 +617,6 @@ created in this task if needed.
 
 - Other useful functions (e.g. for easier handling of columns) can be found in the
 {doc}`../best_practices` section of this documentation.
-
-
 
 ## Running the SelectEvents task
 

--- a/docs/user_guide/cms_specializations.md
+++ b/docs/user_guide/cms_specializations.md
@@ -1,5 +1,6 @@
-(cms_specializations_section)=
 # CMS specializations
+
+(cms_specializations_section)=
 
 ## Tasks
 
@@ -9,8 +10,10 @@
 {py:class}`~columnflow.production.cms.pileup.pu_weight` Producer, more specifically due to its
 requirements, in the {py:meth}`~columnflow.production.cms.pileup.pu_weight_requires` method, which
 contains the following lines:
+
 ```python
 from columnflow.tasks.cms.external import CreatePileupWeights
 reqs["pu_weights"] = CreatePileupWeights.req(self.task)
 ```
+
 TODO: purpose of the task? Why CMS-specific?

--- a/docs/user_guide/cms_specializations.md
+++ b/docs/user_guide/cms_specializations.md
@@ -6,10 +6,8 @@
 
 ### CreatePileUpWeights
 
-{py:class}`~columnflow.tasks.cms.external.CreatePileUpWeights`: This task is called because of the
-{py:class}`~columnflow.production.cms.pileup.pu_weight` Producer, more specifically due to its
-requirements, in the {py:meth}`~columnflow.production.cms.pileup.pu_weight_requires` method, which
-contains the following lines:
+{py:class}`~columnflow.tasks.cms.external.CreatePileUpWeights`:
+This task is called because of the {py:class}`~columnflow.production.cms.pileup.pu_weight` Producer, more specifically due to its requirements, in the {py:meth}`~columnflow.production.cms.pileup.pu_weight_requires` method, which contains the following lines:
 
 ```python
 from columnflow.tasks.cms.external import CreatePileupWeights

--- a/docs/user_guide/debugging.md
+++ b/docs/user_guide/debugging.md
@@ -4,17 +4,16 @@
 
 If you get an error while using columnflow and look at the error stack, you will probably see
 two errors:
+
 1) the actual error and where it happened in the code (standard python error), this is probably
 the error you are interested in.
 2) a sandbox error that you can ignore in most of the cases, as
 it does not correspond to your problem, it only says in which sandbox it happened.
 
-
 In this section, debugging tools already implemented in columnflow to inspect the intermediate
 results of tasks will be presented.
 
 TODO
-
 
 Add a FAQ here? Oder in a new file? first questions:
 - troubleshooting:

--- a/docs/user_guide/debugging.md
+++ b/docs/user_guide/debugging.md
@@ -2,59 +2,47 @@
 
 (soon to be changed:)
 
-If you get an error while using columnflow and look at the error stack, you will probably see
-two errors:
+If you get an error while using columnflow and look at the error stack, you will probably see two errors:
 
-1) the actual error and where it happened in the code (standard python error), this is probably
-the error you are interested in.
-2) a sandbox error that you can ignore in most of the cases, as
-it does not correspond to your problem, it only says in which sandbox it happened.
+1) the actual error and where it happened in the code (standard python error), this is probably the error you are interested in.
+2) a sandbox error that you can ignore in most of the cases, as it does not correspond to your problem, it only says in which sandbox it happened.
 
-In this section, debugging tools already implemented in columnflow to inspect the intermediate
-results of tasks will be presented.
+In this section, debugging tools already implemented in columnflow to inspect the intermediate results of tasks will be presented.
 
 TODO
 
 Add a FAQ here? Oder in a new file? first questions:
 - troubleshooting:
 
-- "I have changed something in the code and called the corresponding ```law run``` bash command,
-but the task isn't starting/the task started is further down the task tree."
+- "I have changed something in the code and called the corresponding ```law run``` bash command, but the task isn't starting/the task started is further down the task tree."
 
-A: Do not forget to remove the corresponding intermediate output(s), for example with
-```--remove-output``` (see {doc}`law`), or start a new version with ```--version``` if you do
-explicitely want to conserve the previous output before the change in the code.
+A: Do not forget to remove the corresponding intermediate output(s), for example with ```--remove-output``` (see {doc}`law`), or start a new version with ```--version``` if you do explicitely want to conserve the previous output before the change in the code.
 
 - "Where do I find the outputs of my tasks?"
 
-A: When you run "source setup.sh {name_of_the_setup}" in columnflow for the first time, you choose
-the storage locations. You can find the storage locations again by opening the
-".setups/{name_of_the_setup}.sh" file in the analysis repository. You may also use law functions to
-ease the search, namely with the ```--print-output``` command, see in the {doc}`law` section.
+A: When you run "source setup.sh {name_of_the_setup}" in columnflow for the first time, you choose the storage locations.
+You can find the storage locations again by opening the ".setups/{name_of_the_setup}.sh" file in the analysis repository.
+You may also use law functions to ease the search, namely with the ```--print-output``` command, see in the {doc}`law` section.
 
-- "I get an error telling me that some columns could not be found/produced. What can I do?"
+- "I get an error telling me that some columns could not be found/produced.
+What can I do?"
 
-A: You have declared some columns in the uses or produces set of your Selectors, Producers or
-Calibrators that are not available. Maybe you did not produce them before, or they have been
-removed, for example in the ReduceEvents task. You should start by verifying that these columns
-are necessary for you and remove them if not. If you need them, and this is a "uses" problem: check
-if you have created the column in a previous task and declared the
-column in "keep_columns" in your analysis config if you are in a task after "ReduceEvents". Do not
-forget to remove the outputs to start the corresponding tasks again if you have made changes in them
-after running them. If this a "produce" error, verify that the column has been produced in your
-script. If you still cannot pinpoint the error, use the debugging tools to check your intermediate
-outputs or an IPython shell in your script.
+A: You have declared some columns in the uses or produces set of your Selectors, Producers or Calibrators that are not available.
+Maybe you did not produce them before, or they have been removed, for example in the ReduceEvents task.
+You should start by verifying that these columns are necessary for you and remove them if not.
+If you need them, and this is a "uses" problem:
+check if you have created the column in a previous task and declared the column in "keep_columns" in your analysis config if you are in a task after "ReduceEvents".
+Do not forget to remove the outputs to start the corresponding tasks again if you have made changes in them after running them.
+If this a "produce" error, verify that the column has been produced in your script.
+If you still cannot pinpoint the error, use the debugging tools to check your intermediate outputs or an IPython shell in your script.
 
 - "I get an error during the setup telling me that some packages/scripts are not available"
 
-A: When you run "source setup.sh {name_of_the_setup}", columnflow internally checks all the scripts
-declared in the law.cfg file. It may lead to two problems: 1) if what is not available is an
-external package that you try to import, the issue may come from the fact that the package you try
-to import is only available in a specific cf_sandbox (which is not the default sandbox). For these,
-simply use the "maybe_import" function from columnflow.util, in a similar way to
-{doc}`building_blocks/producers`. 2) If what is not available is a local script in columnflow,
-you might need to declare it in the law.cfg BEFORE the script causing the error. For example, if
-the error is in some calibrator in "calibration/cms/new_calibrator.py" which is using some
-calibrator in "calibration/cms/jets.py", you might want to declare them in the law.cfg in the
-following way: "calibration_modules: columnflow.calibration.cms.{jets,new_calibrator}" (and NOT
-"calibration_modules: columnflow.calibration.cms.{new_calibrator,jets}").
+A: When you run "source setup.sh {name_of_the_setup}", columnflow internally checks all the scripts declared in the law.cfg file.
+It may lead to two problems:
+
+1) if what is not available is an external package that you try to import, the issue may come from the fact that the package you try to import is only available in a specific cf_sandbox (which is not the default sandbox).
+For these, simply use the "maybe_import" function from columnflow.util, in a similar way to {doc}`building_blocks/producers`.
+2) If what is not available is a local script in columnflow, you might need to declare it in the law.cfg BEFORE the script causing the error.
+For example, if the error is in some calibrator in "calibration/cms/new_calibrator.py" which is using some calibrator in "calibration/cms/jets.py", you might want to declare them in the law.cfg in the following way:
+"calibration_modules: columnflow.calibration.cms.{jets,new_calibrator}" (and NOT "calibration_modules: columnflow.calibration.cms.{new_calibrator,jets}").

--- a/docs/user_guide/examples.md
+++ b/docs/user_guide/examples.md
@@ -11,6 +11,7 @@ Tasks in columnflow are based on {external+law:py:class}`~law.task.base.BaseTask
 Refer to the documentation of these packages for more information on the task class and a detailed description of the implemented methods.
 
 (example_task_class_section)=
+
 ### Example: Task Class
 
 ```python showLineNumbers
@@ -202,6 +203,7 @@ lfn_sources: wlcg_fs_desy_store
 hbt.MyNewTask: wlcg
 ...
 ```
+
 ### Executing the Task
 
 After new sourcing the law environment or by running `law index` in a setup enviroment, the task can be executed using the command:

--- a/docs/user_guide/law.md
+++ b/docs/user_guide/law.md
@@ -32,7 +32,6 @@ used to decide if a task further down the task tree should run or not, the versi
 for bookkeeping and storage of several intermediate results, where all other parameters would be
 equivalent.
 
-
 Tasks in law are organized as a graph with dependencies. Therefore a "depth" for the different
 required tasks exists, depending on which task required which other task. In order to see the
 different required tasks for a single task, you might use the argument ```--print-status -1```,
@@ -43,6 +42,7 @@ followed by the depth of the task. If you want a finished task to be run anew wi
 the version (e.g. do a new histogram with different binning), you might remove the previous
 outputs with the ```--remove-output``` argument, followed by the depth up to which to remove the
 outputs. There are three removal modes:
+
 - ```a``` (all: remove all outputs of the different tasks up to the given depth),
 - ```i``` (interactive: prompt a selection of the tasks to remove up to the given depth. For each
 task which output you decide to remove, you will be asked how you want to remove the potentially
@@ -72,6 +72,7 @@ law run cf.PlotVariables1D --version test_plot --print-output 0
 ```
 
 (law_config_section)=
+
 ## Law Config
 
 TODO

--- a/docs/user_guide/law.md
+++ b/docs/user_guide/law.md
@@ -1,71 +1,53 @@
 # Law introduction
 
 This analysis tool uses [law](https://github.com/riga/law) for the workflow orchestration.
-Therefore, a short introduction to the most essential functions of law you should be
-aware of when using this tool are provided here. More informations are available for example in the
-"[Examples](https://github.com/riga/law#examples)" section of this
-[Github repository](https://github.com/riga/law). This section can be ignored if you are already
-familiar with law.
+Therefore, a short introduction to the most essential functions of law you should be aware of when using this tool are provided here.
+More informations are available for example in the "[Examples](https://github.com/riga/law#examples)" section of this [Github repository](https://github.com/riga/law).
+This section can be ignored if you are already familiar with law.
 
 ## Tasks and parameters
 
-In [law](https://github.com/riga/law), tasks are objects, which, as the name implies, should be
-implemented in such a way, that they fulfill a specific task in the workflow. They are defined and
-separated by purpose and may have dependencies to each other. As an example, columnflow defines a
-task for the creation of histograms and a different task to make a plot of these histograms. The
-plotting task requires the histogram task to have already run, in order to have data to plot. This
-is internally checked by the presence or absence of the corresponding output file from the required
-task. If the required file is not present, the required task will be automatically started with the
-corresponding parameters before the called task.
+In [law](https://github.com/riga/law), tasks are objects, which, as the name implies, should be implemented in such a way, that they fulfill a specific task in the workflow.
+They are defined and separated by purpose and may have dependencies to each other.
+As an example, columnflow defines a task for the creation of histograms and a different task to make a plot of these histograms.
+The plotting task requires the histogram task to have already run, in order to have data to plot.
+This is internally checked by the presence or absence of the corresponding output file from the required task.
+If the required file is not present, the required task will be automatically started with the corresponding parameters before the called task.
 
-The full task tree of general tasks already implemented in columnflow can be seen in
-[this wikipage](https://github.com/columnflow/columnflow/wiki#default-task-graph).
+The full task tree of general tasks already implemented in columnflow can be seen in [this wikipage](https://github.com/columnflow/columnflow/wiki#default-task-graph).
 
 A task is run with the command ```law run``` followed by the name of the task.
 A version, given by the argument ```--version```, followed by the name of the version, is required.
 
-In law, the intermediate results (=the outputs of the different tasks) are saved locally in the
-corresponding directory (given in the setup, the arguments to run the task are also used for the path).
-The name of the version also appears in the path and should therefore be selected to match your
-purpose, for example ```--version selection_with_gen_matching```. As the intermediate results are
-used to decide if a task further down the task tree should run or not, the version argument allows
-for bookkeeping and storage of several intermediate results, where all other parameters would be
-equivalent.
+In law, the intermediate results (=the outputs of the different tasks) are saved locally in the corresponding directory (given in the setup, the arguments to run the task are also used for the path).
+The name of the version also appears in the path and should therefore be selected to match your purpose, for example ```--version selection_with_gen_matching```.
+As the intermediate results are used to decide if a task further down the task tree should run or not, the version argument allows for bookkeeping and storage of several intermediate results, where all other parameters would be equivalent.
 
-Tasks in law are organized as a graph with dependencies. Therefore a "depth" for the different
-required tasks exists, depending on which task required which other task. In order to see the
-different required tasks for a single task, you might use the argument ```--print-status -1```,
-which will show all required tasks and the existence or absence of their output for the given input
-parameters up to depth "-1", hence the deepest one. The called task with ```law run``` will have
-depth 0. You might check the output path of a task with the argument ```--print-output```,
-followed by the depth of the task. If you want a finished task to be run anew without changing
-the version (e.g. do a new histogram with different binning), you might remove the previous
-outputs with the ```--remove-output``` argument, followed by the depth up to which to remove the
-outputs. There are three removal modes:
+Tasks in law are organized as a graph with dependencies.
+Therefore a "depth" for the different required tasks exists, depending on which task required which other task.
+In order to see the different required tasks for a single task, you might use the argument ```--print-status -1```, which will show all required tasks and the existence or absence of their output for the given input parameters up to depth "-1", hence the deepest one.
+The called task with ```law run``` will have depth 0.
+You might check the output path of a task with the argument ```--print-output```, followed by the depth of the task.
+If you want a finished task to be run anew without changing the version (e.g. do a new histogram with different binning), you might remove the previous outputs with the ```--remove-output``` argument, followed by the depth up to which to remove the outputs.
+There are three removal modes:
 
 - ```a``` (all: remove all outputs of the different tasks up to the given depth),
-- ```i``` (interactive: prompt a selection of the tasks to remove up to the given depth. For each
-task which output you decide to remove, you will be asked how you want to remove the potentially
-multiple outputs)
-- ```d``` (dry: show which files might be deleted with the same selection options, but do not remove
-        the outputs).
+- ```i``` (interactive: prompt a selection of the tasks to remove up to the given depth.
+For each task which output you decide to remove, you will be asked how you want to remove the potentially multiple outputs)
+- ```d``` (dry: show which files might be deleted with the same selection options, but do not remove the outputs).
 
-The ```--remove-output``` argument does not allow the depth "-1", check the task
-tree with ```--print-output``` before selecting the depth you want. The removal mode
-can be already selected in the command, e.g. with ```--remove-output 1,a``` (remove all outputs up
-to depth 1).
+The ```--remove-output``` argument does not allow the depth "-1", check the task tree with ```--print-output``` before selecting the depth you want.
+The removal mode can be already selected in the command, e.g. with ```--remove-output 1,a``` (remove all outputs up to depth 1).
 
-Once the output has been removed, it is possible to run the task again. It is also possible to
-rerun the task in the same command as the removal by adding the ```y``` argument at the end.
-Therefore, removing all outputs of a selected task (but not its dependencies) and running it again
-at once would correspond to the following command:
+Once the output has been removed, it is possible to run the task again.
+It is also possible to rerun the task in the same command as the removal by adding the ```y``` argument at the end.
+Therefore, removing all outputs of a selected task (but not its dependencies) and running it again at once would correspond to the following command:
 
 ```shell
 law run name_of_the_task --version name_of_the_version --remove-output 0,a,y
 ```
 
-An example command to see the location of the output file after running a 1D plot of a variable
-with columnflow using only law functions and the default arguments for the tasks would be:
+An example command to see the location of the output file after running a 1D plot of a variable with columnflow using only law functions and the default arguments for the tasks would be:
 
 ```shell
 law run cf.PlotVariables1D --version test_plot --print-output 0

--- a/docs/user_guide/ml.md
+++ b/docs/user_guide/ml.md
@@ -2,7 +2,8 @@
 
 In this section, the users will learn how to implement machine learning in their analysis with columnflow.
 
-# How training happens in Columnflow: K-fold cross validation
+## How training happens in Columnflow: K-fold cross validation
+
 Machine learning in columnflow is implemented in a way that k-fold cross validation is enabled by default.
 In k-fold cross validation the dataset is split in k-parts of equal size.
 For each training, k-1 parts are used for the actual training and the remaining part is used to test the model.
@@ -10,42 +11,52 @@ This process is repeated k-times, resulting in the training of k-model instances
 In the end of the training columnflow will save all k-models, which are then usable for evaluation.
 An overview and further details about possible variations of k-fold cross validation can be found in the [sci-kit documentation](https://scikit-learn.org/stable/modules/cross_validation.html).
 
-# Configure your custom machine learning class:
+## Configure your custom machine learning class:
+
 To create a custom machine learning (ML) class in columnflow, it is imperative to inherit from the {py:class}`~columnflow.ml.MLModel` class.
 This inheritance ensures the availability of functions to manage and access config and model instances, as well as the necessary producers.
 The name of your custom ML class can be arbitrary, since `law` accesses your machine learning model using a `cls_name` in {py:meth}`~columnflow.util.DerivableMeta.derive`, e.g.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: test_model
 :end-at: test_model
 ```
+
 The second argument in {py:meth}`~columnflow.util.DerivableMeta.derive` is a `cls_dict` which configures your subclass.
 The `cls_dict` needs to be flat.
 The keys of the dictionary are set as class attributes and are therefore also accessible by using `self`.
 The configuration with `derive` has two main advantages:
+
 - **manageability**, since the dictionary can come from loading a config file and these can be changed fairly easy
 - **flexibility**, multiple settings require only different configuration files
 
 A possible configuration and model initialization for such a model could look like this:
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: hyperparameters =
 :end-at: test_model = TestModel.derive(
 ```
+
 One can also simply define class variables within the model.
 This is can be useful for attributes that don't change often, for example to define the datasets your model uses.
 Since these are also class attributes, they are accessible by using `self` and are also shared between all instances of this model.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: class TestModel(
 :end-at: your instance variables
 ```
+
 If you have settings that should not be shared between all instances, define them within `__init__`.
 
-# After the configuration
+## After the configuration
+
 After the configuration of your ML model, `law` needs to be informed in the `law.cfg` about the existence of the new machine learning model.
 Add in your `law.cfg`, under the sections `analysis`, a `ml_modules` keyword, where you point to the Python module where the model's definition and derivation happens.
 These import structures are relative to the analysis root directory.
+
 ```bash
 [analysis]
 # any other config entries
@@ -54,21 +65,27 @@ These import structures are relative to the analysis root directory.
 ml_modules: hbt.ml.{test}
 inference_modules: hbt.inference.test
 ```
-# ABC functions
+
+## ABC functions
+
 In the following we will go through several abstract functions that you must overwrite, in order to be able to use your custom ML class with columnflow.
 
-## sandbox:
+### sandbox:
+
 In {py:meth}`~columnflow.ml.MLModel.sandbox`, you specify which sandbox setup file should be sourced to setup the environment for ML usage.
 The return value of {py:meth}`~columnflow.ml.MLModel.sandbox` is the path to your shell (sh) file, e.g:
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def sandbox
 :end-at: return "bash::$HBT_BASE/sandboxes/venv_columnar_tf.sh"
 ```
+
 It is recommended to start the path with `bash::`, to indicate that you want to source the {py:meth}`~columnflow.ml.MLModel.sandbox` with `bash`.
 How to actually write the setup and requirement files can be found in the section about [setting up a sandbox](building_blocks/sandbox).
 
-## datasets:
+### datasets:
+
 In the {py:meth}`~columnflow.ml.MLModel.datasets` function, you specify which datasets are important for your machine learning model and which dataset instance(s) should be extracted from your config.
 To use this function your datasets needs to be added to your campaign, as defined by the [Order](https://python-order.readthedocs.io/en/latest/) Module.
 An example can be found [here](https://github.com/uhh-cms/cmsdb/blob/d83fb085d6e43fe9fc362df75bbc12816b68d413/cmsdb/campaigns/run2_2018_nano_uhh_v11/top.py).
@@ -76,14 +93,15 @@ It is recommended to return this as `set`, to prevent double counting.
 In the following example all datasets given by the {ref}`external config <init_of_ml_model>` are taken, but also an additional dataset is given.
 Note how the name of each dataset is used to get a `dataset instance` from your `config instance`.
 This ensures that you properly use the correct dataset.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def datasets
 :end-at: return set(dataset_inst)
 ```
 
+### produces:
 
-## produces:
 By default, intermediate columns are not saved within the columnflow framework but are filtered out afterwards.
 If you want to prevent certain columns from being filtered out, you need to tell columnflow.
 You can tell columnflow, by let {py:meth}`~columnflow.ml.MLModel.produces` return the names of all columns that should be preserved, do this by define the names as strings within an interable.
@@ -92,48 +110,56 @@ More information can be found in the official documentation about [producers](bu
 In the following example, I want tell columnflow to preserve the output of the neural network, but also the fold indices, that are used to create the trainings and test fold.
 I do not store the input and target columns of that fold to save disk space, since they are already stored in the training set parquet file.
 To avoid confusion, we are not producing the columns in this function, we only tell columnflow to not throwing them away.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def produces
 :end-at: return preserved_columns
 ```
+
 Thus, the choice to include these columns is your choice.
 
-## uses:
+### uses:
+
 In `uses` you define the columns that are needed by your machine learning model, and are forwarded to the ML model during the execution of the various tasks
 In this case we want to request the input and target features, as well as some weights:
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def uses(
 :end-at: return columns
 ```
 
-## output:
+### output:
+
 In the {py:meth}`~columnflow.ml.MLModel.output` function, you define your local target directory that your current model instance will have access to.
 
 Since machine learning in columnflow uses k-fold cross validation by default, it is a good idea to have a separate directory for each fold, and this should be reflected in the {py:meth}`~columnflow.ml.MLModel.output` path.
 It is of good practice to store your "machine-learning-instance" files within the directory of the models instance. To get the path to this directory use `task.target`.
 In this example we want to save each fold separately e.g:
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def output
 :end-at: return target
 ```
 
+### open_model:
 
-## open_model:
 In the {py:meth}`~columnflow.ml.MLModel.open_model` function, you implement the loading of the trained model and if necessary its configuration, so it is ready to use for {py:meth}`~columnflow.ml.MLModel.evaluate`.
 This does not define how the model is build for {py:meth}`~columnflow.ml.MLModel.train`.
 
 The `target` parameter represents the local path to the models directory.
 In the the following example a TensorFlow model saved with Keras API is loaded and returned, and no further configuration happens:
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def open_model
 :end-at: return loaded_model
 ```
 
-## train:
+### train:
+
 In the {py:meth}`~columnflow.ml.MLModel.train` function, you implement the initialization of your models and the training loop.
 The `task` corresponding to the models training is {py:class}`~columnflow.tasks.ml.MLTraining`.
 By default {py:meth}`~columnflow.ml.MLModel.train` has access to the location of the models `inputs` and `outputs`.
@@ -145,17 +171,21 @@ Using `self`, you have also access to the entire `analysis_inst`ance the `config
 With this information, you can call and prepare the columns to be used by the model for training.
 In the following example a very simple dummy training loop is performed using the Keras fit function.
 Within this function some helper functions are used that are further explained in the following chapter about good practices.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def train
 :end-at: return
 ```
-### Good practice for training:
+
+#### Good practice for training:
+
 It is considered to be a good practice to define helper functions for model building and column preprocessing and call them in {py:meth}`~columnflow.ml.MLModel.train`.
 The reasoning behind this design decision is that in {py:meth}`~columnflow.ml.MLModel.train`, you want to focus more on the definition of the actual trainings loop.
 Another reason is that especially the preparation of events can take a large amount of code lines, making it messy to debug.
 In the following example it is shown how to define these helper functions.
 First of all one needs a function to handle the opening and combination of all parquet files.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def open_input_files
@@ -165,20 +195,25 @@ First of all one needs a function to handle the opening and combination of all p
 In `prepare_events` we use the combined awkward array and filter out all columns we are not interested in during the training, to stay lightweight.
 Next we split the remaining columns into input and target column and bring these columns into the correct shape, data type, and also use certain preprocessing transformation.
 At the end we transform the awkward array into a Tensorflow tensor, something that our machine learning model can handle.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def prepare_events
 :end-at: return tf.convert_to_tensor
 ```
+
 The actual building of the model is also handled by a separate function.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def build_model
 :end-at: return model
 ```
+
 With this little example one can see why it is of good practice to separate this process into small chunks.
 
-## evaluate:
+### evaluate:
+
 Within {py:meth}`~columnflow.ml.MLModel.train` one defined the trainings process of the ML model, while in {py:meth}`~columnflow.ml.MLModel.evaluate` its evaluation is defined.
 The corresponding `task` is {py:class}`~columnflow.tasks.ml.MLEvaluation`, which depends on {py:class}`~columnflow.tasks.ml.MLTraining` and will therefore trigger a training if no training was performed before.
 
@@ -205,9 +240,11 @@ This flag determines if a certain `dataset` and shift combination can be used by
 The evaluations output is saved as parquet file with the name of the model as field name.
 To get the files path afterwards, rerun the same law command again, but with `--print-output 0` at the end.
 
-# Commands to start training and evaluation
+## Commands to start training and evaluation
+
 To start the machine learning training `law run cf.MLTraining`, while for evaluation use `law run cf.MLEvaluation`.
 When not using the `config`, `calibrators`, `selector`s or `dataset`
+
 ```bash
 law run cf.MLTraining \
     --version your_current_version \
@@ -217,6 +254,7 @@ law run cf.MLTraining \
     --selector selector_name \
     --dataset datasets_1,dataset_2,dataset_3,...
 ```
+
 ```bash
 law run cf.MLEvaluation \
     --version your_current_version \
@@ -224,15 +262,18 @@ law run cf.MLEvaluation \
     --config run2_2017_nano_uhh_v11_limited \
     --calibrators calibrator_name
 ```
+
 Most of these settings should sound familiar, if not look into the corresponding tutorial.
 `version` defines a setup configuration of your ML task, think more of a label than of an actual `version`.
 If you change the version label, columnflow will rerun all dependencies that are unique for this label, this typically just means you will retrain a new model. You can then switch freely between both models version.
 
-# Optional useful functions:
-## Separate training and evaluation configuration for configs, calibrators, selector and producers:
+## Optional useful functions
+
+### Separate training and evaluation configuration for configs, calibrators, selector and producers
+
 By default chosen configs, calibrators, selector and producer are used for both training and evaluation.
 Sometimes one does not want to share the same environment or does not need all the columns in evaluation as in training.
-Another possible scenario is the usage of different selectors or datasets, to be able to explore different phase spaces. 
+Another possible scenario is the usage of different selectors or datasets, to be able to explore different phase spaces.
 This is where a separation of both comes in handy.
 
 To separate this behavior one need to define the training_{configs,calibrators, selector,producers}.
@@ -244,26 +285,32 @@ the calibrator for the evaluation is provided by the used command.
 Take special note on the numerus of the functions name and of course of the type hint.
 The selector expects only a string, since we typically apply only 1 selection, while the calibrator or producers expect a sequence of strings.
 In this special case we use an own defined calibrator called "skip_jecunc", which is of course defined within the law.cfg.
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def training_selector
 :end-at: return "default"
 ```
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def training_producers
 :end-at: return ["default"]
 ```
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def training_calibrators
 :end-at: return ["skip_jecunc"]
 ```
-## setup
+
+### setup
+
 Setup is called at the end of `__init__` of your ML model.
 Within this function you can prepare operations that should stay open during the whole life time of your instance.
 A typical example for this would be the opening of a file or dynamically appending variables that are only relevant to your ML model, and no where else.
 In the following example definitions needed to plot variables that are created in ML model are added to the `config_inst`:
+
 ```{literalinclude} ./examples/ml_code.py
 :language: python
 :start-at: def setup

--- a/docs/user_guide/ml.md
+++ b/docs/user_guide/ml.md
@@ -135,7 +135,8 @@ In this case we want to request the input and target features, as well as some w
 In the {py:meth}`~columnflow.ml.MLModel.output` function, you define your local target directory that your current model instance will have access to.
 
 Since machine learning in columnflow uses k-fold cross validation by default, it is a good idea to have a separate directory for each fold, and this should be reflected in the {py:meth}`~columnflow.ml.MLModel.output` path.
-It is of good practice to store your "machine-learning-instance" files within the directory of the models instance. To get the path to this directory use `task.target`.
+It is of good practice to store your "machine-learning-instance" files within the directory of the models instance.
+To get the path to this directory use `task.target`.
 In this example we want to save each fold separately e.g:
 
 ```{literalinclude} ./examples/ml_code.py
@@ -265,7 +266,8 @@ law run cf.MLEvaluation \
 
 Most of these settings should sound familiar, if not look into the corresponding tutorial.
 `version` defines a setup configuration of your ML task, think more of a label than of an actual `version`.
-If you change the version label, columnflow will rerun all dependencies that are unique for this label, this typically just means you will retrain a new model. You can then switch freely between both models version.
+If you change the version label, columnflow will rerun all dependencies that are unique for this label, this typically just means you will retrain a new model.
+You can then switch freely between both models version.
 
 ## Optional useful functions
 

--- a/docs/user_guide/plotting.md
+++ b/docs/user_guide/plotting.md
@@ -1,10 +1,9 @@
 # Plotting
 
-In columnflow, there are multiple tasks to create plots. This section showcases how to create and
-customize a plot based on the {py:class}`~columnflow.tasks.plotting.PlotVariables1D` task.
-The usage of other plotting tasks is mostly analogous to the ```PlotVariables1D``` task. The most
-important differences compared to ```PlotVariables1D``` are presented in a separate section
-for each of the other plotting tasks.
+In columnflow, there are multiple tasks to create plots.
+This section showcases how to create and customize a plot based on the {py:class}`~columnflow.tasks.plotting.PlotVariables1D` task.
+The usage of other plotting tasks is mostly analogous to the ```PlotVariables1D``` task.
+The most important differences compared to ```PlotVariables1D``` are presented in a separate section for each of the other plotting tasks.
 An overview of all plotting tasks is given in the [Plotting tasks](../task_overview/plotting.md) section.
 
 ## Creating your first plot
@@ -17,8 +16,7 @@ law run cf.PlotVariables1D --version v1 \
     --processes data,tt,st --variables n_jet --categories incl,2j
 ```
 
-This will run the full analysis chain for the given processes (data, tt, st) and should create
-plots looking like this:
+This will run the full analysis chain for the given processes (data, tt, st) and should create plots looking like this:
 
 ::::{grid} 1 1 2 2
 :::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.pdf
@@ -31,67 +29,43 @@ plots looking like this:
 ::::
 
 :::{dropdown} Where do I find that plot?
-You can add ```--print-output 0``` to every task call, which will print the full filename of all
-outputs of the requested task. Alternatively, you can add ```--fetch-output 0,a``` to directly
-copy all outputs of this task into the directory you are currently in.
-Finally, there is the ```--view-cmd``` parameter you can add to directly display the plot during
-the runtime of the task, e.g. via ```--view-cmd evince-previewer```.
+You can add ```--print-output 0``` to every task call, which will print the full filename of all outputs of the requested task.
+Alternatively, you can add ```--fetch-output 0,a``` to directly copy all outputs of this task into the directory you are currently in.
+Finally, there is the ```--view-cmd``` parameter you can add to directly display the plot during the runtime of the task, e.g. via ```--view-cmd evince-previewer```.
 :::
 
-The ```PlotVariables1D``` task is located at the bottom of our
-[task graph](https://github.com/columnflow/columnflow/wiki#default-task-graph), which means that
-all tasks leading to ```PlotVariables1D``` will be run for all datasets corresponding to the
-```--processes``` we requested using the
-{py:class}`~columnflow.calibration.Calibrator`s, {py:class}`~columnflow.selection.Selector`, and
-{py:class}`~columnflow.production.Producer`s
-(often referred to as CSPs) as requested. In the following examples, we will skip the
-```--calibrators```, ```--selector``` and ```--producers``` parameters, which means that the defaults
-defined in the config will be used automatically. Examples on how to
-implement your own CSPs can be found in the [calibrators](building_blocks/calibrators),
-[selectors](building_blocks/selectors), and [producers](building_blocks/producers) sections of the
-user guide. The ```--variables``` parameter defines, for which variables we want to create histograms
-and plots. Variables are [order](https://github.com/riga/order) objects that need to be defined
-in the config as shown in the
-[config objects](building_blocks/config_objects) section. The column corresponding to the expression
-statement needs to be stored either after the {py:class}`~columnflow.tasks.reduction.ReduceEvents`
-task or as part of a ```Producer``` used in the {py:class}`~columnflow.tasks.production.ProduceColumns`
-task.
+The ```PlotVariables1D``` task is located at the bottom of our [task graph](https://github.com/columnflow/columnflow/wiki#default-task-graph), which means that all tasks leading to ```PlotVariables1D``` will be run for all datasets corresponding to the ```--processes``` we requested using the {py:class}`~columnflow.calibration.Calibrator`s, {py:class}`~columnflow.selection.Selector`, and {py:class}`~columnflow.production.Producer`s (often referred to as CSPs) as requested.
+In the following examples, we will skip the ```--calibrators```, ```--selector``` and ```--producers``` parameters, which means that the defaults defined in the config will be used automatically.
+Examples on how to implement your own CSPs can be found in the [calibrators](building_blocks/calibrators), [selectors](building_blocks/selectors), and [producers](building_blocks/producers) sections of the user guide.
+The ```--variables``` parameter defines, for which variables we want to create histograms and plots.
+Variables are [order](https://github.com/riga/order) objects that need to be defined in the config as shown in the [config objects](building_blocks/config_objects) section.
+The column corresponding to the expression statement needs to be stored either after the {py:class}`~columnflow.tasks.reduction.ReduceEvents` task or as part of a ```Producer``` used in the {py:class}`~columnflow.tasks.production.ProduceColumns` task.
 For each of the category given with the ```--categories``` parameter, one plot will be produced.
-A detailed guide on how to implement categories in Columnflow is given in the
-[categories](building_blocks/categories) section.
+A detailed guide on how to implement categories in Columnflow is given in the [categories](building_blocks/categories) section.
 
-To define which processes and datasets to consider when plotting, you can use the ```--processes```
-and ```--datasets``` parameter. When only processes are given, all datasets corresponding to the
-requested processes will be considered. When only datasets are given, all processes in the config
-will be considered.
-The ```--processes``` parameter can be used to change the order of processes in the stack and the legend
-(try for example ```--processes st,tt``` instead) and to further distinguish between sub-processes
-(e.g. via ```--processses tt_sl,tt_dl,tt_fh```).
+To define which processes and datasets to consider when plotting, you can use the ```--processes``` and ```--datasets``` parameter.
+When only processes are given, all datasets corresponding to the requested processes will be considered.
+When only datasets are given, all processes in the config will be considered.
+The ```--processes``` parameter can be used to change the order of processes in the stack and the legend (try for example ```--processes st,tt``` instead) and to further distinguish between sub-processes (e.g. via ```--processses tt_sl,tt_dl,tt_fh```).
 
 :::{dropdown} IMPORTANT! Do not add the same dataset via multiple processes!
-At the time of writing this documentation, there is still an issue present that histograms corresponding
-to a dataset can accidentally be used multiple times. For example, when adding ```--processes tt,tt_sl```,
-the events corresponding to the dataset ```tt_sl_powheg``` will be displayed twice in the resulting
-plot.
+At the time of writing this documentation, there is still an issue present that histograms corresponding to a dataset can accidentally be used multiple times.
+For example, when adding ```--processes tt,tt_sl```, the events corresponding to the dataset ```tt_sl_powheg``` will be displayed twice in the resulting plot.
 :::
 
 ## Customization of plots
 
-There are many different parameters implemented that allow customizing the style of a plot. A short
-overview to all plotting parameters is given in the [Plotting tasks](../task_overview/plotting.md).
-In the following, a few exemplary task calls are given to present the usage of our plotting parameters,
-using the {py:class}`~columnflow.tasks.plotting.PlotVariables1D` task.
-Most paramaters are shared between the different plotting tasks. The most important changes regarding
-the task parameters are discussed in separate sections for each type of plotting task.
+There are many different parameters implemented that allow customizing the style of a plot.
+A short overview to all plotting parameters is given in the [Plotting tasks](../task_overview/plotting.md).
+In the following, a few exemplary task calls are given to present the usage of our plotting parameters, using the {py:class}`~columnflow.tasks.plotting.PlotVariables1D` task.
+Most paramaters are shared between the different plotting tasks.
+The most important changes regarding the task parameters are discussed in separate sections for each type of plotting task.
 
-Per default, the ```PlotVariables1D``` task creates one plot
-per variable with all Monte Carlo processes being included
-in a stack and data being shown as separate points. The bottom subplot shows the ratio between signal
-and all processes included in the stack and can be disabled via the ```--skip-ratio``` parameter.
+Per default, the ```PlotVariables1D``` task creates one plot per variable with all Monte Carlo processes being included in a stack and data being shown as separate points.
+The bottom subplot shows the ratio between signal and all processes included in the stack and can be disabled via the ```--skip-ratio``` parameter.
 To change the text next to the label, you can add the ```--cms-label``` parameter.
 :::{dropdown} What are the ```cms-label``` options?
-In general, this parameter accepts all types of strings, but there is a set of shortcuts for commonly
-used labels that will automatically be resolved:
+In general, this parameter accepts all types of strings, but there is a set of shortcuts for commonly used labels that will automatically be resolved:
 
 ```{literalinclude} ../../columnflow/plotting/plot_all.py
 :language: python
@@ -102,11 +76,10 @@ used labels that will automatically be resolved:
 :::
 
 To compare shapes of multiple processes, you might want to plot each process separately as one line.
-To achieve this, you can use the ```unstack``` option of the ```--process-settings``` parameter. This
-parameter can also be used to change other attributes of your process instances, such as color, label,
-and the scale. To better compare shapes of processes, we can normalize each line with the
-```--shape-norm``` parameter. Combining all the previously discussed parameters might lead to a task
-call such as
+To achieve this, you can use the ```unstack``` option of the ```--process-settings``` parameter.
+This parameter can also be used to change other attributes of your process instances, such as color, label, and the scale.
+To better compare shapes of processes, we can normalize each line with the ```--shape-norm``` parameter.
+Combining all the previously discussed parameters might lead to a task call such as
 
 ```shell
 law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1_pt \
@@ -126,25 +99,20 @@ to produce the following plot:
 :::
 ::::
 
-Parameters that only contain a single value can also be passed via the ```--general-settings```, which
-is a single comma-separated list of parameters, where the name and the value are separated via a `=`.
-The value of each parameter is automatically resolved to either a float, bool, or a string. When no `=`
-is present, the parameter is automatically set to True.
+Parameters that only contain a single value can also be passed via the ```--general-settings```, which is a single comma-separated list of parameters, where the name and the value are separated via a `=`.
+The value of each parameter is automatically resolved to either a float, bool, or a string.
+When no `=` is present, the parameter is automatically set to True.
 :::{dropdown} What is the advantage of setting parameters via the ```--general-settings``` parameter?
-While there is no direct advantage of setting parameters via the ```--general-settings```, this
-parameter provides some convenience by allowing you to define defaults and groups in the config
-(will be discussed later in the guide).
+While there is no direct advantage of setting parameters via the ```--general-settings```, this parameter provides some convenience by allowing you to define defaults and groups in the config (will be discussed later in the guide).
 
-Additionally, this parameter allows you to set parameters on the command line that are not directly
-implemented as task parameters. This is especially helpful when you want to parametrize
+Additionally, this parameter allows you to set parameters on the command line that are not directly implemented as task parameters.
+This is especially helpful when you want to parametrize
 {ref}`custom plotting functions <custom_plot_function>`.
 :::
 
-We can also change the y-scale of the plot to a log scale by adding ```--yscale log``` and change some
-properties of specific variables via the ```variable-settings``` parameter. For example, we might
-want to create the plots of our two obserables in one call, but would like to try out a
-rebinned version of `jet1_pt` that merges bins by a factor of 10. A corresponding task call
-might be
+We can also change the y-scale of the plot to a log scale by adding ```--yscale log``` and change some properties of specific variables via the ```variable-settings``` parameter.
+For example, we might want to create the plots of our two obserables in one call, but would like to try out a rebinned version of `jet1_pt` that merges bins by a factor of 10.
+A corresponding task call might be
 
 ```shell
 law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1_pt \
@@ -163,15 +131,11 @@ law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1
 ::::
 
 :::{dropdown} Limitations of the ```variable_settings```
-While in theory we can change anything inside the variable and process instances via the
-```variable_settings``` parameter, there are certain attributes that are already used during the creation
-of the histograms (e.g. the ```expression``` and the ```binning```). Since our ```variable_settings```
-parameter only modifies these attributes during the runtime of our plotting task, this will not
-impact our final results.
+While in theory we can change anything inside the variable and process instances via the ```variable_settings``` parameter, there are certain attributes that are already used during the creation of the histograms (e.g. the ```expression``` and the ```binning```).
+Since our ```variable_settings``` parameter only modifies these attributes during the runtime of our plotting task, this will not impact our final results.
 :::
 
-For the ```general_settings```, ```process_settings```, and ```variable_settings``` you can define
-defaults and groups in the config, e.g. via
+For the ```general_settings```, ```process_settings```, and ```variable_settings``` you can define defaults and groups in the config, e.g. via
 
 ```python
 config_inst.x.default_variable_settings = {"jet1_pt": {"rebin": 4, "x_title": r"Leading jet $p_{T}$"}}
@@ -183,9 +147,8 @@ config_inst.x.general_settings_groups = {
 }
 ```
 
-The default is automatically used when no parameter is given in the task call, and the groups can
-be used directly on the command line and will be resolved automatically. Our previously defined
-defaults and groups will be used e.g. by the following task call:
+The default is automatically used when no parameter is given in the task call, and the groups can be used directly on the command line and will be resolved automatically.
+Our previously defined defaults and groups will be used e.g. by the following task call:
 
 ```shell
 law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1_pt \
@@ -204,10 +167,8 @@ law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1
 
 ## Creating 2D plots
 
-Columnflow also provides the {py:class}`~columnflow.tasks.plotting.PlotVariables2D` task to create
-two-dimensional plots. Two-dimensional histograms are created by passing two variables to the
-```--variables``` parameter, separated by a ```-```. Here is an exemplary task call and their
-outputs.
+Columnflow also provides the {py:class}`~columnflow.tasks.plotting.PlotVariables2D` task to create two-dimensional plots.
+Two-dimensional histograms are created by passing two variables to the ```--variables``` parameter, separated by a ```-```. Here is an exemplary task call and their outputs.
 
 ```shell
 law run cf.PlotVariables2D --version v1 \
@@ -224,19 +185,15 @@ law run cf.PlotVariables2D --version v1 \
 :::
 ::::
 
-While most of the plotting parameters used in the ```PlotVariables1D``` task can be reused for this
-task, there are also some additional parameters only available for 2D plotting tasks.
-For more information on the task parameters of the ```PlotVariables2D``` task, take a look into the
-[plotting task overview](../task_overview/plotting.md).
+While most of the plotting parameters used in the ```PlotVariables1D``` task can be reused for this task, there are also some additional parameters only available for 2D plotting tasks.
+For more information on the task parameters of the ```PlotVariables2D``` task, take a look into the [plotting task overview](../task_overview/plotting.md).
 
 ## Creating cutflow plots
 
 The previously discussed plotting functions only create plots after applying the full event selection.
-To allow inspecting and optimizing an event and object selection, Columnflow also includes plotting
-tasks that can produce plots after each individual selection step.
+To allow inspecting and optimizing an event and object selection, Columnflow also includes plotting tasks that can produce plots after each individual selection step.
 
-To create a simple cutflow plot, displaying event yields after each individual selection step,
-you can use the {py:class}`~columnflow.tasks.cutflow.PlotCutflow` task, e.g. via calling
+To create a simple cutflow plot, displaying event yields after each individual selection step, you can use the {py:class}`~columnflow.tasks.cutflow.PlotCutflow` task, e.g. via calling
 
 ```shell
 law run cf.PlotCutflow --version v1 \
@@ -255,17 +212,13 @@ law run cf.PlotCutflow --version v1 \
 :::
 ::::
 
-This will produce a plot with three bins, containing the event yield before applying any selection
-and after each selector step, where we always apply the logical ```and``` of all previous selector steps.
+This will produce a plot with three bins, containing the event yield before applying any selection and after each selector step, where we always apply the logical ```and``` of all previous selector steps.
 
 :::{dropdown} What are the options for the ```--selector-steps```? Can I customize the step labels?
-The steps listed in the ```--selector-steps``` parameter need to be defined by the
-{py:class}`~columnflow.selection.Selector` that has been used.
-A detailed guide on how to implement your own selector can be found in the
-[Selections](building_blocks/selectors) guide.
+The steps listed in the ```--selector-steps``` parameter need to be defined by the {py:class}`~columnflow.selection.Selector` that has been used.
+A detailed guide on how to implement your own selector can be found in the [Selections](building_blocks/selectors) guide.
 
-Per default, the name of the selector step is used on the x-axis, but you can also provide custom
-step labels via the config:
+Per default, the name of the selector step is used on the x-axis, but you can also provide custom step labels via the config:
 
 ```python
 config_inst.x.selector_step_labels = {
@@ -276,9 +229,7 @@ config_inst.x.selector_step_labels = {
 
 :::
 
-To create plots of variables as part of the cutflow, we also provide the
-{py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D`, which mostly behaves the same as the
-{py:class}`~columnflow.tasks.plotting.PlotVariables1D` task.
+To create plots of variables as part of the cutflow, we also provide the {py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D`, which mostly behaves the same as the {py:class}`~columnflow.tasks.plotting.PlotVariables1D` task.
 
 ```shell
 law run cf.PlotCutflowVariables1D --version v1 \
@@ -301,8 +252,7 @@ law run cf.PlotCutflowVariables1D --version v1 \
 :::
 ::::
 
-The ```--per-plot``` parameter defines whether to produce one plot per selector step
-(```--per-plot processes```) or one plot per process (```--per-plot steps```).
+The ```--per-plot``` parameter defines whether to produce one plot per selector step (```--per-plot processes```) or one plot per process (```--per-plot steps```).
 For the ```--per-plot steps``` option, try the following task call:
 
 ```shell
@@ -324,28 +274,20 @@ law run cf.PlotCutflowVariables1D --version v1 \
 
 ## Creating plots for different shifts
 
-Like most tasks, our plotting tasks also contain the ```--shift``` parameter that allows requesting
-the outputs for a certain type of systematic variation. Per default, the ```--shift``` parameter is set
-to "nominal", but you could also produce your plot with a certain systematic uncertainty varied
-up or down, e.g. via running
+Like most tasks, our plotting tasks also contain the ```--shift``` parameter that allows requesting the outputs for a certain type of systematic variation.
+Per default, the ```--shift``` parameter is set to "nominal", but you could also produce your plot with a certain systematic uncertainty varied up or down, e.g. via running
 
 ```shell
 law run cf.PlotVariables1D --version v1 \
     --processes tt,st --variables n_jet --shift mu_up
 ```
 
-If you already ran the same task call with ```--shift nominal``` before, this will only require to
-produce new histograms and plots, as a shift such as the ```mu_up``` is typically implemented as an
-event weight and therefore does not require to reproduce any columns. Other shifts such as ```jec_up```
-also impact our event selection and therefore also need to re-run anything starting from
-{py:class}`~columnflow.tasks.selection.SelectEvents`. A detailed overview on how to implement different
-types of systematic uncertainties is given in the [systematics](systematics)
-section (TODO: not existing).
+If you already ran the same task call with ```--shift nominal``` before, this will only require to produce new histograms and plots, as a shift such as the ```mu_up``` is typically implemented as an event weight and therefore does not require to reproduce any columns.
+Other shifts such as ```jec_up``` also impact our event selection and therefore also need to re-run anything starting from {py:class}`~columnflow.tasks.selection.SelectEvents`.
+A detailed overview on how to implement different types of systematic uncertainties is given in the [systematics](systematics) section (TODO: not existing).
 
-For directly comparing differences introduced by one shift source, we provide the
-{py:class}`~columnflow.tasks.plotting.PlotShiftedVariables1D` task. Instead of the ```--shift```
-parameter, this task implements the ```--shift-sources``` option and creates one plot per shift source
-displaying the nominal distribution (black) compared to the shift source varied up (red) and down (blue).
+For directly comparing differences introduced by one shift source, we provide the {py:class}`~columnflow.tasks.plotting.PlotShiftedVariables1D` task.
+Instead of the ```--shift``` parameter, this task implements the ```--shift-sources``` option and creates one plot per shift source displaying the nominal distribution (black) compared to the shift source varied up (red) and down (blue).
 The task can be called e.g. via
 
 ```shell
@@ -365,14 +307,12 @@ and produces the following plot:
 :::
 ::::
 
-This produces per default only one plot containing the sum of all processes. To produce this plot
-per process, you can use the {py:class}`~columnflow.tasks.plotting.PlotShiftedVariablesPerProcess1D`
-task
+This produces per default only one plot containing the sum of all processes.
+To produce this plot per process, you can use the {py:class}`~columnflow.tasks.plotting.PlotShiftedVariablesPerProcess1D` task
 
 ## Directly displaying plots in the terminal
 
-All plotting tasks also include a ```--view-cmd``` parameter that allows directly printing the plot
-during the runtime of the task:
+All plotting tasks also include a ```--view-cmd``` parameter that allows directly printing the plot during the runtime of the task:
 
 ```shell
 law run cf.PlotVariables1D --version v1 \
@@ -383,11 +323,8 @@ law run cf.PlotVariables1D --version v1 \
 
 ## Using your own plotting function
 
-While all plotting tasks provide default plotting functions which implement many parameters to
-customize the plot, it might be necessary to write your own plotting functions if you want to create
-a specific type of plot. In that case, you can simply write a function that follows the signature
-of all other plotting functions and call a plotting task with this function using the
-`--plot-function` parameter.
+While all plotting tasks provide default plotting functions which implement many parameters to customize the plot, it might be necessary to write your own plotting functions if you want to create a specific type of plot.
+In that case, you can simply write a function that follows the signature of all other plotting functions and call a plotting task with this function using the `--plot-function` parameter.
 
 An example on how to implement such a plotting function is shown in the following:
 

--- a/docs/user_guide/plotting.md
+++ b/docs/user_guide/plotting.md
@@ -10,14 +10,15 @@ An overview of all plotting tasks is given in the [Plotting tasks](../task_overv
 ## Creating your first plot
 
 Assuming you used the analysis template to setup your analysis, you can create a first plot by running
+
 ```shell
 law run cf.PlotVariables1D --version v1 \
     --calibrators example --selector example --producer example \
     --processes data,tt,st --variables n_jet --categories incl,2j
 ```
+
 This will run the full analysis chain for the given processes (data, tt, st) and should create
 plots looking like this:
-
 
 ::::{grid} 1 1 2 2
 :::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.pdf
@@ -29,7 +30,6 @@ plots looking like this:
 :::
 ::::
 
-
 :::{dropdown} Where do I find that plot?
 You can add ```--print-output 0``` to every task call, which will print the full filename of all
 outputs of the requested task. Alternatively, you can add ```--fetch-output 0,a``` to directly
@@ -37,7 +37,6 @@ copy all outputs of this task into the directory you are currently in.
 Finally, there is the ```--view-cmd``` parameter you can add to directly display the plot during
 the runtime of the task, e.g. via ```--view-cmd evince-previewer```.
 :::
-
 
 The ```PlotVariables1D``` task is located at the bottom of our
 [task graph](https://github.com/columnflow/columnflow/wiki#default-task-graph), which means that
@@ -76,7 +75,6 @@ the events corresponding to the dataset ```tt_sl_powheg``` will be displayed twi
 plot.
 :::
 
-
 ## Customization of plots
 
 There are many different parameters implemented that allow customizing the style of a plot. A short
@@ -94,11 +92,13 @@ To change the text next to the label, you can add the ```--cms-label``` paramete
 :::{dropdown} What are the ```cms-label``` options?
 In general, this parameter accepts all types of strings, but there is a set of shortcuts for commonly
 used labels that will automatically be resolved:
+
 ```{literalinclude} ../../columnflow/plotting/plot_all.py
 :language: python
 :start-at: label_options
 :end-at: "}"
 ```
+
 :::
 
 To compare shapes of multiple processes, you might want to plot each process separately as one line.
@@ -162,7 +162,6 @@ law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1
 :::
 ::::
 
-
 :::{dropdown} Limitations of the ```variable_settings```
 While in theory we can change anything inside the variable and process instances via the
 ```variable_settings``` parameter, there are certain attributes that are already used during the creation
@@ -170,7 +169,6 @@ of the histograms (e.g. the ```expression``` and the ```binning```). Since our `
 parameter only modifies these attributes during the runtime of our plotting task, this will not
 impact our final results.
 :::
-
 
 For the ```general_settings```, ```process_settings```, and ```variable_settings``` you can define
 defaults and groups in the config, e.g. via
@@ -184,6 +182,7 @@ config_inst.x.general_settings_groups = {
     "compare_shapes": {"skip_ratio": True, "shape_norm": True, "yscale": "log", "cms_label": "simpw"},
 }
 ```
+
 The default is automatically used when no parameter is given in the task call, and the groups can
 be used directly on the command line and will be resolved automatically. Our previously defined
 defaults and groups will be used e.g. by the following task call:
@@ -203,13 +202,13 @@ law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1
 :::
 ::::
 
-
 ## Creating 2D plots
 
 Columnflow also provides the {py:class}`~columnflow.tasks.plotting.PlotVariables2D` task to create
 two-dimensional plots. Two-dimensional histograms are created by passing two variables to the
 ```--variables``` parameter, separated by a ```-```. Here is an exemplary task call and their
 outputs.
+
 ```shell
 law run cf.PlotVariables2D --version v1 \
     --processes tt,st --variables n_jet-jet1_pt,jet1_pt-n_jet
@@ -238,6 +237,7 @@ tasks that can produce plots after each individual selection step.
 
 To create a simple cutflow plot, displaying event yields after each individual selection step,
 you can use the {py:class}`~columnflow.tasks.cutflow.PlotCutflow` task, e.g. via calling
+
 ```shell
 law run cf.PlotCutflow --version v1 \
     --calibrators example --selector example --categories incl,2j \
@@ -266,14 +266,15 @@ A detailed guide on how to implement your own selector can be found in the
 
 Per default, the name of the selector step is used on the x-axis, but you can also provide custom
 step labels via the config:
+
 ```python
 config_inst.x.selector_step_labels = {
     "muon": r"$N_{muon} = 1$",
     "jet": r"$N_{jets}^{AK4} \geq 1$",
 }
 ```
-:::
 
+:::
 
 To create plots of variables as part of the cutflow, we also provide the
 {py:class}`~columnflow.tasks.cutflow.PlotCutflowVariables1D`, which mostly behaves the same as the
@@ -321,13 +322,13 @@ law run cf.PlotCutflowVariables1D --version v1 \
 :::
 ::::
 
-
 ## Creating plots for different shifts
 
 Like most tasks, our plotting tasks also contain the ```--shift``` parameter that allows requesting
 the outputs for a certain type of systematic variation. Per default, the ```--shift``` parameter is set
 to "nominal", but you could also produce your plot with a certain systematic uncertainty varied
 up or down, e.g. via running
+
 ```shell
 law run cf.PlotVariables1D --version v1 \
     --processes tt,st --variables n_jet --shift mu_up
@@ -346,10 +347,12 @@ For directly comparing differences introduced by one shift source, we provide th
 parameter, this task implements the ```--shift-sources``` option and creates one plot per shift source
 displaying the nominal distribution (black) compared to the shift source varied up (red) and down (blue).
 The task can be called e.g. via
+
 ```shell
 law run cf.PlotShiftedVariables1D --version v1 \
     --processes tt,st --variables jet1_pt,n_jet --shift-sources mu
 ```
+
 and produces the following plot:
 
 ::::{grid} 1 1 2 2
@@ -366,17 +369,18 @@ This produces per default only one plot containing the sum of all processes. To 
 per process, you can use the {py:class}`~columnflow.tasks.plotting.PlotShiftedVariablesPerProcess1D`
 task
 
-
 ## Directly displaying plots in the terminal
 
 All plotting tasks also include a ```--view-cmd``` parameter that allows directly printing the plot
 during the runtime of the task:
+
 ```shell
 law run cf.PlotVariables1D --version v1 \
     --processes tt,st --variables n_jet --view-cmd evince-previewer
 ```
 
 (custom_plot_function)=
+
 ## Using your own plotting function
 
 While all plotting tasks provide default plotting functions which implement many parameters to
@@ -386,7 +390,6 @@ of all other plotting functions and call a plotting task with this function usin
 `--plot-function` parameter.
 
 An example on how to implement such a plotting function is shown in the following:
-
 
 ```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/plotting/example.py
 :language: python

--- a/docs/user_guide/sandbox.md
+++ b/docs/user_guide/sandbox.md
@@ -1,5 +1,6 @@
 
 # Sandboxes and Their Use in Columnflow
+
 Columnflow is a backend framework designed to orchestrate columnar analyses entirely with Python.
 Various steps of an analysis necessitate distinct software environments.
 To maintain flexibility and lightweight configurations [venv](https://docs.python.org/3/library/venv.html) (virtual environments) are employed.
@@ -7,14 +8,16 @@ To maintain flexibility and lightweight configurations [venv](https://docs.pytho
 The following guide explains how to define, update, and utilize a sandbox within Columnflow.
 
 ## Whats needs to be defined
+
 A Columnflow environment consists of two files:
+
 1. **setup.sh:**, sets up a virtual environment in `$CF_VENV_PATH`.
 2. **requirement.txt:** , defines the required modules and their versions.
 
 ## Where to Store the Corresponding Files
 
 For organizational purposes, it is recommended to store your setup and requirement files in `$ANALYSIS_BASE/sandboxes/`, where `$ANALYSIS_BASE` is the root directory for your analysis.
-The latter is usually the abbreviated form you specified for your analysis in upper case, e.g. the root directory for analysis `hbt` is `$HBT_BASE`. 
+The latter is usually the abbreviated form you specified for your analysis in upper case, e.g. the root directory for analysis `hbt` is `$HBT_BASE`.
 It is of good practice to follow the naming conventions used by Columnflow.
 Begin your setup file with "venv," for example, `venv_YOUR_ENVIRONMENT.sh`, and use only the environment name (without "venv") for your requirement file, e.g., `YOUR_ENVIRONMENT.txt`.
 
@@ -23,14 +26,18 @@ Begin your setup file with "venv," for example, `venv_YOUR_ENVIRONMENT.sh`, and 
 Begin your setup file by referencing an existing setup file within the `$ANALYSIS_BASE/sandboxes/` directory.
 In this example, we start from a copy of `venv_columnar.sh`:
 We start from `venv_columnar.sh`
+
 ```{literalinclude} ../../sandboxes/venv_columnar.sh
 :language: bash
 ```
+
 You only need to change `CF_VENV_REQUIREMENTS` to point to your new requirement file.
 
 ## The requirement file
+
 The requirement.txt uses pip notation.
 A quick overview is given of commonly used notation:
+
 ```bash
 # version 1
 # Get Coffea from a GitHub repository with a specific commit/tag (@9ecdee5) as an egg file named coffea (#egg=coffea).
@@ -39,21 +46,24 @@ git+https://github.com/riga/coffea.git@9ecdee5#egg=coffea
 # Get the latest version of dask-awkward, but do not exceed version 2023.2.
 dask-awkward~=2023.2
 ```
+
 For more information, refer to the official [pip documentation](https://pip.pypa.io/en/stable/reference/requirements-file-format/).
 
 Columnflow manages sandboxes by using a version number at the very first line (`# version ANY_FLOAT`).
 This version defines a software package, and it is good practice to change the version number whenever an environment is altered.
 
 ## How to Use the Namespace
+
 One may wonder how to work with namespaces of certain modules when it is not guaranteed that this module is available.
 For this case, the {py:meth}`~columnflow.util.maybe_import` function is there.
 This utility function handles the import for you and makes the namespace available.
 
 The input of {py:meth}`~columnflow.util.maybe_import` is the name of the module, provided as a string.
+
 ```python
 # maybe_import version of:
 # import tensorflow as tf
 tf = maybe_import("tensorflow")
 ```
-It is good practice to use `maybe_import` within the local namespace if you use the module once, and at the global namespace level if you intend to use multiple times.
 
+It is good practice to use `maybe_import` within the local namespace if you use the module once, and at the global namespace level if you intend to use multiple times.

--- a/docs/user_guide/structure.md
+++ b/docs/user_guide/structure.md
@@ -1,8 +1,6 @@
 # Columnflow Structure
 
-
 In this section, an overview to the structure of Columnflow is provided, starting with a general introduction, followed by a description of the various tasks implemented in columnflow and ending with an introduction on how to configure your analysis on top of columnflow with the analysis and config object from the [order](https://github.com/riga/order) package.
-
 
 ## General introduction
 
@@ -11,12 +9,12 @@ The workflow orchestration is managed by [law](https://github.com/riga/law) and 
 A short introduction to law is given in the {doc}`law section <law>`.
 If you have never used law before, this section is highly recommended as a few very convenient commands are presented there.
 
-
 The data processing in columnflow is based on columns in [awkward arrays](https://awkward-array.org/doc/main/) with [coffea](https://coffeateam.github.io/coffea/)-generated behaviour.
 Fields like "Jet" exist too, they contain columns with the same first dimension (the parameters of the field, e.g. Jet.pt). A few additional functions for simplified handling of columns were defined in {py:mod}`~columnflow.columnar_util`.
 
 As most of the information is conserved in the form of columns, it would be very inefficient (and might not even fit in the memory) to use all columns and all events from a dataset at once for each task.
 Therefore, in order to reduce the impact on the memory:
+
 - a chunking of the datasets is implemented using [dask](https://www.dask.org/): not all events from a dataset are inputed in a task at once, but only chunked in groups of events. (100 000 events max per group is default as of 05.2023, default is set in the law.cfg file).
 - the user needs to define for each {py:class}`~columnflow.production.Producer`, {py:class}`~columnflow.calibration.Calibrator` and {py:class}`~columnflow.selection.Selector` which columns are to be loaded (this happens by defining the ```uses``` set in the header of the decorator of the class) and which new columns/fields are to be saved in parquet files after the respective task (this happens by defining the ```produces``` set in the header of the decorator of the class).
 The exact implementation for this feature is further detailed in {doc}`building_blocks/selectors` and {doc}`building_blocks/producers`.
@@ -49,7 +47,6 @@ These two parameters respectively define the config file for the different analy
 
 Similarly the ```--version``` parameter, which purpose is explained in the {doc}`law` section of this documentation, is required to start a task.
 
-
 ## Important modules and configs
 
 The standard syntax to access objects in columnflow is the dot syntax, usable for the [order](https://github.com/riga/order) metavariables (e.g. campaign.x.year) as well as the [awkward arrays](https://awkward-array.org/doc/main/) (e.g. events.Jet.pt).
@@ -58,10 +55,10 @@ TODO
 
 here mention the analysis template
 
-
 ### Law config
 
 (analysis_campaign_config)=
+
 ### Analysis, Campaign and Config
 
 Columnflow uses the {external+order:py:class}`order.analysis.Analysis` class from the [order](https://github.com/riga/order) package to define a specific analysis.
@@ -118,6 +115,7 @@ tt = Process(
 
 Using the physical Process defined above, one may now create a dataset, which can be added to the Campaign object.
 An example of dataset definition with scale variations for this campaign would then be (values taken from [the analysis-grand-challenge GitHub repository](https://github.com/iris-hep/analysis-grand-challenge/blob/be91d2c80225b7a91ce6b153591f8605167bf555/analyses/cms-open-data-ttbar/nanoaod_inputs.json)):
+
 ```python
 import agc.config.processes as procs
 from order import DatasetInfo
@@ -161,6 +159,7 @@ A Config object is saving the variables specific to the analysis.
 It is associated to an Analysis and a Campaign object.
 It is to be created using the {external+order:py:meth}`order.analysis.Analysis.add_config` method on the analysis object, with the associated Campaign object as argument.
 An example would be:
+
 ```python
 cfg = analysis.add_config(campaign, name=config_name, id=config_id)
 ```
@@ -169,4 +168,3 @@ In this way, one Analysis can be tied to different Campaigns (e.g. corresponding
 
 Several classes of the order library are used for the organization and use of the metavariables.
 A more detailed description of the most important objects to be defined in the Config object is presented in the {doc}`building_blocks/config_objects` section of this documentation.
-

--- a/docs/user_guide/structure.md
+++ b/docs/user_guide/structure.md
@@ -15,29 +15,24 @@ Fields like "Jet" exist too, they contain columns with the same first dimension 
 As most of the information is conserved in the form of columns, it would be very inefficient (and might not even fit in the memory) to use all columns and all events from a dataset at once for each task.
 Therefore, in order to reduce the impact on the memory:
 
-- a chunking of the datasets is implemented using [dask](https://www.dask.org/): not all events from a dataset are inputed in a task at once, but only chunked in groups of events. (100 000 events max per group is default as of 05.2023, default is set in the law.cfg file).
+- a chunking of the datasets is implemented using [dask](https://www.dask.org/):
+not all events from a dataset are inputed in a task at once, but only chunked in groups of events.
+(100 000 events max per group is default as of 05.2023, default is set in the law.cfg file).
 - the user needs to define for each {py:class}`~columnflow.production.Producer`, {py:class}`~columnflow.calibration.Calibrator` and {py:class}`~columnflow.selection.Selector` which columns are to be loaded (this happens by defining the ```uses``` set in the header of the decorator of the class) and which new columns/fields are to be saved in parquet files after the respective task (this happens by defining the ```produces``` set in the header of the decorator of the class).
 The exact implementation for this feature is further detailed in {doc}`building_blocks/selectors` and {doc}`building_blocks/producers`.
 
 ## Tasks in columnflow
 
-Tasks are [law](https://github.com/riga/law) objects allowing to control a workflow. All the tasks
-presented below are proposed by columnflow and allow for a fairly complete analysis workflow.
-However, as analyses are very diverse, it is possible that a specific analysis will need more
-stearing options or even completely new tasks. Thankfully, columnflow is not a fixed structure and
-you will be able to create new tasks in such a case, following the corresponding example in the
-{doc}`examples` section of this documentation.
-The full task tree of general columnflow tasks can be seen in
-[this wikipage](https://github.com/columnflow/columnflow/wiki#default-task-graph). There are also
-experiment-specific tasks which are not present in this graph. However, these are introduced in the
-{ref}`CMS specializations section <cms_specializations_section>`.
+Tasks are [law](https://github.com/riga/law) objects allowing to control a workflow.
+All the tasks presented below are proposed by columnflow and allow for a fairly complete analysis workflow.
+However, as analyses are very diverse, it is possible that a specific analysis will need more stearing options or even completely new tasks.
+Thankfully, columnflow is not a fixed structure and you will be able to create new tasks in such a case, following the corresponding example in the {doc}`examples` section of this documentation.
+The full task tree of general columnflow tasks can be seen in [this wikipage](https://github.com/columnflow/columnflow/wiki#default-task-graph).
+There are also experiment-specific tasks which are not present in this graph.
+However, these are introduced in the {ref}`CMS specializations section <cms_specializations_section>`.
 
-Further informations about tasks and law can be found in the
-{doc}`"Law Introduction" <law>` section of this documentation or in the
-[example section](https://github.com/riga/law#examples) of the law
-Github repository.
-For an overview of the tasks that are available with columnflow, please see the
-[Task Overview](../task_overview/introduction.md).
+Further informations about tasks and law can be found in the {doc}`"Law Introduction" <law>` section of this documentation or in the [example section](https://github.com/riga/law#examples) of the law Github repository.
+For an overview of the tasks that are available with columnflow, please see the [Task Overview](../task_overview/introduction.md).
 
 ## Important note on required parameters
 

--- a/tests/run_coverage
+++ b/tests/run_coverage
@@ -43,6 +43,21 @@ action() {
     ret="$?"
     [ "${gret}" = "0" ] && gret="${ret}"
 
+    echo
+    run_coverage test_config_util "venv_columnar_dev.sh"
+    ret="$?"
+    [ "${gret}" = "0" ] && gret="${ret}"
+
+    echo
+    run_coverage test_task_parameters
+    ret="$?"
+    [ "${gret}" = "0" ] && gret="${ret}"
+
+    echo
+    run_coverage test_plotting "venv_columnar_dev.sh"
+    ret="$?"
+    [ "${gret}" = "0" ] && gret="${ret}"
+
     return "${gret}"
 }
 action "$@"

--- a/tests/run_docs
+++ b/tests/run_docs
@@ -20,7 +20,8 @@ action() {
     local ret
 
     # markdown linting
-    pymarkdown --config "${cf_dir}/.markdownlint" scan --recurse "${cf_dir/README.md}" "${cf_dir/docs}"
+    pymarkdown --config "${cf_dir}/.markdownlint" scan "${cf_dir}/README.md" "${cf_dir}/docs/*.md" \
+        "${cf_dir}/docs/*/*.md" "${cf_dir}/docs/*/*/*.md" "${cf_dir}/docs/*/*/*/*.md"
     ret="$?"
     [ "${gret}" = "0" ] && gret="${ret}"
 


### PR DESCRIPTION
This PR fixes all linting issues in the cf-docs and `README` files. There are fixes for the markdown files (from the `pymarkdown` linting) as well as for all warning and errors occurring in `sphinx` when building the docs.

Some rules have been disabled in the config file, since they are widely used (e.g. html tables in the README etc.). Should this not be wanted, I am ready to make further changes :smile: 

The PR also add missing code tests to `run_coverage.sh`