### PR TITLE
Fix input lfn localization in ReduceEvents

### DIFF
--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -169,15 +169,11 @@ class SelectEvents(
                 *reader_targets.values(),
             ],
             mode="r",
-        ) as (local_input_file, *inps):
-            # open with uproot
-            with self.publish_step("load and open ..."):
-                nano_file = local_input_file.load(formatter="uproot")
-
+        ) as inps:
             # iterate over chunks of events and diffs
             n_calib = len(inputs["calibrations"])
             for (events, *cols), pos in self.iter_chunked_io(
-                [nano_file, *(inp.path for inp in inps)],
+                [inp.abspath for inp in inps],
                 source_type=["coffea_root"] + ["awkward_parquet"] * n_calib + [None] * n_ext,
                 read_columns=[read_columns] * (1 + n_calib + n_ext),
                 chunk_size=self.selector_inst.get_min_chunk_size(),
@@ -217,7 +213,7 @@ class SelectEvents(
                 # save results as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"res_{lfn_index}_{pos.index}.parquet", type="f")
                 result_chunks[(lfn_index, pos.index)] = chunk
-                self.chunked_io.queue(sorted_ak_to_parquet, (results_array, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_parquet, (results_array, chunk.abspath))
 
                 # remove columns
                 if write_columns:
@@ -230,7 +226,7 @@ class SelectEvents(
                     # save additional columns as parquet via a thread in the same pool
                     chunk = tmp_dir.child(f"cols_{lfn_index}_{pos.index}.parquet", type="f")
                     column_chunks[(lfn_index, pos.index)] = chunk
-                    self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+                    self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # merge the result files
         sorted_chunks = [result_chunks[key] for key in sorted(result_chunks)]
@@ -511,7 +507,7 @@ class MergeSelectionMasks(
 
             chunk = tmp_dir.child(f"tmp_{inp['results'].basename}", type="f")
             chunks.append(chunk)
-            sorted_ak_to_parquet(out, chunk.path)
+            sorted_ak_to_parquet(out, chunk.abspath)
 
         return chunks
 


### PR DESCRIPTION
This PR fixes a critical issue in our `ReduceEvents` task. So far, all input files except the actual nano file were localized using the `@law.decorator.localize` decorator. However, the nano file was localized dynamically and in the scenario of an analysis using remote lfns without wlcg file caching, this resulted in a situation where the chunked loading complained about a missing local file. This bug only appeared in `ReduceEvents` since `{Calibrate,Select}Events` already used an improved method.

This PR adds the same localization method to `ReduceEvents` and streamlines the implementation.

In addition, I slightly aligned the `{Calibrate,Select}Events` tasks to match the new structure.

@jomatthi 