### PR TITLE
allow stitching using non-leaf processes in sum_mc_weight_per_process

### DIFF
--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -98,16 +98,16 @@ def get_br_from_inclusive_dataset(
             # skip processes that are not covered by any dataset or irrelevant for the used dataset
             # (identified as leaf processes that have no occurrences in the stats)
             # (or as non-leaf processes that are not in the stitching datasets)
-            is_leaf = str(child_proc.id) in sum_mc_weight_per_process.keys()
+            is_leaf = child_proc.is_leaf_process
+            child_in_weight_procs = str(child_proc.id) in sum_mc_weight_per_process
             if (
                 (is_leaf and str(child_proc.id) not in sum_mc_weight_per_process) or
                 (not is_leaf and child_proc.id not in proc_ds_map)
             ):
                 continue
 
-            proc_ids = [child_proc.id] if is_leaf else [
-                p.id for p, _, _ in child_proc.walk_processes()
-                if p.id in sum_mc_weight_per_process.keys()
+            proc_ids = [child_proc.id] if (is_leaf or child_in_weight_procs) else [
+                p.id for p, _, _ in child_proc.walk_processes() if str(p.id) in sum_mc_weight_per_process
             ]
             # compute the uncertainty on the branching ratio using number of events
             _br = N(sum(num_events_per_process.get(str(proc_id), 0) for proc_id in proc_ids)) / N(num_events)


### PR DESCRIPTION
The stiched normalization weights Producer expected that only leaf process IDs are present in the `sum_mc_weight_per_process` dict. This PR should fix that.