### PR TITLE
Inference model improvements.

### DIFF
--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -102,7 +102,7 @@ class DatacardWriter(object):
             blocks.observations = [
                 ("bin", list(rates)),
                 ("observation", [
-                    round(_rates["data"], self.rate_precision)
+                    int(round(_rates["data"], self.rate_precision))
                     for _rates in rates.values()
                 ]),
             ]
@@ -300,7 +300,7 @@ class DatacardWriter(object):
         if blocks.line_parameters:
             blocks.line_parameters = self.align_lines(list(blocks.line_parameters))
         if blocks.groups:
-            blocks.groups = self.align_lines(list(blocks.groups))
+            blocks.groups = self.align_lines(list(blocks.groups), end=3)
         if blocks.mc_stats:
             blocks.mc_stats = self.align_lines(list(blocks.mc_stats))
 
@@ -516,32 +516,36 @@ class DatacardWriter(object):
     def align_lines(
         cls,
         lines: Sequence[Any],
+        end: int = -1,
     ) -> list[str]:
         lines = [
             (line.split() if isinstance(line, str) else list(map(str, law.util.flatten(line))))
             for line in lines
         ]
 
-        lengths = {len(line) for line in lines}
+        lengths = {min(len(line), 1e9 if end < 0 else end) for line in lines}
         if len(lengths) > 1:
             raise Exception(
                 f"line alignment cannot be performed with lines of varying lengths: {lengths}",
             )
 
-        # convert to rows and get the maximum width per row
-        n_rows = list(lengths)[0]
-        rows = [
+        # convert to columns and get the maximum width per column
+        n_cols = lengths.pop()
+        cols = [
             [line[j] for line in lines]
-            for j in range(n_rows)
+            for j in range(n_cols)
         ]
         max_widths = [
-            max(len(s) for s in row)
-            for row in rows
+            max(len(s) for s in col)
+            for col in cols
         ]
 
         # stitch back
         return [
-            cls.col_sep.join(f"{s: <{max_widths[j]}}" for j, s in enumerate(line))
+            cls.col_sep.join(
+                f"{s: <{max_widths[j]}}" if end < 0 or j < end else s
+                for j, s in enumerate(line)
+            )
             for line in lines
         ]
 

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -164,7 +164,8 @@ class DatacardWriter(object):
                 elif _param_obj.type != param_obj.type:
                     raise ValueError(
                         f"misconfigured parameter '{param_name}' with type '{_param_obj.type}' "
-                        f"that was previously seen with incompatible type '{param_obj.type}'")
+                        f"that was previously seen with incompatible type '{param_obj.type}'",
+                    )
 
                 # get the effect
                 effect = _param_obj.effect

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -41,19 +41,45 @@ class CreateDatacards(
 
     def get_mc_datasets(self, proc_obj: dict) -> list[str]:
         """
-        Helper to find automatic datasets
+        Helper to find mc datasets.
 
         :param proc_obj: process object from an InferenceModel
-        :return: List of dataset names corresponding to the process *proc_obj*
+        :return: List of dataset names corresponding to the process *proc_obj*.
         """
-        # when datasets are defined on the process object itself, return them
+        # when datasets are defined on the process object itself, interpret them as patterns
         if proc_obj.config_mc_datasets:
-            return proc_obj.config_mc_datasets
+            return [
+                dataset.name
+                for dataset in self.config_inst.datasets
+                if (
+                    dataset.is_mc and
+                    law.util.multi_match(dataset.name, proc_obj.config_mc_datasets, mode=any)
+                )
+            ]
 
         # if not, check the config
         return [
             dataset_inst.name
             for dataset_inst in get_datasets_from_process(self.config_inst, proc_obj.config_process)
+        ]
+
+    def get_data_datasets(self, cat_obj: dict) -> list[str]:
+        """
+        Helper to find data datasets.
+
+        :param cat_obj: category object from an InferenceModel
+        :return: List of dataset names corresponding to the category *cat_obj*.
+        """
+        if not cat_obj.config_data_datasets:
+            return []
+
+        return [
+            dataset.name
+            for dataset in self.config_inst.datasets
+            if (
+                dataset.is_data and
+                law.util.multi_match(dataset.name, cat_obj.config_data_datasets, mode=any)
+            )
         ]
 
     def workflow_requires(self):
@@ -74,9 +100,8 @@ class CreateDatacards(
                         if self.inference_model_inst.require_shapes_for_parameter(param_obj)
                     )
 
-            if cat_obj.config_data_datasets:
-                for dataset in cat_obj.config_data_datasets:
-                    data_dataset_params[dataset]["variables"].add(cat_obj.config_variable)
+            for dataset in self.get_data_datasets(cat_obj):
+                data_dataset_params[dataset]["variables"].add(cat_obj.config_variable)
 
         # set workflow requirements per mc dataset
         reqs["merged_hists"] = set(
@@ -130,7 +155,7 @@ class CreateDatacards(
                     branch=-1,
                     workflow="local",
                 )
-                for dataset in cat_obj.config_data_datasets
+                for dataset in self.get_data_datasets(cat_obj)
             }
 
         return reqs


### PR DESCRIPTION
This PR provides a bunch of improvements to the inference model interface without breaking any previous behavior. It looks like a lot of changes, but most of them are actually just removing `InferenceModel` from `self: InferenceModel` type hints which is discouraged. Changes in particular:

- Cleaned up yaml representers in the custom `YamlDumper` class. The representer for `ParameterTransformations` was actually missing so yaml conversion did not work before. This is fixed now.
- `config_mc_datasets` and `config_data_datasets` can contain patterns now that are resolved in the `CreateDatacards` task. This is far more convenient than repeating longish lists in various places.
- The `cleanup` method is not called automatically anymore since it needs to be configurable. This should not break anything however. It accepts a `keep_parameters` option now to keep parameters in groups. Without that, the cleanup routine removes parameters that were not added to the datacard but perhaps through a custom combine physics model.
- Block formatting for parameter groups is fixed.
- Observed data events were written into the datacard as a float, though always with a trailing `.0`. This is converted to an integer now as it should be.