### PR TITLE
allow customizing repr of CSPWs

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2181,6 +2181,13 @@ class TaskArrayFunction(ArrayFunction):
     shifts = set()
     _dependency_sets = ArrayFunction._dependency_sets | {"shifts"}
 
+    @property
+    def __str__(self):
+        """
+        Returns a string representation of this TaskArrayFunction instance.
+        """
+        return self.cls_name
+
     @staticmethod
     def pick_cached_result(cached_result: T, *args, **kwargs) -> T:
         """

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -34,7 +34,8 @@ logger = law.logger.get_logger(__name__)
 
 
 class CalibratorMixin(ConfigTask):
-    """Mixin to include a single :py:class:`~columnflow.calibration.Calibrator` into tasks.
+    """
+    Mixin to include a single :py:class:`~columnflow.calibration.Calibrator` into tasks.
 
     Inheriting from this mixin will give access to instantiate and access a
     :py:class:`~columnflow.calibration.Calibrator` instance with name *calibrator*,
@@ -54,7 +55,8 @@ class CalibratorMixin(ConfigTask):
 
     @classmethod
     def get_calibrator_inst(cls, calibrator: str, kwargs=None) -> Calibrator:
-        """Initialize :py:class:`~columnflow.calibration.Calibrator` instance.
+        """
+        Initialize :py:class:`~columnflow.calibration.Calibrator` instance.
 
         Extracts relevant *kwargs* for this calibrator instance using the
         :py:meth:`~columnflow.tasks.framework.base.AnalaysisTask.get_calibrator_kwargs`
@@ -82,7 +84,8 @@ class CalibratorMixin(ConfigTask):
 
     @classmethod
     def resolve_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
-        """Resolve parameter values *params* relevant for the
+        """
+        Resolve parameter values *params* relevant for the
         :py:class:`CalibratorMixin` and all classes it inherits from.
 
         Loads the ``config_inst`` and loads the parameter ``"calibrator"``.
@@ -114,7 +117,8 @@ class CalibratorMixin(ConfigTask):
 
     @classmethod
     def get_known_shifts(cls, config_inst: od.Config, params: dict[str, Any]) -> tuple[set[str], set[str]]:
-        """Adds set of shifts that the current ``calibrator_inst`` registers to the
+        """
+        Adds set of shifts that the current ``calibrator_inst`` registers to the
         set of known ``shifts`` and ``upstream_shifts``.
 
         First, the set of ``shifts`` and ``upstream_shifts`` are obtained from
@@ -166,7 +170,8 @@ class CalibratorMixin(ConfigTask):
 
     @property
     def calibrator_inst(self) -> Calibrator:
-        """Access current :py:class:`~columnflow.calibration.Calibrator` instance.
+        """
+        Access current :py:class:`~columnflow.calibration.Calibrator` instance.
 
         This method loads the current :py:class:`~columnflow.calibration.Calibrator`
         *calibrator_inst* from the cache or initializes it.
@@ -190,11 +195,14 @@ class CalibratorMixin(ConfigTask):
 
     @property
     def calibrator_repr(self):
-        """Return a string representation of the calibrator."""
+        """
+        Return a string representation of the calibrator.
+        """
         return str(self.calibrator_inst)
 
     def store_parts(self) -> law.util.InsertableDict[str, str]:
-        """Create parts to create the output path to store intermediary results
+        """
+        Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
 
         This method calls :py:meth:`store_parts` of the ``super`` class and inserts
@@ -225,7 +233,8 @@ class CalibratorMixin(ConfigTask):
 
 
 class CalibratorsMixin(ConfigTask):
-    """Mixin to include multiple :py:class:`~columnflow.calibration.Calibrator` instances into tasks.
+    """
+    Mixin to include multiple :py:class:`~columnflow.calibration.Calibrator` instances into tasks.
 
     Inheriting from this mixin will allow a task to instantiate and access a set of
     :py:class:`~columnflow.calibration.Calibrator` instances with names *calibrators*,
@@ -245,7 +254,8 @@ class CalibratorsMixin(ConfigTask):
 
     @classmethod
     def get_calibrator_insts(cls, calibrators: Iterable[str], kwargs=None) -> list[Calibrator]:
-        """Get all requested *calibrators*.
+        """
+        Get all requested *calibrators*.
 
         :py:class:`~columnflow.calibration.Calibrator` instances are either
         initalized or loaded from cache.
@@ -275,7 +285,8 @@ class CalibratorsMixin(ConfigTask):
         cls,
         params: law.util.InsertableDict[str, Any],
     ) -> law.util.InsertableDict[str, Any]:
-        """Resolve values *params* and check against possible default values and
+        """
+        Resolve values *params* and check against possible default values and
         calibrator groups.
 
         Check the values in *params* against the default value ``"default_calibrator"``
@@ -310,7 +321,8 @@ class CalibratorsMixin(ConfigTask):
         config_inst: od.Config,
         params: dict[str, Any],
     ) -> tuple[set[str], set[str]]:
-        """Adds set of all shifts that the list of ``calibrator_insts`` register to the
+        """
+        Adds set of all shifts that the list of ``calibrator_insts`` register to the
         set of known ``shifts`` and ``upstream_shifts``.
 
         First, the set of ``shifts`` and ``upstream_shifts`` are obtained from
@@ -364,7 +376,8 @@ class CalibratorsMixin(ConfigTask):
 
     @property
     def calibrator_insts(self) -> list[Calibrator]:
-        """Access current list of :py:class:`~columnflow.calibration.Calibrator` instances.
+        """
+        Access current list of :py:class:`~columnflow.calibration.Calibrator` instances.
 
         Loads the current :py:class:`~columnflow.calibration.Calibrator` *calibrator_insts* from
         the cache or initializes it.
@@ -388,7 +401,8 @@ class CalibratorsMixin(ConfigTask):
         return calibs_repr
 
     def store_parts(self):
-        """Create parts to create the output path to store intermediary results
+        """
+        Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
 
         Calls :py:meth:`store_parts` of the ``super`` class and inserts
@@ -425,7 +439,8 @@ class CalibratorsMixin(ConfigTask):
 
 
 class SelectorMixin(ConfigTask):
-    """Mixin to include a single :py:class:`~columnflow.selection.Selector`
+    """
+    Mixin to include a single :py:class:`~columnflow.selection.Selector`
     instances into tasks.
 
     Inheriting from this mixin will allow a task to instantiate and access a
@@ -447,7 +462,8 @@ class SelectorMixin(ConfigTask):
         selector: str,
         kwargs=None,
     ) -> Selector:
-        """Get requested *selector*.
+        """
+        Get requested *selector*.
 
         :py:class:`~columnflow.selection.Selector` instance is either
         initalized or loaded from cache.
@@ -466,7 +482,8 @@ class SelectorMixin(ConfigTask):
 
     @classmethod
     def resolve_param_values(cls, params: dict[str, Any]) -> dict:
-        """Resolve values *params* and check against possible default values and
+        """
+        Resolve values *params* and check against possible default values and
         selector groups.
 
         Check the values in *params* against the default value ``"default_selector"``
@@ -500,7 +517,8 @@ class SelectorMixin(ConfigTask):
         config_inst: od.Config,
         params: dict[str, Any],
     ) -> tuple[set[str], set[str]]:
-        """Adds set of shifts that the current ``selector_inst`` registers to the
+        """
+        Adds set of shifts that the current ``selector_inst`` registers to the
         set of known ``shifts`` and ``upstream_shifts``.
 
         First, the set of ``shifts`` and ``upstream_shifts`` are obtained from
@@ -531,7 +549,8 @@ class SelectorMixin(ConfigTask):
 
     @classmethod
     def req_params(cls, inst: law.Task, **kwargs) -> dict[str, Any]:
-        """Get the required parameters for the task, preferring the ``--selector`` set on task-level via CLI.
+        """
+        Get the required parameters for the task, preferring the ``--selector`` set on task-level via CLI.
 
         This method first checks if the --selector parameter is set at the task-level via the command line.
         If it is, this parameter is preferred and added to the '_prefer_cli' key in the kwargs dictionary.
@@ -554,7 +573,8 @@ class SelectorMixin(ConfigTask):
 
     @property
     def selector_inst(self):
-        """Access current :py:class:`~columnflow.selection.Selector` instance.
+        """
+        Access current :py:class:`~columnflow.selection.Selector` instance.
 
         Loads the current :py:class:`~columnflow.selection.Selector` *selector_inst* from
         the cache or initializes it.
@@ -578,11 +598,14 @@ class SelectorMixin(ConfigTask):
 
     @property
     def selector_repr(self):
-        """Return a string representation of the selector."""
+        """
+        Return a string representation of the selector.
+        """
         return str(self.selector_inst)
 
     def store_parts(self):
-        """Create parts to create the output path to store intermediary results
+        """
+        Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
 
         Calls :py:meth:`store_parts` of the ``super`` class and inserts
@@ -626,7 +649,8 @@ class SelectorStepsMixin(SelectorMixin):
 
     @classmethod
     def resolve_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
-        """Resolve values *params* and check against possible default values and
+        """
+        Resolve values *params* and check against possible default values and
         selector step groups.
 
         Check the values in *params* against the default value ``"default_selector_steps"``
@@ -661,7 +685,8 @@ class SelectorStepsMixin(SelectorMixin):
 
     @classmethod
     def req_params(cls, inst: law.Task, **kwargs) -> dict[str, Any]:
-        """Get the required parameters for the task, preferring the --selector-steps set on task-level via CLI.
+        """
+        Get the required parameters for the task, preferring the --selector-steps set on task-level via CLI.
 
         This method first checks if the --selector-steps parameter is set at the task-level via the command line.
         If it is, this parameter is preferred and added to the '_prefer_cli' key in the kwargs dictionary.
@@ -677,7 +702,8 @@ class SelectorStepsMixin(SelectorMixin):
         return super().req_params(inst, **kwargs)
 
     def store_parts(self) -> law.util.InsertableDict:
-        """Create parts to create the output path to store intermediary results
+        """
+        Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
 
         Calls :py:meth:`store_parts` of the ``super`` class and inserts
@@ -700,7 +726,8 @@ class SelectorStepsMixin(SelectorMixin):
 
 
 class ProducerMixin(ConfigTask):
-    """Mixin to include a single :py:class:`~columnflow.production.Producer` into tasks.
+    """
+    Mixin to include a single :py:class:`~columnflow.production.Producer` into tasks.
 
     Inheriting from this mixin will give access to instantiate and access a
     :py:class:`~columnflow.production.Producer` instance with name *producer*,
@@ -718,7 +745,8 @@ class ProducerMixin(ConfigTask):
 
     @classmethod
     def get_producer_inst(cls, producer: str, kwargs=None) -> Producer:
-        """Initialize :py:class:`~columnflow.production.Producer` instance.
+        """
+        Initialize :py:class:`~columnflow.production.Producer` instance.
 
         Extracts relevant *kwargs* for this producer instance using the
         :py:meth:`~columnflow.tasks.framework.base.AnalaysisTask.get_producer_kwargs`
@@ -747,7 +775,8 @@ class ProducerMixin(ConfigTask):
 
     @classmethod
     def resolve_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
-        """Resolve parameter values *params* relevant for the
+        """
+        Resolve parameter values *params* relevant for the
         :py:class:`ProducerMixin` and all classes it inherits from.
 
         Loads the ``config_inst`` and loads the parameter ``"producer"``.
@@ -779,7 +808,8 @@ class ProducerMixin(ConfigTask):
 
     @classmethod
     def get_known_shifts(cls, config_inst: od.Config, params: dict[str, Any]) -> tuple[set[str], set[str]]:
-        """Adds set of shifts that the current ``producer_inst`` registers to the
+        """
+        Adds set of shifts that the current ``producer_inst`` registers to the
         set of known ``shifts`` and ``upstream_shifts``.
 
         First, the set of ``shifts`` and ``upstream_shifts`` are obtained from
@@ -810,7 +840,8 @@ class ProducerMixin(ConfigTask):
 
     @classmethod
     def req_params(cls, inst: law.Task, **kwargs) -> dict[str, Any]:
-        """Get the required parameters for the task, preferring the ``--producer`` set on task-level via CLI.
+        """
+        Get the required parameters for the task, preferring the ``--producer`` set on task-level via CLI.
 
         This method first checks if the ``--producer`` parameter is set at the task-level via the command line.
         If it is, this parameter is preferred and added to the '_prefer_cli' key in the kwargs dictionary.
@@ -833,7 +864,8 @@ class ProducerMixin(ConfigTask):
 
     @property
     def producer_inst(self) -> Producer:
-        """Access current :py:class:`~columnflow.production.Producer` instance.
+        """
+        Access current :py:class:`~columnflow.production.Producer` instance.
 
         Loads the current :py:class:`~columnflow.production.Producer` *producer_inst* from
         the cache or initializes it.
@@ -857,11 +889,14 @@ class ProducerMixin(ConfigTask):
 
     @property
     def producer_repr(self) -> str:
-        """Return a string representation of the producer."""
+        """
+        Return a string representation of the producer.
+        """
         return str(self.producer) if self.producer != law.NO_STR else "none"
 
     def store_parts(self) -> law.util.InsertableDict[str, str]:
-        """Create parts to create the output path to store intermediary results
+        """
+        Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
 
         Calls :py:meth:`store_parts` of the ``super`` class and inserts
@@ -876,7 +911,8 @@ class ProducerMixin(ConfigTask):
         return parts
 
     def find_keep_columns(self: ConfigTask, collection: ColumnCollection) -> set[Route]:
-        """Finds the columns to keep based on the *collection*.
+        """
+        Finds the columns to keep based on the *collection*.
 
         This method first calls the 'find_keep_columns' method of the superclass with the given *collection*.
         If the *collection* is equal to ``ALL_FROM_PRODUCER``, it adds the
@@ -894,7 +930,8 @@ class ProducerMixin(ConfigTask):
 
 
 class ProducersMixin(ConfigTask):
-    """Mixin to include multiple :py:class:`~columnflow.production.Producer` instances into tasks.
+    """
+    Mixin to include multiple :py:class:`~columnflow.production.Producer` instances into tasks.
 
     Inheriting from this mixin will allow a task to instantiate and access a set of
     :py:class:`~columnflow.production.Producer` instances with names *producers*,
@@ -914,7 +951,8 @@ class ProducersMixin(ConfigTask):
 
     @classmethod
     def get_producer_insts(cls, producers: Iterable[str], kwargs=None) -> list[Producer]:
-        """Get all requested *producers*.
+        """
+        Get all requested *producers*.
 
         :py:class:`~columnflow.production.Producer` instances are either
         initalized or loaded from cache.
@@ -943,7 +981,8 @@ class ProducersMixin(ConfigTask):
         cls,
         params: law.util.InsertableDict[str, Any],
     ) -> law.util.InsertableDict[str, Any]:
-        """Resolve values *params* and check against possible default values and
+        """
+        Resolve values *params* and check against possible default values and
         producer groups.
 
         Check the values in *params* against the default value ``"default_producer"``
@@ -974,7 +1013,8 @@ class ProducersMixin(ConfigTask):
 
     @classmethod
     def get_known_shifts(cls, config_inst: od.Config, params: dict[str, Any]) -> tuple[set[str], set[str]]:
-        """Adds set of all shifts that the list of ``producer_insts`` register to the
+        """
+        Adds set of all shifts that the list of ``producer_insts`` register to the
         set of known ``shifts`` and ``upstream_shifts``.
 
         First, the set of ``shifts`` and ``upstream_shifts`` are obtained from
@@ -1005,7 +1045,8 @@ class ProducersMixin(ConfigTask):
 
     @classmethod
     def req_params(cls, inst: law.Task, **kwargs) -> dict[str, Any]:
-        """Get the required parameters for the task, preferring the --producers set on task-level via CLI.
+        """
+        Get the required parameters for the task, preferring the --producers set on task-level via CLI.
 
         This method first checks if the --producers parameter is set at the task-level via the command line.
         If it is, this parameter is preferred and added to the '_prefer_cli' key in the kwargs dictionary.
@@ -1028,7 +1069,8 @@ class ProducersMixin(ConfigTask):
 
     @property
     def producer_insts(self) -> list[Producer]:
-        """Access current list of :py:class:`~columnflow.production.Producer` instances.
+        """
+        Access current list of :py:class:`~columnflow.production.Producer` instances.
 
         Loads the current :py:class:`~columnflow.production.Producer` *producer_insts* from
         the cache or initializes it.
@@ -1050,7 +1092,8 @@ class ProducersMixin(ConfigTask):
         return prods_repr
 
     def store_parts(self):
-        """Create parts to create the output path to store intermediary results
+        """
+        Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
 
         Calls :py:meth:`store_parts` of the ``super`` class and inserts
@@ -1068,7 +1111,8 @@ class ProducersMixin(ConfigTask):
         return parts
 
     def find_keep_columns(self: ConfigTask, collection: ColumnCollection) -> set[Route]:
-        """Finds the columns to keep based on the *collection*.
+        """
+        Finds the columns to keep based on the *collection*.
 
         This method first calls the 'find_keep_columns' method of the superclass with the given *collection*.
         If the *collection* is equal to ``ALL_FROM_PRODUCERS``, it adds the
@@ -1089,7 +1133,8 @@ class ProducersMixin(ConfigTask):
 
 
 class MLModelMixinBase(AnalysisTask):
-    """Base Mixin to include a machine learning applications into tasks.
+    """
+    Base Mixin to include a machine learning applications into tasks.
 
     Inheriting from this mixin will allow a task to instantiate and access a
     :py:class:`~columnflow.ml.MLModel` instance with name *ml_model*,
@@ -1109,12 +1154,15 @@ class MLModelMixinBase(AnalysisTask):
 
     @property
     def ml_model_repr(self):
-        """Returns a string representation of the ML model instance."""
+        """
+        Returns a string representation of the ML model instance.
+        """
         return str(self.ml_model_inst)
 
     @classmethod
     def req_params(cls, inst: law.Task, **kwargs) -> dict[str, Any]:
-        """Get the required parameters for the task, preferring the ``--ml-model`` set on task-level via CLI.
+        """
+        Get the required parameters for the task, preferring the ``--ml-model`` set on task-level via CLI.
 
         This method first checks if the ``--ml-model`` parameter is set at the task-level via the command line.
         If it is, this parameter is preferred and added to the '_prefer_cli' key in the kwargs dictionary.
@@ -1137,7 +1185,8 @@ class MLModelMixinBase(AnalysisTask):
         requested_configs: list[str] | None = None,
         **kwargs,
     ) -> MLModel:
-        """Get requested *ml_model* instance.
+        """
+        Get requested *ml_model* instance.
 
         This method retrieves the requested *ml_model* instance.
         If *requested_configs* are provided, they are used for the training of
@@ -1164,7 +1213,8 @@ class MLModelMixinBase(AnalysisTask):
         dataset_inst: od.dataset.Dataset,
         shift_inst: od.shift.Shift,
     ) -> bool:
-        """Evaluate whether the events for the combination of *dataset_inst* and
+        """
+        Evaluate whether the events for the combination of *dataset_inst* and
         *shift_inst* shall be used in the training.
 
         This method checks if the *dataset_inst* is in the set of datasets of
@@ -1186,7 +1236,8 @@ class MLModelMixinBase(AnalysisTask):
 
 
 class MLModelTrainingMixin(MLModelMixinBase):
-    """A mixin class for training machine learning models.
+    """
+    A mixin class for training machine learning models.
 
     This class provides parameters for configuring the training of machine learning models.
     """
@@ -1233,7 +1284,8 @@ class MLModelTrainingMixin(MLModelMixinBase):
         ml_model_inst: MLModel,
         params: dict[str, Any],
     ) -> tuple[tuple[str]]:
-        """Resolve the calibrators for the given ML model instance.
+        """
+        Resolve the calibrators for the given ML model instance.
 
         This method retrieves the calibrators from the parameters *params* and
         broadcasts them to the configs if necessary.
@@ -1295,7 +1347,8 @@ class MLModelTrainingMixin(MLModelMixinBase):
         ml_model_inst: MLModel,
         params: dict[str, Any],
     ) -> tuple[str]:
-        """Resolve the selectors for the given ML model instance.
+        """
+        Resolve the selectors for the given ML model instance.
 
         This method retrieves the selectors from the parameters *params* and
         broadcasts them to the configs if necessary.
@@ -1356,7 +1409,8 @@ class MLModelTrainingMixin(MLModelMixinBase):
         ml_model_inst: MLModel,
         params: dict[str, Any],
     ) -> tuple[tuple[str]]:
-        """Resolve the producers for the given ML model instance.
+        """
+        Resolve the producers for the given ML model instance.
 
         This method retrieves the producers from the parameters *params* and
         broadcasts them to the configs if necessary.
@@ -1414,7 +1468,8 @@ class MLModelTrainingMixin(MLModelMixinBase):
 
     @classmethod
     def resolve_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
-        """Resolve the parameter values for the given parameters.
+        """
+        Resolve the parameter values for the given parameters.
 
         This method retrieves the parameters and resolves the ML model instance, configs,
         calibrators, selectors, and producers. It also calls the model's setup hook.
@@ -1472,7 +1527,8 @@ class MLModelTrainingMixin(MLModelMixinBase):
         )
 
     def store_parts(self) -> law.util.InsertableDict[str, str]:
-        """Generate a dictionary of store parts for the current instance.
+        """
+        Generate a dictionary of store parts for the current instance.
 
         This method extends the base method to include additional parts related to machine learning
         model configurations, calibrators, selectors, producers (CSP), and the ML model instance itself.
@@ -2137,16 +2193,7 @@ class WeightProducerMixin(ConfigTask):
                 multiple=False,
             )
             if params["weight_producer"] is None:
-                raise Exception(
-                    f"no weight producer configured for task. {cls.task_family}. "
-                    "As of 02.05.2024, it is required to pass a weight_producer for tasks creating "
-                    "histograms. You can add a 'default_weight_producer' to your config or directly "
-                    "add the weight_producer on command line via the '--weight_producer' parameter. "
-                    "To reproduce results from before this date, you can use the "
-                    "'all_weights' weight_producer defined in columnflow.weight.all_weights, e.g. by adding "
-                    "The following line to your config: \n"
-                    "config.x.default_weight_producer = \"all_weights\"",
-                )
+                raise Exception(f"no weight producer configured for task {cls.task_family}")
             params["weight_producer_inst"] = cls.get_weight_producer_inst(
                 params["weight_producer"],
                 params,

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -190,7 +190,7 @@ class CalibratorMixin(ConfigTask):
 
     @property
     def calibrator_repr(self):
-        """Return the name of the calibrator."""
+        """Return a string representation of the calibrator."""
         return str(self.calibrator_inst)
 
     def store_parts(self) -> law.util.InsertableDict[str, str]:
@@ -380,12 +380,12 @@ class CalibratorsMixin(ConfigTask):
         """
         Return a string representation of the calibrators.
         """
-        part = "none"
+        calibs_repr = "none"
         if self.calibrators:
-            part = "__".join([str(calib) for calib in self.calibrator_insts[:5]])
+            calibs_repr = "__".join([str(calib) for calib in self.calibrator_insts[:5]])
             if len(self.calibrators) > 5:
-                part += f"__{law.util.create_hash([str(calib) for calib in self.calibrator_insts[5:]])}"
-        return part
+                calibs_repr += f"__{law.util.create_hash([str(calib) for calib in self.calibrator_insts[5:]])}"
+        return calibs_repr
 
     def store_parts(self):
         """Create parts to create the output path to store intermediary results
@@ -1042,12 +1042,12 @@ class ProducersMixin(ConfigTask):
     @property
     def producers_repr(self) -> str:
         """Return a string representation of the producers."""
-        part = "none"
+        prods_repr = "none"
         if self.producers:
-            part = "__".join([str(prod) for prod in self.producer_insts[:5]])
+            prods_repr = "__".join([str(prod) for prod in self.producer_insts[:5]])
             if len(self.producers) > 5:
-                part += f"__{law.util.create_hash([str(prod) for prod in self.producer_insts[5:]])}"
-        return part
+                prods_repr += f"__{law.util.create_hash([str(prod) for prod in self.producer_insts[5:]])}"
+        return prods_repr
 
     def store_parts(self):
         """Create parts to create the output path to store intermediary results

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -188,6 +188,11 @@ class CalibratorMixin(ConfigTask):
 
         return self._calibrator_inst
 
+    @property
+    def calibrator_repr(self):
+        """Return the name of the calibrator."""
+        return str(self.calibrator_inst)
+
     def store_parts(self) -> law.util.InsertableDict[str, str]:
         """Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
@@ -199,7 +204,7 @@ class CalibratorMixin(ConfigTask):
         :return: Updated parts to create output path to store intermediary results.
         """
         parts = super().store_parts()
-        parts.insert_before("version", "calibrator", f"calib__{self.calibrator}")
+        parts.insert_before("version", "calibrator", f"calib__{self.calibrator_repr}")
         return parts
 
     def find_keep_columns(self: ConfigTask, collection: ColumnCollection) -> set[Route]:
@@ -370,6 +375,18 @@ class CalibratorsMixin(ConfigTask):
             self._calibrator_insts = self.get_calibrator_insts(self.calibrators, {"task": self})
         return self._calibrator_insts
 
+    @property
+    def calibrators_repr(self) -> str:
+        """
+        Return a string representation of the calibrators.
+        """
+        part = "none"
+        if self.calibrators:
+            part = "__".join([str(calib) for calib in self.calibrator_insts[:5]])
+            if len(self.calibrators) > 5:
+                part += f"__{law.util.create_hash([str(calib) for calib in self.calibrator_insts[5:]])}"
+        return part
+
     def store_parts(self):
         """Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
@@ -384,12 +401,7 @@ class CalibratorsMixin(ConfigTask):
         :return: Updated parts to create output path to store intermediary results.
         """
         parts = super().store_parts()
-
-        part = "__".join(self.calibrators[:5])
-        if len(self.calibrators) > 5:
-            part += f"__{law.util.create_hash(self.calibrators[5:])}"
-        parts.insert_before("version", "calibrators", f"calib__{part or 'none'}")
-
+        parts.insert_before("version", "calibrators", f"calib__{self.calibrators_repr}")
         return parts
 
     def find_keep_columns(self: ConfigTask, collection: ColumnCollection) -> set[Route]:
@@ -564,6 +576,11 @@ class SelectorMixin(ConfigTask):
 
         return self._selector_inst
 
+    @property
+    def selector_repr(self):
+        """Return a string representation of the selector."""
+        return str(self.selector_inst)
+
     def store_parts(self):
         """Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
@@ -575,7 +592,7 @@ class SelectorMixin(ConfigTask):
         :return: Updated parts to create output path to store intermediary results.
         """
         parts = super().store_parts()
-        parts.insert_before("version", "selector", f"sel__{self.selector}")
+        parts.insert_before("version", "selector", f"sel__{self.selector_repr}")
         return parts
 
     def find_keep_columns(self: ConfigTask, collection: ColumnCollection) -> set[Route]:
@@ -838,6 +855,11 @@ class ProducerMixin(ConfigTask):
 
         return self._producer_inst
 
+    @property
+    def producer_repr(self) -> str:
+        """Return a string representation of the producer."""
+        return str(self.producer) if self.producer != law.NO_STR else "none"
+
     def store_parts(self) -> law.util.InsertableDict[str, str]:
         """Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
@@ -849,7 +871,7 @@ class ProducerMixin(ConfigTask):
         :return: Updated parts to create output path to store intermediary results.
         """
         parts = super().store_parts()
-        producer = f"prod__{self.producer}" if self.producer != law.NO_STR else "none"
+        producer = f"prod__{self.producer_repr}"
         parts.insert_before("version", "producer", producer)
         return parts
 
@@ -1017,6 +1039,16 @@ class ProducersMixin(ConfigTask):
             self._producer_insts = self.get_producer_insts(self.producers, {"task": self})
         return self._producer_insts
 
+    @property
+    def producers_repr(self) -> str:
+        """Return a string representation of the producers."""
+        part = "none"
+        if self.producers:
+            part = "__".join([str(prod) for prod in self.producer_insts[:5]])
+            if len(self.producers) > 5:
+                part += f"__{law.util.create_hash([str(prod) for prod in self.producer_insts[5:]])}"
+        return part
+
     def store_parts(self):
         """Create parts to create the output path to store intermediary results
         for the current :py:class:`~law.task.base.Task`.
@@ -1031,13 +1063,7 @@ class ProducersMixin(ConfigTask):
         :return: Updated parts to create output path to store intermediary results.
         """
         parts = super().store_parts()
-
-        part = "none"
-        if self.producers:
-            part = "__".join(self.producers[:5])
-            if len(self.producers) > 5:
-                part += f"__{law.util.create_hash(self.producers[5:])}"
-        parts.insert_before("version", "producers", f"prod__{part or 'none'}")
+        parts.insert_before("version", "producers", f"prod__{self.producers_repr}")
 
         return parts
 
@@ -1721,10 +1747,14 @@ class InferenceModelMixin(ConfigTask):
         # get the inference model instance
         self.inference_model_inst = self.get_inference_model_inst(self.inference_model, self.config_inst)
 
+    @property
+    def inference_model_repr(self):
+        return str(self.inference_model)
+
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
         if self.inference_model != law.NO_STR:
-            parts.insert_before("version", "inf_model", f"inf__{self.inference_model}")
+            parts.insert_before("version", "inf_model", f"inf__{self.inference_model_repr}")
         return parts
 
 
@@ -2166,9 +2196,13 @@ class WeightProducerMixin(ConfigTask):
 
         return self._weight_producer_inst
 
+    @property
+    def weight_producer_repr(self: WeightProducerMixin) -> str:
+        return str(self.weight_producer_inst)
+
     def store_parts(self: WeightProducerMixin) -> law.util.InsertableDict[str, str]:
         parts = super().store_parts()
-        parts.insert_before("version", "weightprod", f"weight__{self.weight_producer}")
+        parts.insert_before("version", "weightprod", f"weight__{self.weight_producer_repr}")
         return parts
 
 


### PR DESCRIPTION
This PR allows overwriting the string representation of CSPWs that is stored as part of the output path. 

Example: I'd like to set a `version` in my Producer that I can update separate from the Producer class name to signal my workflow to re-run everything that depends on this particular Producer.

```python
@memoize
def patch_cspw_string_repr():
    def TaskArrayFunction_str(self):
        version_str = f"V{self.version}" if hasattr(self, "version") else ""
        return f"{self.cls_name}{version_str}"

    TaskArrayFunction.__str__ = TaskArrayFunction_str
```

This can of course already be achieved by updating the Producer's `cls_name`, but this might lead to having to update this Producer name at many different code locations as well.

The PR also allows more advanced versioning of CSPWs, e.g. there might be a list of significant parameters that could be turned into a hash.