### PR TITLE
Feature: Added the possibility to blind data points

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -121,7 +121,7 @@ cfg.x.default_variables = ("n_jet", "jet1_pt")
 # process groups for conveniently looping over certain processs
 # (used in wrapper_factory and during plotting)
 cfg.x.process_groups = {
-    "signals": [],  # list of signal parent processes e.g. tt, hh etc. (required for some tasks)
+    "signals": [],  # list of signal parent processes e.g. h, hh etc. (needed for some features)
     "other_groups": [],
 }
 

--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -120,7 +120,10 @@ cfg.x.default_variables = ("n_jet", "jet1_pt")
 
 # process groups for conveniently looping over certain processs
 # (used in wrapper_factory and during plotting)
-cfg.x.process_groups = {}
+cfg.x.process_groups = {
+    "signals": [],  # list of signal parent processes e.g. tt, hh etc. (required for some tasks)
+    "other_groups": [],
+}
 
 # dataset groups for conveniently looping over certain datasets
 # (used in wrapper_factory and during plotting)

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -22,6 +22,7 @@ from columnflow.plotting.plot_util import (
     apply_density_to_hists,
     get_position,
     get_profile_variations,
+    blind_sensitivity,
 )
 
 hist = maybe_import("hist")
@@ -52,6 +53,7 @@ def plot_variable_per_process(
     remove_residual_axis(hists, "shift")
 
     variable_inst = variable_insts[0]
+    hists = blind_sensitivity(hists, config_inst, kwargs.get("blind_sensitivity"))
     hists = apply_variable_settings(hists, variable_insts, variable_settings)
     hists = apply_process_settings(hists, process_settings)
     hists = apply_density_to_hists(hists, density)

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -53,7 +53,10 @@ def plot_variable_per_process(
     remove_residual_axis(hists, "shift")
 
     variable_inst = variable_insts[0]
-    hists = blind_sensitivity(hists, config_inst, kwargs.get("blind_sensitivity"))
+    blinding_threshold = kwargs.get("blinding_threshold", None)
+
+    if blinding_threshold:
+        hists = blind_sensitivity(hists, config_inst, blinding_threshold)
     hists = apply_variable_settings(hists, variable_insts, variable_settings)
     hists = apply_process_settings(hists, process_settings)
     hists = apply_density_to_hists(hists, density)

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -22,7 +22,7 @@ from columnflow.plotting.plot_util import (
     apply_density_to_hists,
     get_position,
     get_profile_variations,
-    blind_sensitivity,
+    blind_sensitive_bins,
 )
 
 hist = maybe_import("hist")
@@ -56,7 +56,7 @@ def plot_variable_per_process(
     blinding_threshold = kwargs.get("blinding_threshold", None)
 
     if blinding_threshold:
-        hists = blind_sensitivity(hists, config_inst, blinding_threshold)
+        hists = blind_sensitive_bins(hists, config_inst, blinding_threshold)
     hists = apply_variable_settings(hists, variable_insts, variable_settings)
     hists = apply_process_settings(hists, process_settings)
     hists = apply_density_to_hists(hists, density)

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -669,7 +669,7 @@ def get_profile_variations(h_in: hist.Hist, axis: int = 1) -> dict[str, hist.His
 def blind_sensitivity(
     hists: dict[od.Process, hist.Hist],
     config_inst: od.Config,
-    threshold: float
+    threshold: float,
 ) -> dict[od.Process, hist.Hist]:
     """
     Function that takes a histogram *h_in* and blinds the values of the profile

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -708,6 +708,11 @@ def blind_sensitive_bins(
     sensitivity = signals_sum.values() / np.sqrt(signals_sum.values() + backgrounds_sum.values())
     mask = sensitivity >= threshold
 
+    # adjust the mask to blind the bins inbetween blinded ones
+    if sum(mask) > 1:
+        first_ind, last_ind = np.where(mask)[0][::sum(mask) - 1]
+        mask[first_ind:last_ind] = True
+
     # set data points in masked region to zero
     for proc, hist in data.items():
         hist.values()[mask] = 0

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -689,9 +689,9 @@ def blind_sensitive_bins(
     check_if_signal = lambda proc: any(signal == proc or signal.has_process(proc) for signal in signal_procs)
 
     # separate histograms into signals, backgrounds and data hists and calculate sums
-    signals = {proc: hist for proc, hist in hists.items() if check_if_signal(proc)}
+    signals = {proc: hist for proc, hist in hists.items() if proc.is_mc and check_if_signal(proc)}
     data = {proc: hist.copy() for proc, hist in hists.items() if proc.is_data}
-    backgrounds = {proc: hist for proc, hist in hists.items() if proc not in signals and proc.is_mc}
+    backgrounds = {proc: hist for proc, hist in hists.items() if proc.is_mc and proc not in signals}
 
     # Return hists unchanged in case any of the three dicts is empty.
     if not signals or not backgrounds or not data:

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -682,13 +682,11 @@ def blind_sensitive_bins(
     The histograms are not changed inplace, but copies of the modified histograms are returned.
     """
     # build the logic to seperate signal processes
-    cfg_signals: set[od.Process] = {
+    signal_procs: set[od.Process] = {
         config_inst.get_process(proc)
         for proc in config_inst.x.process_groups.get("signals", [])
     }
-    if not cfg_signals:
-        raise Exception("No signal processes defined under `process_groups` in config")
-    check_if_signal = lambda proc: any(signal.has_process(proc) for signal in cfg_signals)
+    check_if_signal = lambda proc: any(signal == proc or signal.has_process(proc) for signal in signal_procs)
 
     # separate histograms into signals, backgrounds and data hists and calculate sums
     signals = {proc: hist for proc, hist in hists.items() if check_if_signal(proc)}
@@ -698,8 +696,8 @@ def blind_sensitive_bins(
     # Return hists unchanged in case any of the three dicts is empty.
     if not signals or not backgrounds or not data:
         logger.info(
-            "One of the following categories: signals, backgrounds or data was not found in the given processes. "
-            "Returning unchanged histograms.",
+            "one of the following categories: signals, backgrounds or data was not found in the given processes, "
+            "returning unchanged histograms",
         )
         return hists
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -72,7 +72,14 @@ class PlotBase(ConfigTask):
         description="when True, an ipython debugger is started after the plot figure is created "
         "for interactive adjustments; default: False",
     )
-
+    blinding_threshold = luigi.FloatParameter(
+        default=-1.0,
+        significant=False,
+        description="parameter to blind datapoints in the region where the sensitivity exceeds a "
+        "certain threshold, calculated from the sensitivity of MC signal and background stacks; "
+        "via a dictionary in the `default_blinding_threshold` auxiliary in the config; "
+        "defaults to the `default_blinding_threshold` aux field if not given via CLI",
+    )
     exclude_params_remote_workflow = {"debug_plot"}
 
     @classmethod
@@ -110,6 +117,11 @@ class PlotBase(ConfigTask):
         dict_add_strict(params, "cms_label", None if self.cms_label == law.NO_STR else self.cms_label)
         dict_add_strict(params, "general_settings", self.general_settings)
         dict_add_strict(params, "custom_style_config", self.custom_style_config)
+        dict_add_strict(
+            params,
+            "blinding_threshold",
+            None if self.blinding_threshold == -1.0 else self.blinding_threshold,
+        )
         return params
 
     def plot_parts(self) -> law.util.InsertableDict:
@@ -265,6 +277,12 @@ class PlotBase(ConfigTask):
             kwargs["style_config"] = style_config
         # update defaults after application of general_settings
         kwargs.setdefault("cms_label", "pw")
+
+        # resolve blinding_threshold
+        blinding_threshold = kwargs.get("blinding_threshold", None)
+        if blinding_threshold is None:
+            blinding_threshold = self.config_inst.x("default_blinding_threshold", None)
+        kwargs["blinding_threshold"] = blinding_threshold
 
         return kwargs
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -75,9 +75,9 @@ class PlotBase(ConfigTask):
     blinding_threshold = luigi.FloatParameter(
         default=law.NO_FLOAT,
         significant=False,
-        description="parameter to blind datapoints in the region where the sensitivity exceeds a "
-        "certain threshold, calculated from the sensitivity of MC signal and background stacks; "
-        "defaults to the `default_blinding_threshold` aux field if not given via CLI",
+        description="parameter to blind datapoints in the region where the sensitivity s/sqrt(s+b) "
+        "exceeds a certain threshold; defaults to the `default_blinding_threshold` aux field of "
+        "the config",
     )
     exclude_params_remote_workflow = {"debug_plot"}
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -73,11 +73,10 @@ class PlotBase(ConfigTask):
         "for interactive adjustments; default: False",
     )
     blinding_threshold = luigi.FloatParameter(
-        default=-1.0,
+        default=law.NO_FLOAT,
         significant=False,
         description="parameter to blind datapoints in the region where the sensitivity exceeds a "
         "certain threshold, calculated from the sensitivity of MC signal and background stacks; "
-        "via a dictionary in the `default_blinding_threshold` auxiliary in the config; "
         "defaults to the `default_blinding_threshold` aux field if not given via CLI",
     )
     exclude_params_remote_workflow = {"debug_plot"}
@@ -120,7 +119,7 @@ class PlotBase(ConfigTask):
         dict_add_strict(
             params,
             "blinding_threshold",
-            None if self.blinding_threshold == -1.0 else self.blinding_threshold,
+            None if self.blinding_threshold == law.NO_FLOAT else self.blinding_threshold,
         )
         return params
 


### PR DESCRIPTION
if the sensitivity (S/sqrt(S + B) of MC processes) is above a threshold in a bin, the data point are set to 0.

The threshold can be given in the CLI or alternatively can be set to a default in the config via: `self.config_inst.x.default_blinding_threshold`

Also needed is to define the signal processes in the config via:
a dict entry called signals in the `cfg.x.process_groups`