### PR TITLE
Plotting updates

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -263,7 +263,11 @@ def plot_all(
         }
         rax_kwargs.update(style_config.get("rax_cfg", {}))
         rax.set(**rax_kwargs)
-        fig.align_ylabels()
+
+        if "xlabel" in rax_kwargs:
+            ax.set_xlabel("")
+
+    fig.align_labels()
 
     # legend
     if not skip_legend:

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -133,7 +133,7 @@ def inject_label(
             elif c == "(":
                 in_parentheses -= 1
             if not in_parentheses:
-                return f"{label[:i]}{inject} {label[i:]}"
+                return f"{label[:i]} {inject} {label[i:]}"
 
     # otherwise, just append
     return f"{label} {inject}"

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -144,7 +144,7 @@ def inject_label(
             if not in_parentheses:
                 return f"{label[:i]}{inject} {label[i:]}"
 
-    # otherwise, just append the scale
+    # otherwise, just append
     return f"{label} {inject}"
 
 

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -110,7 +110,7 @@ def inject_label(
     inject: str | int | float,
     *,
     placeholder: str | None = None,
-    before_parentheses: bool = True,
+    before_parentheses: bool = False,
 ) -> str:
     """
     Injects a string *inject* into a *label* at a specific position, determined by different

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -12,6 +12,7 @@ import functools
 from collections import OrderedDict
 
 import order as od
+import scinum as sn
 
 from columnflow.util import maybe_import, try_int, try_complex
 from columnflow.types import Iterable, Any, Callable
@@ -62,7 +63,7 @@ def round_dynamic(value: int | float) -> int | float:
     Rounds a *value* at various scales to a subjective, sensible precision. Rounding rules:
 
         - 0 -> 0
-        - (0, 1) -> round to 0.1
+        - (0, 1) -> round to 1 significant digit
         - [1, 20]: round to 1
         - (20, 100]: round to 5
         - (100, 500]: round to 10
@@ -82,8 +83,9 @@ def round_dynamic(value: int | float) -> int | float:
         # plain 0 int
         return 0
     if value < 1:
-        # round to float with 0.1 precision
-        return sign * round(value, 1)
+        # one significant digit
+        v_str, _, mag = sn.round_value(value, method=1)
+        return float(v_str) * 10**mag
 
     # determine the reference scale
     mag_over_100 = int(math.ceil(math.log10(value) - 2)) if value > 100 else 0

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -65,7 +65,7 @@ def round_dynamic(value: int | float) -> int | float:
         - 0 -> 0 (int)
         - (0, 1) -> round to 1 significant digit (float)
         - [1, 10) -> round to 1 significant digit (int)
-        - [10, inf): round to 2 significant digits (float)
+        - [10, inf): round to 2 significant digits (int)
 
     :param value: The value to round.
     :return: The rounded value.

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -65,11 +65,9 @@ def round_dynamic(value: int | float) -> int | float:
         - (0, 1) -> round to 0.1
         - [1, 20]: round to 1
         - (20, 100]: round to 5
-        - (100, 200]: round to 10
-        - (200, 500]: round to 20
+        - (100, 500]: round to 10
         - (500, 1000]: round to 50
-        - (1000, 2000]: round to 100
-        - (2000, 5000]: round to 200
+        - (1000, 5000]: round to 100
         - (5000, 10000]: round to 500
         - ...
 
@@ -88,21 +86,12 @@ def round_dynamic(value: int | float) -> int | float:
         return sign * round(value, 1)
 
     # determine the reference scale
-    mag_over_1k = int(math.ceil(math.log10(value) - 3)) if value > 1000 else 0
-    value /= 10**mag_over_1k
-    if value <= 20:
-        ref = 1
-    elif value <= 100:
-        ref = 5
-    elif value <= 200:
-        ref = 10
-    elif value <= 500:
-        ref = 20
-    else:
-        ref = 50
+    mag_over_100 = int(math.ceil(math.log10(value) - 2)) if value > 100 else 0
+    value /= 10**mag_over_100
+    ref = 1 if value <= 20 else 5
 
     # round and return
-    return sign * int(round(value / ref) * ref * 10**mag_over_1k)
+    return sign * int(round(value / ref) * ref * 10**mag_over_100)
 
 
 def inject_label(

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -62,38 +62,25 @@ def round_dynamic(value: int | float) -> int | float:
     """
     Rounds a *value* at various scales to a subjective, sensible precision. Rounding rules:
 
-        - 0 -> 0
-        - (0, 1) -> round to 1 significant digit
-        - [1, 20]: round to 1
-        - (20, 100]: round to 5
-        - (100, 500]: round to 10
-        - (500, 1000]: round to 50
-        - (1000, 5000]: round to 100
-        - (5000, 10000]: round to 500
-        - ...
+        - 0 -> 0 (int)
+        - (0, 1) -> round to 1 significant digit (float)
+        - [1, 10) -> round to 1 significant digit (int)
+        - [10, inf): round to 2 significant digits (float)
 
     :param value: The value to round.
     :return: The rounded value.
     """
-    # separate sign
-    sign, value = (-1 if value < 0 else 1), abs(value)
+    # determine significant digits
+    digits = 1 if abs(value) < 10 else 2
 
-    # special cases
-    if not value:
-        # plain 0 int
-        return 0
-    if value < 1:
-        # one significant digit
-        v_str, _, mag = sn.round_value(value, method=1)
-        return float(v_str) * 10**mag
+    # split into value and magnitude
+    v_str, _, mag = sn.round_value(value, method=digits)
 
-    # determine the reference scale
-    mag_over_100 = int(math.ceil(math.log10(value) - 2)) if value > 100 else 0
-    value /= 10**mag_over_100
-    ref = 1 if value <= 20 else 5
+    # recombine
+    value = float(v_str) * 10**mag
 
-    # round and return
-    return sign * int(round(value / ref) * ref * 10**mag_over_100)
+    # return with proper type
+    return int(value) if value >= 1 else value
 
 
 def inject_label(

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -65,7 +65,7 @@ def round_dynamic(value: int | float) -> int | float:
         - 0 -> 0 (int)
         - (0, 1) -> round to 1 significant digit (float)
         - [1, 10) -> round to 1 significant digit (int)
-        - [10, inf): round to 2 significant digits (int)
+        - [10, inf) -> round to 2 significant digits (int)
 
     :param value: The value to round.
     :return: The rounded value.

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -209,6 +209,7 @@ def apply_process_settings(
                 proc_inst.label,
                 rf"$\times${scale_factor}",
                 placeholder="SCALE",
+                before_parentheses=True,
             )
 
         # remove remaining placeholders

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -198,7 +198,7 @@ class PlotBase(ConfigTask):
         def show(cmd=default_cmd, ext=pdf):
             if ext not in tmp_plots:
                 tmp_plots[ext] = law.LocalFileTarget(is_tmp=ext)
-            fig.savefig(tmp_plots[ext].abspath)
+            tmp_plots[ext].dump(fig, formatter="mpl")
             if cmd:
                 law.util.interruptable_popen([cmd, tmp_plots[ext].abspath])
             else:

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -44,15 +44,15 @@ class PlotBase(ConfigTask):
     general_settings = SettingsParameter(
         default=DotDict(),
         significant=False,
-        description="Parameter to set a list of custom plotting parameters. Format: "
+        description="parameter to set a list of custom plotting parameters; format: "
         "'option1=val1,option2=val2,...'",
     )
     custom_style_config = luigi.Parameter(
         default=RESOLVE_DEFAULT,
         significant=False,
-        description="Parameter to overwrite the *style_config* that is passed to the plot function"
-        "via a dictionary in the `custom_style_config_groups` auxiliary in the config;"
-        "defaults to the `default_custom_style_config` aux",
+        description="parameter to overwrite the *style_config* that is passed to the plot function"
+        "via a dictionary in the `custom_style_config_groups` auxiliary in the config; "
+        "defaults to the `default_custom_style_config` aux field",
     )
     skip_legend = law.OptionalBoolParameter(
         default=None,
@@ -66,6 +66,14 @@ class PlotBase(ConfigTask):
         "the following special values are expanded into the usual postfixes: wip, pre, pw, sim, "
         "simwip, simpre, simpw, od, odwip, public; no default",
     )
+    debug_plot = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="when True, an ipython debugger is started after the plot figure is created "
+        "for interactive adjustments; default: False",
+    )
+
+    exclude_params_remote_workflow = {"debug_plot"}
 
     @classmethod
     def resolve_param_values(cls, params):
@@ -156,8 +164,76 @@ class PlotBase(ConfigTask):
         Gets the plot function referred to by *func_name* via :py:meth:`get_plot_func`, calls it
         with all *kwargs* and returns its result. *kwargs* are updated through the
         :py:meth:`update_plot_kwargs` hook first.
+
+        Also, when the :py:attr:`debug_plot` parameter is set to True, an ipython debugger is
+        started after the plot is created and can be interactively debugged.
         """
-        return self.get_plot_func(func_name)(**(self.update_plot_kwargs(kwargs)))
+        plot_func = self.get_plot_func(func_name)
+        plot_kwargs = self.update_plot_kwargs(kwargs)
+
+        # defer to debug routine
+        if self.debug_plot:
+            return self._debug_plot(plot_func, plot_kwargs)
+
+        return plot_func(**plot_kwargs)
+
+    def _debug_plot(self, plot_func: Callable, plot_kwargs: dict[str, Any]) -> Any:
+        plot_kwargs = DotDict.wrap(plot_kwargs)
+
+        # helper to create the plot and set the return value, plus some locals for debugging
+        ret = fig = ax = None
+        has_fig = False
+        def plot():
+            nonlocal ret, fig, ax, has_fig
+            ret = plot_func(**plot_kwargs)
+            if isinstance(ret, tuple) and len(ret) == 2:
+                fig, ax = ret
+                has_fig = True
+            return ret
+
+        # helper to show the plot with a view command
+        tmp_plots = {}
+        pdf, png, imgcat = "pdf", "png", "imgcat"  # noqa: F841
+        default_cmd = imgcat if law.util.which("imgcat") else None
+        def show(cmd=default_cmd, ext=pdf):
+            if ext not in tmp_plots:
+                tmp_plots[ext] = law.LocalFileTarget(is_tmp=ext)
+            fig.savefig(tmp_plots[ext].abspath)
+            if cmd:
+                law.util.interruptable_popen([cmd, tmp_plots[ext].abspath])
+            else:
+                print(f"created {tmp_plots[ext].abspath}")
+
+        # helper to reload plotting modules
+        def reload():
+            for mod in ["plot_all", "plot_util", "plot_functions_1d", "plot_functions_2d"]:
+                importlib.reload(importlib.import_module(f"columnflow.plotting.{mod}"))
+
+        # helper to repeat the reload, plot and show steps
+        def repeat(*args, **kwargs):
+            reload()
+            plot()
+            show(*args, **kwargs)
+
+        # debugger message
+        c = lambda s: law.util.colored(s, color="cyan")
+        msg = " plot debugging ".center(80, "-")
+        msg += f"\n - run '{c('plot()')}' to repeat the plot creation"
+        msg += f"\n - run '{c('show(CMD)')}' to show the plot with the given command"
+        if default_cmd:
+            msg += f" (default: {c(default_cmd)})"
+        msg += f"\n - run '{c('reload()')}' to reload plotting libraries"
+        msg += f"\n - run '{c('repeat()')}' to trigger the reload->plot->show steps"
+        msg += f"\n - access plot options via '{c('plot_kwargs')}'"
+        if has_fig:
+            msg += f"\n - access figure and axes objects via '{c('fig')}' and '{c('ax')}'"
+
+        # call the plot function and debug
+        plot()
+        from IPython import embed
+        embed(header=msg)
+
+        return ret
 
     def update_plot_kwargs(self, kwargs: dict) -> dict:
         """
@@ -187,7 +263,7 @@ class PlotBase(ConfigTask):
         if isinstance(custom_style_config, dict) and isinstance(style_config, dict):
             style_config = law.util.merge_dicts(custom_style_config, style_config)
             kwargs["style_config"] = style_config
-        # update defaults after application of `general_settings`
+        # update defaults after application of general_settings
         kwargs.setdefault("cms_label", "pw")
 
         return kwargs

--- a/setup.sh
+++ b/setup.sh
@@ -359,7 +359,6 @@ EOF
     else
         cat << EOF
 
-     $( cf_color green '┓' )
   ┏┏┓$( cf_color green '┃' )╻┏┏┳┓┏┓
   ┗┗┛$( cf_color green '┃' )┗┛╹┗┗╹┗
     ┏$( cf_color green '┃' )


### PR DESCRIPTION
This PR provides a couple updates for the plotting routines:

- A `round_dynamic` function is added that is used by the determination of the scale factor when a process setting contains `scale=stack`. Before, the value was rounded to the closest "10", but sometimes values are in the order of O(10k) which requires a smaller precision. This is handled now by `round_dynamic`.
- A generic `inject_label` is added which can inject substrings into labels (e.g. process labels) according to some predefined rules (e.g. "replace `__PLACEHOLDER__`" or "inject before parentheses").
- Plots have a `--debug-plot` parameter now. When set, an ipython debugger is invoked after the plot function is called which allows to visualize and optionally change plot styles interactively.