### PR TITLE
Fix over/underflow handling for histograms

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -132,7 +132,7 @@ remote_lcg_setup_el7: /cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-
 remote_lcg_setup_el9: /cvmfs/grid.cern.ch/alma9-ui-test/etc/profile.d/setup-alma9-test.sh
 
 # whether the loading of the remove lcg setup file is enforced
-# otherwise is might be skipped in case gfal-ls, etc., are already available
+# otherwise this might be skipped in case gfal-ls, etc., are already available
 remote_lcg_setup_force: True
 
 

--- a/law.cfg
+++ b/law.cfg
@@ -132,7 +132,7 @@ remote_lcg_setup_el7: /cvmfs/grid.cern.ch/centos7-ui-200122/etc/profile.d/setup-
 remote_lcg_setup_el9: /cvmfs/grid.cern.ch/alma9-ui-test/etc/profile.d/setup-alma9-test.sh
 
 # whether the loading of the remove lcg setup file is enforced
-# otherwise is might be skipped in case gfal-ls, etc., are already available
+# otherwise this might be skipped in case gfal-ls, etc., are already available
 remote_lcg_setup_force: True
 
 


### PR DESCRIPTION
The over- and underflow handling implemented in our plot utils is returning a copy of the input histogram. However, the portion where handling is triggered treats it as being in-place. As a result, produced plots are always shown without flow handling, independent of the variable settings.

This PR updates `use_flow_bins` to consistently return a copy of the histogram (regardless of the flags), and changes adjust to code to handle it as a copy. This fixes the plot functions.

@aalvesan 