### PR TITLE
Support for wlcg targets with local mirror.

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -91,8 +91,9 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 # the config name, the task family, the dataset name, or the shift name
 # (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
 # values can have the following format:
-# for local targets : "local[, LOCAL_FS_NAME or STORE_PATH][, store_parts_modifier]"
-# for remote targets: "wlcg[, WLCG_FS_NAME][, store_parts_modifier]"
+# for local targets   : "local[, LOCAL_FS_NAME or STORE_PATH][, store_parts_modifier]"
+# for remote targets  : "wlcg[, WLCG_FS_NAME][, store_parts_modifier]"
+# for mirrored targets: "wlcg_mirrored, LOCAL_FS_NAME, WLCG_FS_NAME[, store_parts_modifier]"
 # (when WLCG_FS_NAME is empty, the tasks' "default_wlcg_fs" attribute is used)
 # the "store_parts_modifiers" can be the name of a function in the "store_parts_modifiers" aux dict
 # of the analysis instance, which is called with an output's store parts of an output to modify them

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -1171,6 +1171,6 @@ class PlotMLResults(PlotMLResultsBase):
 
                 for index, f in enumerate(figs):
                     f.savefig(
-                        file_path.abs_dirname + "/" + file_path.basename.replace("0", str(index)),
+                        file_path.absdirname + "/" + file_path.basename.replace("0", str(index)),
                         format=file_path.ext(),
                     )

--- a/law.cfg
+++ b/law.cfg
@@ -91,8 +91,9 @@ lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirec
 # the config name, the task family, the dataset name, or the shift name
 # (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
 # values can have the following format:
-# for local targets : "local[, LOCAL_FS_NAME or STORE_PATH][, store_parts_modifier]"
-# for remote targets: "wlcg[, WLCG_FS_NAME][, store_parts_modifier]"
+# for local targets  : "local[, LOCAL_FS_NAME or STORE_PATH][, store_parts_modifier]"
+# for remote targets  : "wlcg[, WLCG_FS_NAME][, store_parts_modifier]"
+# for mirrored targets: "wlcg_mirrored, LOCAL_FS_NAME, WLCG_FS_NAME[, store_parts_modifier]"
 # (when WLCG_FS_NAME is empty, the tasks' "default_wlcg_fs" attribute is used)
 # the "store_parts_modifiers" can be the name of a function in the "store_parts_modifiers" aux dict
 # of the analysis instance, which is called with an output's store parts of an output to modify them


### PR DESCRIPTION
So far we offer support for local targets and wlcg targets on remote resources. However, many clusters are set up in a way that a local, read-only mount exists for remote targets. 

For this purpose, there is a new "wrapper" target now called `MirroredTarget`'s. All read requests are forwarded to local representations if they exist. If not, the remote *original* resource is queried.

This PR changes the target definition (in `AnalysisTask.target()`) to understand this new `wlcg_mirrored` target type used in the law.cfg file.