### PR TITLE
Fix ProvideReducedEvents

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -150,7 +150,6 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         # when not explicitly set in kwargs and no global value was defined on the cli for the task
         # family, evaluate and use the default value
-        # use a default version when not explicitly set in kwargs and no global command line option
         if (
             isinstance(getattr(cls, "version", None), luigi.Parameter) and
             "version" not in kwargs and

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -531,7 +531,7 @@ class ProvideReducedEvents(
 
     @law.workflow_property(setter=True, cache=True, empty_value=0)
     def file_merging(self):
-        if self.skip_merging:
+        if self.skip_merging or self.dataset_info_inst.n_files == 1:
             return 1
 
         # check if the merging stats are present
@@ -564,54 +564,70 @@ class ProvideReducedEvents(
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        # when skipping merging, require the reduced events directly
-        # when forcing merging, require the merged events
-        # (also, when merged events are complete, require them to show the dependence in the cli)
-        # otherwise, do not register reqs but yield them dynamically in local_workflow_pre_run()
-        if self.skip_merging:
+        # strategy:
+        # - when it is clear that the reduced events are being used directly, require them when not
+        #   in pilot mode
+        # - otherwise, always require the reduction stats as they are needed to make a decision
+        # - when merging is forced, require it
+        # - otherwise, and if the merging is already known, require either reduced or merged events
+        if self.skip_merging or self.dataset_info_inst.n_files == 1:
             if not self.pilot:
                 reqs["events"] = self._req_reduced_events()
         else:
-            req_merged = self._req_merged_reduced_events()
-            if self.force_merging or req_merged.complete():
-                reqs["events"] = req_merged
+            reqs["reduction_stats"] = self.reqs.MergeReductionStats.req(self)
+
+            if self.force_merging:
+                reqs["events"] = self._req_merged_reduced_events()
+            else:
+                file_merging = self.file_merging
+                if file_merging > 1:
+                    reqs["events"] = self._req_merged_reduced_events()
+                elif file_merging == 1 and not self.pilot:
+                    reqs["events"] = self._req_reduced_events()
 
         return reqs
 
     def requires(self):
-        # same as for workflow requirements, declare static requirements when a decision is pre-set,
-        # and otherwise let run() yield dynamic ones
-        if self.skip_merging:
-            return self._req_reduced_events()
-        req_merged = self._req_merged_reduced_events()
-        if self.force_merging or req_merged.complete():
-            return req_merged
-        return []
+        # same as for workflow requirements without optional pilot check
+        reqs = {}
+        if self.skip_merging or self.dataset_info_inst.n_files == 1:
+            reqs["events"] = self._req_reduced_events()
+        else:
+            reqs["reduction_stats"] = self.reqs.MergeReductionStats.req(self)
+
+            if self.force_merging:
+                reqs["events"] = self._req_merged_reduced_events()
+            else:
+                file_merging = self.file_merging
+                if file_merging > 1:
+                    reqs["events"] = self._req_merged_reduced_events()
+                elif file_merging == 1:
+                    reqs["events"] = self._req_reduced_events()
+
+        return reqs
 
     @workflow_condition.output
     def output(self):
-        if self.skip_merging or self.force_merging:
-            req = self.requires()
+        # determine the definitive requirement
+        if (
+            self.skip_merging or
+            self.dataset_info_inst.n_files == 1 or
+            (not self.force_merging and self.file_merging == 1)
+        ):
+            req = self._req_reduced_events()
         else:
-            # declare the output to be the one of the upstream task
-            req = (
-                self._req_reduced_events()
-                if self.file_merging == 1
-                else self._req_merged_reduced_events()
-            )
+            req = self._req_merged_reduced_events()
 
         # to simplify the handling for downstream tasks, extract the single output from workflows
         output = req.output()
         return list(output.collection.targets.values())[0] if req.is_workflow() else output
 
     def _yield_dynamic_deps(self):
-        # do nothing if a decision was pre-set
-        if self.skip_merging or self.force_merging:
+        # do nothing if a decision was pre-set in which case requirements were already triggered
+        if self.skip_merging or self.dataset_info_inst.n_files == 1 or self.force_merging:
             return
 
-        if self.file_merging == 0:
-            yield self.reqs.MergeReductionStats.req(self)
-
+        # yield the appropriate requirement
         yield (
             self._req_reduced_events()
             if self.file_merging == 1

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -613,15 +613,8 @@ class ProvideReducedEvents(
 
     @workflow_condition.output
     def output(self):
-        # determine the definitive requirement
-        if (
-            self.skip_merging or
-            self.dataset_info_inst.n_files == 1 or
-            (not self.force_merging and self.file_merging == 1)
-        ):
-            req = self._req_reduced_events()
-        else:
-            req = self._req_merged_reduced_events()
+        # the "events" requirement is known at this point
+        req = self.requires()["events"]
 
         # to simplify the handling for downstream tasks, extract the single output from workflows
         output = req.output()


### PR DESCRIPTION
ProvideReducedEvents is meant to provide reduced events through its output, which is dynamically assigned to be either the output of `ReduceEvents` or `MergeReduceEvents` depending on various conditions. It also dynamically defines its requirements to trigger the right task at the right time in order to have an at least partially known dependency tree ahead of runtime.

However, we observed an issue where datasets were merged that contained only a single file, which is an unnecessary indirection. This PR fixes that. To summarize, the aforementioned conditions are now:

- When merging is explicitly skipped (`--skip-merging`) or the number of input files is known to be 1 while the merging is also not forced (`--force-merging`), require `reduced` events **without the need to request the reduction stats file**.
- Otherwise:
  - The reduction stats file is needed.
  - When merging is forced, require merged events.
  - Otherwise
    - If the file merging (how many input files make up one merged file) is known (i.e., the reduction stats are already present), require either reduced (`file_merging == 1`) or merged events (`file_merging > 1`).
    - If not, do not declare a static dependency since a decision cannot be made yet and defer to the dynamic dependency definition in the run method.

The implementation of these conditions looks cumbersome at first, but since they are rather complex and potentially not easy to maintain, I used a code structure that exactly matches the summary above, while at the same time, requiring and reading the stats file only if really necessary.