### PR TITLE
Fix selector steps default resolution.

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -560,7 +560,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         # interpret missing parameters (e.g. NO_STR) as None
         # (special case: an empty string is usually an active decision, but counts as missing too)
-        if law.is_no_param(param) or resolve_default or param == "":
+        if law.is_no_param(param) or resolve_default or param == "" or param == ():
             param = None
 
         # actual resolution

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -230,7 +230,7 @@ class CalibratorsMixin(ConfigTask):
     calibrators = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
         description="comma-separated names of calibrators to be applied; default: value of the "
-        "'default_calibrator' config in a 1-tuple",
+        "'default_calibrator' config",
         brace_expand=True,
         parse_empty=True,
     )
@@ -598,7 +598,7 @@ class SelectorStepsMixin(SelectorMixin):
     selector_steps = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
         description="a subset of steps of the selector to apply; uses all steps when empty; "
-        "default: value of the 'default_selector_steps' config in a 1-tuple",
+        "default: value of the 'default_selector_steps' config",
         brace_expand=True,
         parse_empty=True,
     )
@@ -882,7 +882,7 @@ class ProducersMixin(ConfigTask):
     producers = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
         description="comma-separated names of producers to be applied; default: value of the "
-        "'default_producer' config in a 1-tuple",
+        "'default_producer' config",
         brace_expand=True,
         parse_empty=True,
     )
@@ -1593,7 +1593,7 @@ class MLModelsMixin(ConfigTask):
     ml_models = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
         description="comma-separated names of ML models to be applied; default: value of the "
-        "'default_ml_model' config in a 1-tuple",
+        "'default_ml_model' config",
         brace_expand=True,
         parse_empty=True,
     )

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -588,17 +588,17 @@ class SelectorMixin(ConfigTask):
 
 
 class SelectorStepsMixin(SelectorMixin):
-    """Mixin to include multiple selector steps into tasks.
+    """
+    Mixin to include multiple selector steps into tasks.
 
-    Inheriting from this mixin will allow a task to access selector steps,
-    which can be a comma-separated list of selector step names and is an input
-    parameter for this task.
+    Inheriting from this mixin will allow a task to access selector steps, which can be a
+    comma-separated list of selector step names and is an input parameter for this task.
     """
 
     selector_steps = law.CSVParameter(
-        default=(),
+        default=(RESOLVE_DEFAULT,),
         description="a subset of steps of the selector to apply; uses all steps when empty; "
-        "empty default",
+        "default: value of the 'default_selector_steps' config in a 1-tuple",
         brace_expand=True,
         parse_empty=True,
     )
@@ -881,7 +881,8 @@ class ProducersMixin(ConfigTask):
 
     producers = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
-        description="comma-separated names of producers to be applied; empty default",
+        description="comma-separated names of producers to be applied; default: value of the "
+        "'default_producer' config in a 1-tuple",
         brace_expand=True,
         parse_empty=True,
     )
@@ -1591,7 +1592,8 @@ class MLModelsMixin(ConfigTask):
 
     ml_models = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
-        description="comma-separated names of ML models to be applied; empty default",
+        description="comma-separated names of ML models to be applied; default: value of the "
+        "'default_ml_model' config in a 1-tuple",
         brace_expand=True,
         parse_empty=True,
     )


### PR DESCRIPTION
This PR fixes the default value resolution of the `--selector-steps` parameter.
Before, there was no default, leading to the `steps` field of the selection results. However, the order is arbitrary and usually never reasonable by chance.

The parameter now defaults to config values, and falls back to the "random" steps when nothing is found.