### PR TITLE
Minor fixes for weight producers.

### DIFF
--- a/columnflow/calibration/__init__.py
+++ b/columnflow/calibration/__init__.py
@@ -106,6 +106,7 @@ class Calibrator(TaskArrayFunction):
                             "data_only, nominal_only or shifts_only are set",
                         )
 
+                if "skip_func" not in cls_dict:
                     def skip_func(self):
                         # check mc_only and data_only
                         if getattr(self, "dataset_inst", None):

--- a/columnflow/production/__init__.py
+++ b/columnflow/production/__init__.py
@@ -106,6 +106,7 @@ class Producer(TaskArrayFunction):
                             "data_only, nominal_only or shifts_only are set",
                         )
 
+                if "skip_func" not in cls_dict:
                     def skip_func(self):
                         # check mc_only and data_only
                         if getattr(self, "dataset_inst", None):

--- a/columnflow/selection/__init__.py
+++ b/columnflow/selection/__init__.py
@@ -120,6 +120,7 @@ class Selector(TaskArrayFunction):
                             "data_only, nominal_only or shifts_only are set",
                         )
 
+                if "skip_func" not in cls_dict:
                     def skip_func(self):
                         # check mc_only and data_only
                         if getattr(self, "dataset_inst", None):

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -193,7 +193,7 @@ class CreateHistograms(
                 )
 
                 # build the full event weight
-                if not self.weight_producer_inst.skip_func():
+                if hasattr(self.weight_producer_inst, "skip_func") and not self.weight_producer_inst.skip_func():
                     events, weight = self.weight_producer_inst(events)
                 else:
                     weight = ak.Array(np.ones(len(events), dtype=np.float32))

--- a/columnflow/weight/__init__.py
+++ b/columnflow/weight/__init__.py
@@ -81,6 +81,7 @@ class WeightProducer(TaskArrayFunction):
                     raise Exception(
                         f"weight producer {cls_name} received both mc_only and data_only",
                     )
+
                 if mc_only or data_only:
                     if cls_dict.get("skip_func"):
                         raise Exception(
@@ -88,6 +89,7 @@ class WeightProducer(TaskArrayFunction):
                             "mc_only or data_only are set",
                         )
 
+                if "skip_func" not in cls_dict:
                     def skip_func(self):
                         # check mc_only and data_only
                         if getattr(self, "dataset_inst", None):

--- a/columnflow/weight/empty.py
+++ b/columnflow/weight/empty.py
@@ -14,4 +14,4 @@ ak = maybe_import("awkward")
 @weight_producer
 def empty(self: WeightProducer, events: ak.Array, **kwargs) -> ak.Array:
     # simply return ones
-    return ak.Array(np.ones(len(events), dtype=np.float32))
+    return events, ak.Array(np.ones(len(events), dtype=np.float32))


### PR DESCRIPTION
This PR adds some minor fixes related to weight producers.

* a custom `skip_func` is no longer ignored when `{data,mc}_only` are not given
* `CreateHistograms` checks if a custom `skip_func` exists before attempting to evaluate it
* the `empty` weight producer now returns `events` in addition to the weight array