### PR TITLE
Make el9 the default on NAF.

### DIFF
--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -28,7 +28,7 @@ bootstrap_htcondor_standalone() {
     fi
     local sharing_software="$( [ -z "{{cf_software_base}}" ] && echo "false" || echo "true" )"
     local lcg_setup="{{cf_remote_lcg_setup}}"
-    lcg_setup="${lcg_setup:-/cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh}"
+    lcg_setup="${lcg_setup:-/cvmfs/grid.cern.ch/alma9-ui-test/etc/profile.d/setup-alma9-test.sh}"
 
     # fallback to a default path when the externally given software base is empty or inaccessible
     local fetch_software="true"

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -147,7 +147,7 @@ bootstrap_crab() {
     export CF_WLCG_TOOLS="{{wlcg_tools}}"
     export LAW_CONFIG_FILE="{{law_config_file}}"
     local lcg_setup="{{cf_remote_lcg_setup}}"
-    lcg_setup="${lcg_setup:-/cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh}"
+    lcg_setup="${lcg_setup:-/cvmfs/grid.cern.ch/alma9-ui-test/etc/profile.d/setup-alma9-test.sh}"
 
     # when gfal is not available, check that the lcg_setup file exists
     local skip_lcg_setup="true"

--- a/law.cfg
+++ b/law.cfg
@@ -126,7 +126,8 @@ crab_storage_element: $CF_CRAB_STORAGE_ELEMENT
 crab_base_directory: $CF_CRAB_BASE_DIRECTORY
 
 # lcg setup file sourced in remote jobs to access gfal tools
-remote_lcg_setup: /cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh
+remote_lcg_setup_el7: /cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-c7-ui-python3-example.sh
+remote_lcg_setup_el9: /cvmfs/grid.cern.ch/alma9-ui-test/etc/profile.d/setup-alma9-test.sh
 
 
 [logging]


### PR DESCRIPTION
This PR makes Alma9/el9 the default on the NAF htcondor batch system.

The changes are pretty straight forward.

**Switching to el9**

At this time, naf-cms* login nodes 15 and higher are already on el9, so to switch, naf users would have to login only to these nodes and reinstall their entire software stack once (doing `CF_REINSTALL_SOFTWARE=1 source setup.sh ...` once).

**Staying at centos7**

To stay on the old OS, one could export `CF_HTCONDOR_FLAVOR=naf_el7` or set `--htcondor-flavor naf_el7` per task. **However**, I think this would only be a temporary solution since also login nodes ≤ 14 will be moved in the very near future so I guess we should all transition asap anyway.