### PR TITLE
Scoped CSP requirements and inputs.

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2342,7 +2342,7 @@ class TaskArrayFunction(ArrayFunction):
         """
         # default requirements
         if reqs is None:
-            reqs = {}
+            reqs = DotDict()
 
         # create the call cache
         if _cache is None:
@@ -2350,7 +2350,7 @@ class TaskArrayFunction(ArrayFunction):
 
         # run this instance's requires function
         if callable(self.requires_func):
-            self.requires_func(reqs)
+            self.requires_func(reqs.setdefault(self.cls_name, DotDict()))
 
         # run the requirements of all dependent objects
         for dep in self.get_dependencies():
@@ -2375,7 +2375,7 @@ class TaskArrayFunction(ArrayFunction):
         """
         # default column targets
         if reader_targets is None:
-            reader_targets = {}
+            reader_targets = DotDict()
 
         # create the call cache
         if _cache is None:
@@ -2383,7 +2383,11 @@ class TaskArrayFunction(ArrayFunction):
 
         # run this instance's setup function
         if callable(self.setup_func):
-            self.setup_func(reqs, inputs, reader_targets)
+            self.setup_func(
+                reqs.setdefault(self.cls_name, DotDict()),
+                inputs.setdefault(self.cls_name, DotDict()),
+                reader_targets,
+            )
 
         # run the setup of all dependent objects
         for dep in self.get_dependencies():

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2205,10 +2205,10 @@ class TaskArrayFunction(ArrayFunction):
         positional arguments:
 
             - *reqs*, a dictionary containing the required tasks as defined by the custom
-              :py:meth:`requires_func`.
+            :py:meth:`requires_func`.
             - *inputs*, a dictionary containing the outputs created by the tasks in *reqs*.
             - *reader_targets*, an InsertableDict containing the targets to be included
-              in an event chunk loop
+            in an event chunk loop
 
         The decorator does not return the wrapped function.
         """

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2350,7 +2350,9 @@ class TaskArrayFunction(ArrayFunction):
 
         # run this instance's requires function
         if callable(self.requires_func):
-            self.requires_func(reqs.setdefault(self.cls_name, DotDict()))
+            if self.cls_name not in reqs:
+                reqs[self.cls_name] = DotDict()
+            self.requires_func(reqs[self.cls_name])
 
         # run the requirements of all dependent objects
         for dep in self.get_dependencies():
@@ -2383,11 +2385,11 @@ class TaskArrayFunction(ArrayFunction):
 
         # run this instance's setup function
         if callable(self.setup_func):
-            self.setup_func(
-                reqs.setdefault(self.cls_name, DotDict()),
-                inputs.setdefault(self.cls_name, DotDict()),
-                reader_targets,
-            )
+            if self.cls_name not in reqs:
+                reqs[self.cls_name] = DotDict()
+            if self.cls_name not in inputs:
+                inputs[self.cls_name] = DotDict()
+            self.setup_func(reqs[self.cls_name], inputs[self.cls_name], reader_targets)
 
         # run the setup of all dependent objects
         for dep in self.get_dependencies():

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -134,8 +134,6 @@ def normalization_weights_requires(self: Producer, reqs: dict) -> None:
     Adds the requirements needed by the underlying py:attr:`task` to access selection stats into
     *reqs*.
     """
-    self.selection_stats_key = f"{'stitched_' if self.allow_stitching else 'norm_'}selection_stats"
-
     if self.allow_stitching:
         self.stitching_datasets = self.get_stitching_datasets()
     else:
@@ -149,7 +147,7 @@ def normalization_weights_requires(self: Producer, reqs: dict) -> None:
             )
 
     from columnflow.tasks.selection import MergeSelectionStats
-    reqs[self.selection_stats_key] = {
+    reqs["selection_stats"] = {
         dataset.name: MergeSelectionStats.req(
             self.task,
             dataset=dataset.name,
@@ -184,7 +182,7 @@ def normalization_weights_setup(
             key=f"selection_stats_{dataset}",
             func=lambda: inp["collection"][0]["stats"].load(formatter="json"),
         )
-        for dataset, inp in inputs[self.selection_stats_key].items()
+        for dataset, inp in inputs["selection_stats"].items()
     }
     # if necessary, merge the selection stats across datasets
     if len(normalization_selection_stats) > 1:

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -78,7 +78,7 @@ class CreateHistograms(
                 ]
 
             # add weight_producer dependent requirements
-            reqs["weight_producer"] = self.weight_producer_inst.run_requires()
+            reqs["weight_producer"] = law.util.make_unique(law.util.flatten(self.weight_producer_inst.run_requires()))
 
         return reqs
 
@@ -98,7 +98,7 @@ class CreateHistograms(
             ]
 
         # add weight_producer dependent requirements
-        reqs["weight_producer"] = self.weight_producer_inst.run_requires()
+        reqs["weight_producer"] = law.util.make_unique(law.util.flatten(self.weight_producer_inst.run_requires()))
 
         return reqs
 
@@ -119,15 +119,15 @@ class CreateHistograms(
             Route, update_ak_array, add_ak_aliases, has_ak_column, fill_hist,
         )
 
-        # prepare inputs and outputs
-        reqs = self.requires()
+        # prepare inputs
         inputs = self.input()
 
         # declare output: dict of histograms
         histograms = {}
 
         # run the weight_producer setup
-        reader_targets = self.weight_producer_inst.run_setup(reqs["weight_producer"], inputs["weight_producer"])
+        producer_reqs = self.weight_producer_inst.run_requires()
+        reader_targets = self.weight_producer_inst.run_setup(producer_reqs, luigi.task.getpaths(producer_reqs))
 
         # create a temp dir for saving intermediate files
         tmp_dir = law.LocalDirectoryTarget(is_tmp=True)

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -50,7 +50,6 @@ class ProduceColumns(
         return reqs
 
     def requires(self):
-        print(f"requirements evaluated, {self!r}")
         return {
             "events": self.reqs.ProvideReducedEvents.req(self),
             "producer": law.util.make_unique(law.util.flatten(self.producer_inst.run_requires())),


### PR DESCRIPTION
This PR solves the issue of potentially ambiguous / redundant requirements of task array functions. Calibrators/selectors/producers can define custom requirements which were - until now - added to a single dictionary so that collisions between requirements of different CSPs could occur.

Now, every CSP receives its own dictionary that can be filled with requirements. In order not to require identical tasks multiple times, our main tasks remove redundant tasks from a flattened list of requirements.