### PR TITLE
Accept multiple hist hooks.

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -2378,32 +2378,49 @@ class ChunkedIOMixin(AnalysisTask):
 
 class HistHookMixin(ConfigTask):
 
-    hist_hook = luigi.Parameter(
-        default=law.NO_STR,
-        description="name of a function in the config's auxiliary dictionary 'hist_hooks' that is "
+    hist_hooks = law.CSVParameter(
+        default=(),
+        description="names of functions in the config's auxiliary dictionary 'hist_hooks' that are "
         "invoked before plotting to update a potentially nested dictionary of histograms; "
         "default: empty",
     )
 
-    def invoke_hist_hook(self, hists: dict) -> dict:
+    def invoke_hist_hooks(self, hists: dict) -> dict:
         """
-        Hook to update histograms before plotting.
+        Invoke hooks to update histograms before plotting.
         """
-        if self.hist_hook in (None, "", law.NO_STR):
+        if not self.hist_hooks:
             return hists
 
-        # get the hook from the config instance
-        hooks = self.config_inst.x("hist_hooks", {})
-        if self.hist_hook not in hooks:
-            raise ValueError(
-                f"hist hook '{self.hist_hook}' not found in 'hist_hooks' auxiliary entry of config",
-            )
-        func = hooks[self.hist_hook]
-        if not callable(func):
-            raise ValueError(f"hist hook '{self.hist_hook}' is not callable: {func}")
+        for hook in self.hist_hooks:
+            if hook in (None, "", law.NO_STR):
+                continue
 
-        # invoke it
-        self.publish_message(f"invoking hist hook '{self.hist_hook}'")
-        hists = func(self, hists)
+            # get the hook from the config instance
+            hooks = self.config_inst.x("hist_hooks", {})
+            if hook not in hooks:
+                raise KeyError(
+                    f"hist hook '{hook}' not found in 'hist_hooks' auxiliary entry of config",
+                )
+            func = hooks[hook]
+            if not callable(func):
+                raise TypeError(f"hist hook '{hook}' is not callable: {func}")
+
+            # invoke it
+            self.publish_message(f"invoking hist hook '{hook}'")
+            hists = func(self, hists)
 
         return hists
+
+    @property
+    def hist_hooks_repr(self) -> str:
+        """
+        Return a string representation of the hist hooks.
+        """
+        hooks = [hook for hook in self.hist_hooks if hook not in (None, "", law.NO_STR)]
+
+        hooks_repr = "__".join(hooks[:5])
+        if len(hooks) > 5:
+            hooks_repr += f"__{law.util.create_hash(hooks[5:])}"
+
+        return hooks_repr

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -145,8 +145,8 @@ class PlotVariablesBase(
                     "  - selected --processes did not match any value on the process axis of the input histogram",
                 )
 
-            # update histograms using a custom hook
-            hists = self.invoke_hist_hook(hists)
+            # update histograms using custom hooks
+            hists = self.invoke_hist_hooks(hists)
 
             # add new processes to the end of the list
             for process_inst in hists:
@@ -229,8 +229,9 @@ class PlotVariablesBaseSingleShift(
         parts["category"] = f"cat_{self.branch_data.category}"
         parts["variable"] = f"var_{self.branch_data.variable}"
 
-        if self.hist_hook not in ("", law.NO_STR, None):
-            parts["hook"] = f"hook_{self.hist_hook}"
+        hooks_repr = self.hist_hooks_repr
+        if hooks_repr:
+            parts["hook"] = f"hooks_{hooks_repr}"
 
         return parts
 
@@ -330,8 +331,9 @@ class PlotVariablesBaseMultiShifts(
         parts["category"] = f"cat_{self.branch_data.category}"
         parts["variable"] = f"var_{self.branch_data.variable}"
 
-        if self.hist_hook not in ("", law.NO_STR, None):
-            parts["hook"] = f"hook_{self.hist_hook}"
+        hooks_repr = self.hist_hooks_repr
+        if hooks_repr:
+            parts["hook"] = f"hooks_{hooks_repr}"
 
         return parts
 


### PR DESCRIPTION
This PR is very straight forward.

Before, we accepted only a single `--hist-hook NAME` to add/remove/change histograms right before plotting or datacard creation. With this PR, multiple comma-separated `--hist-hooks NAME,NAME,...` can be used which receive the histograms in the exact order they are defined on the command line.