### PR TITLE
Route brace expansion

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -243,9 +243,9 @@ cfg.x.keep_columns = DotDict.wrap({
         # additional columns can be added as strings, similar to object info
         ColumnCollection.MANDATORY_COFFEA,
         # object info
-        "Jet.pt", "Jet.eta", "Jet.phi", "Jet.mass", "Jet.btagDeepFlavB", "Jet.hadronFlavour",
-        "Muon.pt", "Muon.eta", "Muon.phi", "Muon.mass", "Muon.pfRelIso04_all",
-        "MET.pt", "MET.phi", "MET.significance", "MET.covXX", "MET.covXY", "MET.covYY",
+        "Jet.{pt,eta,phi,mass,btagDeepFlavB,hadronFlavour}",
+        "Muon.{pt,eta,phi,mass,pfRelIso04_all}",
+        "MET.{pt,phi,significance,covXX,covXY,covYY}",
         "PV.npvs",
         # all columns added during selection using a ColumnCollection flag, but skip cutflow ones
         ColumnCollection.ALL_FROM_SELECTOR,

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -366,6 +366,15 @@ class Route(od.TagMixin):
             return self.column == other
         return False
 
+    def __lt__(self, other: Route | str | Sequence[str | int | slice | type(Ellipsis) | list]) -> bool:
+        if isinstance(other, Route):
+            return self.fields < other.fields
+        if isinstance(other, (list, tuple)):
+            return self.fields < tuple(other)
+        if isinstance(other, str):
+            return self.column < other
+        return False
+
     def __bool__(self) -> bool:
         return len(self._fields) > 0
 
@@ -1837,7 +1846,11 @@ class ArrayFunction(Derivable):
 
                 # add the columns
                 columns |= flagged.wrapped._get_columns(flagged.io_flag, _cache=_cache)
+            elif isinstance(obj, str):
+                # expand braces in strings
+                columns |= set(map(Route, law.util.brace_expand(obj)))
             else:
+                # let Route handle it
                 columns.add(Route(obj))
 
         return columns

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1956,7 +1956,8 @@ def tagged_column(
     """
     Takes one or several objects *routes* whose type can be anything that is accepted by the
     :py:class:`~.Route` constructor, and returns a single or a set of route objects being tagged
-    *tag*, which can be a single tag, a sequence, or a set of tags.
+    *tag*, which can be a single tag, a sequence, or a set of tags. Brace expansion is supported
+    in strings.
     """
     if not routes:
         raise Exception("at least one route argument must be given")
@@ -1974,8 +1975,17 @@ def tagged_column(
     elif len(routes) > 1:
         multiple = True
 
-    # create multiple or a single tagged route
-    return set(map(tagged_route, routes)) if multiple else tagged_route(list(routes)[0])
+    # create tagged routes
+    tagged_routes = set()
+    for r in routes:
+        # brace expansions for strings
+        if isinstance(r, str):
+            tagged_routes |= set(map(tagged_route, law.util.brace_expand(r)))
+        else:
+            tagged_routes.add(tagged_route(r))
+
+    multiple |= len(tagged_routes) > 1
+    return tagged_routes if multiple else tagged_routes.pop()
 
 
 def optional_column(

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -981,6 +981,31 @@ class ConfigTask(AnalysisTask):
 
         return columns
 
+    def _expand_keep_column(
+        self: ConfigTask,
+        column:
+            ColumnCollection | Route | str |
+            Sequence[str | int | slice | type(Ellipsis) | list | tuple],
+    ) -> set[Route]:
+        """
+        Expands a *column* into a set of :py:class:`Route` objects. *column* can be a
+        :py:class:`ColumnCollection`, a string, or any type that is accepted by :py:class:`Route`.
+        Collections are expanded through :py:meth:`find_keep_columns`.
+
+        :param column: The column to expand.
+        :return: A set of :py:class:`Route` objects.
+        """
+        # expand collections
+        if isinstance(column, ColumnCollection):
+            return self.find_keep_columns(column)
+
+        # brace expand strings
+        if isinstance(column, str):
+            return set(map(Route, law.util.brace_expand(column)))
+
+        # let Route handle it
+        return {Route(column)}
+
 
 class ShiftTask(ConfigTask):
 

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -91,8 +91,8 @@ class ReduceEvents(
     @law.decorator.safe_output
     def run(self):
         from columnflow.columnar_util import (
-            ColumnCollection, Route, RouteFilter, mandatory_coffea_columns, update_ak_array,
-            add_ak_aliases, sorted_ak_to_parquet,
+            Route, RouteFilter, mandatory_coffea_columns, update_ak_array, add_ak_aliases,
+            sorted_ak_to_parquet,
         )
         from columnflow.selection.util import create_collections_from_masks
 
@@ -113,15 +113,7 @@ class ReduceEvents(
         write_columns: set[Route] = set()
         skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, ["*"]):
-            # expand collections and braces in strings
-            if isinstance(c, ColumnCollection):
-                routes = self.find_keep_columns(c)
-            elif isinstance(c, str):
-                routes = set(map(Route, law.util.brace_expand(c)))
-            else:
-                routes = {Route(c)}
-            # loop
-            for r in routes:
+            for r in self._expand_keep_column(c):
                 if r.has_tag("skip"):
                     skip_columns.add(r.column)
                 else:

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -113,7 +113,15 @@ class ReduceEvents(
         write_columns: set[Route] = set()
         skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, ["*"]):
-            for r in (self.find_keep_columns(c) if isinstance(c, ColumnCollection) else {Route(c)}):
+            # expand collections and braces in strings
+            if isinstance(c, ColumnCollection):
+                routes = self.find_keep_columns(c)
+            elif isinstance(c, str):
+                routes = set(map(Route, law.util.brace_expand(c)))
+            else:
+                routes = {Route(c)}
+            # loop
+            for r in routes:
                 if r.has_tag("skip"):
                     skip_columns.add(r.column)
                 else:

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -479,7 +479,15 @@ class MergeSelectionMasks(
         write_columns: set[Route] = set()
         skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, []):
-            for r in (self.find_keep_columns(c) if isinstance(c, ColumnCollection) else {Route(c)}):
+            # expand collections and braces in strings
+            if isinstance(c, ColumnCollection):
+                routes = self.find_keep_columns(c)
+            elif isinstance(c, str):
+                routes = set(map(Route, law.util.brace_expand(c)))
+            else:
+                routes = {Route(c)}
+            # loop
+            for r in routes:
                 if r.has_tag("skip"):
                     skip_columns.add(r.column)
                 else:

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -463,7 +463,7 @@ class MergeSelectionMasks(
 
     def zip_results_and_columns(self, inputs, tmp_dir):
         from columnflow.columnar_util import (
-            ColumnCollection, Route, RouteFilter, sorted_ak_to_parquet, mandatory_coffea_columns,
+            Route, RouteFilter, sorted_ak_to_parquet, mandatory_coffea_columns,
         )
 
         chunks = []
@@ -479,15 +479,7 @@ class MergeSelectionMasks(
         write_columns: set[Route] = set()
         skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, []):
-            # expand collections and braces in strings
-            if isinstance(c, ColumnCollection):
-                routes = self.find_keep_columns(c)
-            elif isinstance(c, str):
-                routes = set(map(Route, law.util.brace_expand(c)))
-            else:
-                routes = {Route(c)}
-            # loop
-            for r in routes:
+            for r in self._expand_keep_column(c):
                 if r.has_tag("skip"):
                     skip_columns.add(r.column)
                 else:

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -106,7 +106,15 @@ class UniteColumns(
         write_columns: set[Route] = set()
         skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, ["*"]):
-            for r in (self.find_keep_columns(c) if isinstance(c, ColumnCollection) else {Route(c)}):
+            # expand collections and braces in strings
+            if isinstance(c, ColumnCollection):
+                routes = self.find_keep_columns(c)
+            elif isinstance(c, str):
+                routes = set(map(Route, law.util.brace_expand(c)))
+            else:
+                routes = {Route(c)}
+            # loop
+            for r in routes:
                 if r.has_tag("skip"):
                     skip_columns.add(r.column)
                 else:

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -89,8 +89,8 @@ class UniteColumns(
     @law.decorator.safe_output
     def run(self):
         from columnflow.columnar_util import (
-            ColumnCollection, Route, RouteFilter, mandatory_coffea_columns, update_ak_array,
-            sorted_ak_to_parquet, sorted_ak_to_root,
+            Route, RouteFilter, mandatory_coffea_columns, update_ak_array, sorted_ak_to_parquet,
+            sorted_ak_to_root,
         )
 
         # prepare inputs and outputs
@@ -106,15 +106,7 @@ class UniteColumns(
         write_columns: set[Route] = set()
         skip_columns: set[str] = set()
         for c in self.config_inst.x.keep_columns.get(self.task_family, ["*"]):
-            # expand collections and braces in strings
-            if isinstance(c, ColumnCollection):
-                routes = self.find_keep_columns(c)
-            elif isinstance(c, str):
-                routes = set(map(Route, law.util.brace_expand(c)))
-            else:
-                routes = {Route(c)}
-            # loop
-            for r in routes:
+            for r in self._expand_keep_column(c):
                 if r.has_tag("skip"):
                     skip_columns.add(r.column)
                 else:


### PR DESCRIPTION
This PR provides brace expansion to all places where we handle multiple user defined routes / columns. As a result, it becomes possible to write e.g.

```python
@producer(
   uses={"Jet.{pt,eta,phi}"},
)
def ...
```

in CSPs, or

```python
cfg.x.keep_columns = DotDict.wrap({
    "cf.ReduceEvents": {
        "{Jet,FatJet}.{pt,eta,phi,mass,btagPNet*}",
```

in the config. On our end, this would make longish configurations way easier to understand and maintain.