### PR TITLE
Add CSPs to lookup keys for versions and locations.

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -233,6 +233,26 @@ class CalibratorMixin(ConfigTask):
 
         return columns
 
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: CalibratorMixin | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        get = (
+            inst_or_params.get
+            if isinstance(inst_or_params, dict)
+            else lambda attr: (getattr(inst_or_params, attr, None))
+        )
+
+        # add the calibrator name
+        calibrator = get("calibrator")
+        if calibrator not in {law.NO_STR, None, ""}:
+            keys["calibrator"] = f"calib_{calibrator}"
+
+        return keys
+
 
 class CalibratorsMixin(ConfigTask):
     """
@@ -630,6 +650,26 @@ class SelectorMixin(ConfigTask):
 
         return columns
 
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: SelectorMixin | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        get = (
+            inst_or_params.get
+            if isinstance(inst_or_params, dict)
+            else lambda attr: (getattr(inst_or_params, attr, None))
+        )
+
+        # add the selector name
+        selector = get("selector")
+        if selector not in {law.NO_STR, None, ""}:
+            keys["selector"] = f"sel_{selector}"
+
+        return keys
+
 
 class SelectorStepsMixin(SelectorMixin):
     """
@@ -933,6 +973,26 @@ class ProducerMixin(ConfigTask):
             columns |= self.producer_inst.produced_columns
 
         return columns
+
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: ProducerMixin | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        get = (
+            inst_or_params.get
+            if isinstance(inst_or_params, dict)
+            else lambda attr: (getattr(inst_or_params, attr, None))
+        )
+
+        # add the producer name
+        producer = get("producer")
+        if producer not in {law.NO_STR, None, ""}:
+            keys["producer"] = f"prod_{producer}"
+
+        return keys
 
 
 class ProducersMixin(ConfigTask):

--- a/docs/user_guide/best_practices.md
+++ b/docs/user_guide/best_practices.md
@@ -40,6 +40,9 @@ Most tasks, however, define their lookup keys as:
 3. task family
 4. dataset name
 5. shift name
+6. calibrator name, prefixed by `calib_`
+7. selector name, prefixed by `sel_`
+8. producer name, prefixed by `prod_`
 
 When defining `TASK_IDENTIFIER`'s, not all keys need to be specified, and patterns or regular expressions (`^EXPR$`) can be used.
 The definition order is **important** as the first matching definition is used.


### PR DESCRIPTION
As mentioned already during the review of #449, it would be beneficial for the lookup of tasks versions and output locations if calibrators/selectors/producers could be included. This is achieved by this PR. Example:

```ini
[versions]

run3_2022_preEE*__cf.ProduceColumns__prod_res_pdnn: prod1
run3_2022_preEE*__cf.ProduceColumns: prod2
```

→ This adds default versions for the `cf.ProduceColumns` task when the campaign matches `run3_2022_preEE*`. However, the exact value depends on the producer. When it's the `res_pdnn` producer, it defaults to `prod1` and otherwise to `prod2`.


Unlike existing keys which have rather unique names (e.g. you wouldn't confuse a config name with a task name), CSPs are different so I included prefixes `{calib,sel,prod}_` as we already do in other places.