### PR TITLE
FIX `stack` argument for the scaling of processes in the plotting

### DIFF
--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -107,8 +107,8 @@ def apply_process_settings(
         if stack_integral is None:
             stack_integral = sum(
                 proc_h.sum().value
-                for proc_h in hists.values()
-                if not hasattr(proc_h, "unstack")
+                for proc, proc_h in hists.items()
+                if not hasattr(proc, "unstack") and not proc.is_data
             )
         return stack_integral
 


### PR DESCRIPTION
Small bug, where the data is added to the area of the stacked processes, when calculating the integral of the stack.
In line 110 `hists.items()` is required, because the `unstack` and `is_data` flags are carried by the process instances and not by the histograms.