### PR TITLE
Fix hist and plot requirements.

### DIFF
--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -312,28 +312,43 @@ class MergeHistograms(
         # create a dummy branch map so that this task could be submitted as a job
         return {0: None}
 
+    def _get_variables(self):
+        if self.is_workflow():
+            return self.as_branch()._get_variables()
+
+        variables = self.variables
+
+        # optional dynamic behavior: determine not yet created variables and require only those
+        if self.only_missing:
+            missing = self.output().count(existing=False, keys=True)[1]
+            variables = sorted(missing, key=variables.index)
+
+        return variables
+
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        reqs["hists"] = self.as_branch().requires()
+        if not self.pilot:
+            variables = self._get_variables()
+            if variables:
+                reqs["hists"] = self.reqs.CreateHistograms.req_different_branching(
+                    self,
+                    branch=-1,
+                    variables=tuple(variables),
+                )
 
         return reqs
 
     def requires(self):
-        # optional dynamic behavior: determine not yet created variables and require only those
-        variables = self.variables
-        if self.only_missing:
-            missing = self.output().count(existing=False, keys=True)[1]
-            variables = tuple(sorted(missing, key=variables.index))
-
+        variables = self._get_variables()
         if not variables:
             return []
 
-        return self.reqs.CreateHistograms.req(
+        return self.reqs.CreateHistograms.req_different_branching(
             self,
             branch=-1,
             variables=tuple(variables),
-            _exclude={"branches"},
+            workflow="local",
         )
 
     def output(self):

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -214,7 +214,8 @@ class PlotVariablesBaseSingleShift(
         reqs = super().workflow_requires()
 
         # no need to require merged histograms since each branch already requires them as a workflow
-        reqs.pop("merged_hists", None)
+        if self.workflow == "local":
+            reqs.pop("merged_hists", None)
 
         return reqs
 
@@ -322,7 +323,8 @@ class PlotVariablesBaseMultiShifts(
         reqs = super().workflow_requires()
 
         # no need to require merged histograms since each branch already requires them as a workflow
-        reqs.pop("merged_hists", None)
+        if self.workflow == "local":
+            reqs.pop("merged_hists", None)
 
         return reqs
 

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -210,6 +210,14 @@ class PlotVariablesBaseSingleShift(
             for cat_name in sorted(self.categories)
         ]
 
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+
+        # no need to require merged histograms since each branch already requires them as a workflow
+        reqs.pop("merged_hists", None)
+
+        return reqs
+
     def requires(self):
         return {
             d: self.reqs.MergeHistograms.req(
@@ -310,6 +318,14 @@ class PlotVariablesBaseMultiShifts(
             for source in sorted(self.shift_sources)
         ]
 
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+
+        # no need to require merged histograms since each branch already requires them as a workflow
+        reqs.pop("merged_hists", None)
+
+        return reqs
+
     def requires(self):
         return {
             d: self.reqs.MergeShiftedHistograms.req(
@@ -371,12 +387,7 @@ class PlotShiftedVariables1D(
     )
 
 
-class PlotShiftedVariablesPerProcess1D(
-    law.WrapperTask,
-    PlotShiftedVariables1D,
-):
-    # force this one to be a local workflow
-    workflow = "local"
+class PlotShiftedVariablesPerProcess1D(law.WrapperTask):
 
     # upstream requirements
     reqs = Requirements(


### PR DESCRIPTION
This PR fixes the dependency structure of histogramming and plotting tasks.

- The `MergeHistograms` **workflow** required exactly what its branch 0 required (via `reqs["hists"] = self.as_branch().requires()`), and branches required the `CreateHistograms` workflow, **however**, with it's `--workflow` parameter not set to `local`. This could have lead to situations where a remote job tries to submit new remote jobs. It's fixed now by defining requirements for workflow and branches separately from each other.

- The plot tasks currently require merged histograms with identical settings in both their workflow and branch requirements. This is not changed by this PR as the decision is made on the most abstract plotting base tasks, so further discussions needed. However, to accelerate the initial dependency tree building, this PR drops the workflow requirements on specialized plot tasks.

- `PlotShiftedVariablesPerProcess1D` is meant to be a wrapper tasks, triggering multiple `PlotShiftedVariables1D` with different `--processes` parameters. However, it is currently also a `PlotShiftedVariables1D` task which makes it a workflow with all bells and whistles (proxy object, custom output and completeness definitions, it's own run method, etc.). Although this provides the convenience of having parameters defined directly on wrapper task level, mixing wrapper and workflow features can lead to weird scenarios. It's fixed for now by this PR, however, also dropping convenient parameter access.