### PR TITLE
Allow running over empty Nano files

### DIFF
--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -139,7 +139,8 @@ class CalibrateEvents(
                 events = update_ak_array(events, *cols)
 
                 # just invoke the calibration function
-                events = self.calibrator_inst(events)
+                if len(events) != 0:
+                    events = self.calibrator_inst(events)
 
                 # remove columns
                 events = route_filter(events)

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -488,7 +488,7 @@ class MergeReducedEvents(
         with law.localize_file_targets(
             inputs, cache=False, mode="r",
         ) as localized_inputs:
-            
+
             metadata = [pq.read_metadata(inp.abspath) for inp in localized_inputs]
 
             # empty nano files are not considered for merging

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -23,6 +23,7 @@ from columnflow.tasks.selection import CalibrateEvents, SelectEvents
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox, safe_div
 
 ak = maybe_import("awkward")
+pq = maybe_import("pyarrow.parquet")
 
 
 # default parameters
@@ -482,7 +483,11 @@ class MergeReducedEvents(
         ])
 
     def merge(self, inputs, output):
-        inputs = [inp["events"] for inp in inputs]
+        # remove empty inputs
+        inputs = [
+            inp["events"] for inp in inputs
+            if not pq.read_metadata(inp["events"].path).num_rows == 0
+        ]
         law.pyarrow.merge_parquet_task(
             self, inputs, output["events"], writer_opts=self.get_parquet_writer_opts(),
         )

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -21,6 +21,7 @@ from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.tasks.selection import CalibrateEvents, SelectEvents
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox, safe_div
+from columnflow.columnar_util import mandatory_coffea_columns
 
 ak = maybe_import("awkward")
 pq = maybe_import("pyarrow.parquet")
@@ -487,7 +488,7 @@ class MergeReducedEvents(
         metadata = [pq.read_metadata(inp.path) for inp in inputs]
 
         # empty nano files are not considered for merging
-        empty_nano = lambda meta: (meta.num_rows == 0) & (meta.num_columns <= 3)
+        empty_nano = lambda meta: (meta.num_rows == 0) & (meta.num_columns <= len(mandatory_coffea_columns))
 
         # check if the number of columns is consistent
         unique_num_fields = set(meta.num_columns for meta in metadata if not empty_nano(meta))

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -488,8 +488,7 @@ class MergeReducedEvents(
         with law.localize_file_targets(
             inputs, cache=False, mode="r",
         ) as localized_inputs:
-            from IPython import embed
-            embed(header="merging inputs in MergeReducedEvents")
+            
             metadata = [pq.read_metadata(inp.abspath) for inp in localized_inputs]
 
             # empty nano files are not considered for merging

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -118,6 +118,7 @@ class SelectEvents(
             Route, RouteFilter, mandatory_coffea_columns, update_ak_array, add_ak_aliases,
             sorted_ak_to_parquet,
         )
+        from columnflow.selection import SelectionResult
 
         # prepare inputs and outputs
         lfn_task = self.requires()["lfns"]
@@ -195,7 +196,10 @@ class SelectEvents(
                 )
 
                 # invoke the selection function
-                events, results = self.selector_inst(events, stats, hists=hists)
+                if len(events) != 0:
+                    events, results = self.selector_inst(events, stats, hists=hists)
+                else:
+                    results = SelectionResult(event=events.event > 0)
 
                 # complain when there is no event mask
                 if results.event is None:


### PR DESCRIPTION
There are some NanoAOD files (*) with 0 events that fail when running through our workflow. This PR fixes that by skipping these files when running calibrators/selectors or when merging files.
Additionally, I also added a check for inconsistencies in number of fields when merging ReduceEvents outputs.



(*) example: file 0 from `data_muoneg_f`in the run3_2022_postEE_nano_v12 campaign:
```
# DAS
/MuonEG/Run2022F-22Sep2023-v1/NANOAOD
```
```
# file
/store/data/Run2022F/MuonEG/NANOAOD/22Sep2023-v1/50000/4d76213a-ef14-411a-9558-559a6df3f978.root
```