### PR TITLE
Update sandboxes, adjust dak/ak IO.

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2560,11 +2560,9 @@ class DaskArrayReader(object):
         self.close()
 
     def __len__(self: DaskArrayReader) -> int:
-        return (
-            len(self.dak_array)
-            if self.dak_array.known_divisions
-            else dak.num(self.dak_array, axis=0).compute()
-        )
+        if not self.dak_array.known_divisions:
+            self.dak_array.eager_compute_divisions()
+        return len(self.dak_array)
 
     @property
     def closed(self: DaskArrayReader) -> bool:

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2529,9 +2529,7 @@ class DaskArrayReader(object):
         self: DaskArrayReader,
         path: str,
         open_options: dict | None = None,
-        # TODO: we want to go back to SLICES as soon as possible, but currently there is an issue
-        #       that we load all events into memory for each chunk when using SLICES
-        materialization_strategy: MaterializationStrategy = MaterializationStrategy.PARTITIONS,
+        materialization_strategy: MaterializationStrategy = MaterializationStrategy.SLICES,
     ):
         super().__init__()
 
@@ -2562,7 +2560,11 @@ class DaskArrayReader(object):
         self.close()
 
     def __len__(self: DaskArrayReader) -> int:
-        return len(self.dak_array)
+        return (
+            len(self.dak_array)
+            if self.dak_array.known_divisions
+            else dak.num(self.dak_array, axis=0).compute()
+        )
 
     @property
     def closed(self: DaskArrayReader) -> bool:
@@ -2631,7 +2633,9 @@ class DaskArrayReader(object):
         # fill the chunk -> partitions mapping once
         with self.chunk_to_partitions_lock:
             if not self.chunk_to_partitions:
-                divs = self.dak_array.divisions
+                if not self.dak_array.known_divisions:
+                    self.dak_array.eager_compute_divisions()
+                divs = tuple(map(int, self.dak_array.divisions))
                 # note: a hare-and-tortoise algorithm could be possible to get the mapping with less
                 # than n^2 complexity, but for our case with ~30 chunks this should be ok (for now)
                 n_chunks = int(math.ceil(len(self) / max_chunk_size))
@@ -3022,13 +3026,13 @@ class ChunkedIOHandler(object):
         ),
         open_options: dict | None = None,
         read_columns: set[str | Route] | None = None,
-    ) -> tuple[uproot.ReadOnlyDirectory, int]:
+    ) -> tuple[tuple[uproot.ReadOnlyDirectory, str], int]:
         """
         Opens an uproot file at *source* for subsequent processing with coffea and returns a 2-tuple
-        *(uproot file, tree entries)*. *source* can be the path of the file, an already opened,
-        readable uproot file (assuming the tree is called "Events"), or a 2-tuple whose second item
-        defines the name of the tree to be loaded. *open_options* are forwarded to ``uproot.open``
-        if a new file is opened. Passing *read_columns* has no effect.
+        *((uproot file, tree name), tree entries)*. *source* can be the path of the file, an already
+        opened, readable uproot file (assuming the tree is called "Events"), or a 2-tuple whose
+        second item defines the name of the tree to be loaded. *open_options* are forwarded to
+        ``uproot.open`` if a new file is opened. Passing *read_columns* has no effect.
         """
         tree_name = "Events"
         if isinstance(source, tuple) and len(source) == 2:
@@ -3045,38 +3049,39 @@ class ChunkedIOHandler(object):
         else:
             raise Exception(f"'{source}' cannot be opened as coffea_root")
 
-        return (source, tree.num_entries)
+        return ((source, tree_name), tree.num_entries)
 
     @classmethod
     def close_coffea_root(
         cls,
-        source_object: str | uproot.ReadOnlyDirectory,
+        source_object: tuple[str | uproot.ReadOnlyDirectory, str],
     ) -> None:
         """
-        Closes a ROOT file referred to by *source_object* if it is a ``ReadOnlyDirectory``. In case
-        a string is passed, this method does nothing.
+        Closes a ROOT file referred to by the first item in a 2-tuple *source_object* if it is a
+        ``ReadOnlyDirectory``. In case a string is passed, this method does nothing.
         """
-        close = None if isinstance(source_object, str) else getattr(source_object, "close", None)
+        close = getattr(source_object[0], "close", None)
         if callable(close):
             close()
 
     @classmethod
     def read_coffea_root(
         cls,
-        source_object: str | uproot.ReadOnlyDirectory,
+        source_object: tuple[str | uproot.ReadOnlyDirectory, str],
         chunk_pos: ChunkPosition,
         read_options: dict | None = None,
         read_columns: set[str | Route] | None = None,
     ) -> coffea.nanoevents.methods.base.NanoEventsArray:
         """
-        Given a file location or opened uproot file *source_object*, returns an awkward array chunk
-        referred to by *chunk_pos*, assuming nanoAOD structure. *read_options* are passed to
-        ``coffea.nanoevents.NanoEventsFactory.from_root``. *read_columns* are converted to strings
-        and, if not already present, added as nested field ``iteritems_options.filter_name`` to
-        *read_options*.
+        Given a file location or opened uproot file, and a tree name in a 2-tuple *source_object*,
+        returns an awkward array chunk referred to by *chunk_pos*, assuming nanoAOD structure.
+        *read_options* are passed to ``coffea.nanoevents.NanoEventsFactory.from_root``.
+        *read_columns* are converted to strings and, if not already present, added as nested fields
+        ``iteritems_options.filter_name`` to *read_options*.
         """
         # default read options
         read_options = read_options or {}
+        read_options["delayed"] = False
         read_options["runtime_cache"] = None
         read_options["persistent_cache"] = None
 
@@ -3099,8 +3104,10 @@ class ChunkedIOHandler(object):
             read_options.setdefault("iteritems_options", {})["filter_name"] = filter_name
 
         # read the events chunk into memory
+        _source_object, tree_name = source_object
         chunk = coffea.nanoevents.NanoEventsFactory.from_root(
-            source_object,
+            _source_object,
+            treepath=tree_name,
             entry_start=chunk_pos.entry_start,
             entry_stop=chunk_pos.entry_stop,
             **read_options,

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -354,13 +354,14 @@ class DatacardWriter(object):
             cat_obj = self.inference_model_inst.get_category(cat_name)
 
             # helper to fill empty bins in-place
-            fill_empty = lambda h: None
             if cat_obj.empty_bin_value:
                 def fill_empty(h):
                     value = h.view().value
                     mask = value <= 0
                     value[mask] = cat_obj.empty_bin_value
                     h.view().variance[mask] = cat_obj.empty_bin_value
+            else:
+                fill_empty = lambda h: None
 
             _rates = rates[cat_name] = OrderedDict()
             _effects = effects[cat_name] = OrderedDict()

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -83,7 +83,10 @@ def normalization_weights_setup(
           processes known to the config of the task, with keys being process ids.
     """
     # load the selection stats
-    selection_stats = inputs["selection_stats"]["collection"][0]["stats"].load(formatter="json")
+    selection_stats = self.task.cached_value(
+        key="selection_stats",
+        func=lambda: inputs["selection_stats"]["collection"][0]["stats"].load(formatter="json"),
+    )
 
     # for the lookup tables below, determine the maximum process id
     process_insts = [

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -275,13 +275,17 @@ class SelectionResult(od.AuxDataMixin):
 
         # helper to create a view without behavior
         def deepcopy_without_behavior(struct: T) -> T:
-            return copy.deepcopy(law.util.map_struct(
-                (lambda obj: ak.Array(obj, behavior={}) if isinstance(obj, ak.Array) else obj),
+            return law.util.map_struct(
+                (lambda obj: (
+                    ak.Array(obj, behavior={})
+                    if isinstance(obj, ak.Array)
+                    else copy.deepcopy(obj)
+                )),
                 struct,
                 map_list=True,
                 map_tuple=True,
                 map_dict=True,
-            ))
+            )
 
         # logical AND between event masks
         if self.event is None:

--- a/docs/user_guide/examples/ml_code.py
+++ b/docs/user_guide/examples/ml_code.py
@@ -24,13 +24,12 @@ law.contrib.load("tensorflow")
 
 
 class TestModel(MLModel):
+
     # shared between all model instances
-    datasets: dict = {
-        "datasets_name": [
-            "hh_ggf_bbtautau_madgraph",
-            "tt_sl_powheg",
-        ],
-    }
+    dataset_names = [
+        "hh_ggf_bbtautau_madgraph",
+        "tt_sl_powheg",
+    ]
 
     def __init__(
         self,
@@ -63,10 +62,10 @@ class TestModel(MLModel):
 
     def datasets(self, config_inst: od.Config) -> set[od.Dataset]:
         # normally you would pass this to the model via config and loop through these names ...
-        all_datasets_names = self.datasets_name
+        all_dataset_names = self.dataset_names
 
         dataset_inst = []
-        for dataset_name in all_datasets_names:
+        for dataset_name in all_dataset_names:
             dataset_inst.append(config_inst.get_dataset(dataset_name))
 
         # ... but you can also add one dataset by using its name

--- a/sandboxes/cf.txt
+++ b/sandboxes/cf.txt
@@ -1,8 +1,8 @@
-# version 11
+# version 12
 
 tenacity!=8.4.0
 luigi~=3.5.1
 scinum~=2.1.1
 six~=1.16.0
-pyyaml==6.*
-typing_extensions~=4.8.0
+pyyaml~=6.0.1
+typing_extensions~=4.12.2

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,12 +1,12 @@
-# version 13
+# version 14
 
-awkward==2.4.6
-uproot==5.1.2
-pyarrow==13.0.0
-dask-awkward==2023.10.1
-git+https://github.com/CoffeaTeam/coffea.git@v2023.10.0.rc1#egg=coffea
+awkward==2.6.6
+uproot==5.3.9
+pyarrow==16.1.0
+dask-awkward==2024.6.0
+coffea==2024.6.1
+correctionlib==2.6.0
 tabulate~=0.9.0
-zstandard~=0.21.0
-lz4~=4.3.2
+zstandard~=0.22.0
+lz4~=4.3.3
 xxhash~=3.4.1
-correctionlib~=2.4.0

--- a/sandboxes/dev.txt
+++ b/sandboxes/dev.txt
@@ -1,10 +1,10 @@
-# version 8
+# version 9
 
-ipython~=8.8
-pytest~=7.1
-pytest-cov~=3.0
-flake8~=5.0
-flake8-commas~=2.1
-flake8-quotes~=3.3
-pipdeptree~=2.13
+ipython~=8.18.1
+pytest~=8.2.2
+pytest-cov~=5.0.0
+flake8~=7.1.0
+flake8-commas~=4.0.0
+flake8-quotes~=3.4.0
+pipdeptree~=2.23.0
 pymarkdownlnt~=0.9.20


### PR DESCRIPTION
This PR updates all central sandboxes to use latest dependencies.

Most packages are referenced through the "compatible release" modifier `~=X.Y.Z` (meaning `>= X.Y.Z,==X.Y.*`, so only allowing patch releases), whereas columnar packages (uproot/awkward/dask_awkward/coffea) are pinned to exact versions since they are still somewhat moving targets.

I tested the entire workflow with these updates which, as expected, failed due to some core changes in said columnar packages. Therefore I made some changes deep in the IO, as well as some more high level adjustments, so that everything is running smoothly now. Maybe you can confirm @mafrahm, but I think the memory consumption during event handling is improved.

Closes #469.