### PR TITLE
MultiConfigTask

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -109,11 +109,11 @@ for dataset_name in dataset_names:
 verify_config_processes(cfg, warn=True)
 
 # default objects, such as calibrator, selector, producer, ml model, inference model, etc
-cfg.x.default_calibrator = "example"
-cfg.x.default_selector = "example"
-cfg.x.default_producer = "example"
+ana.x.default_calibrator = "example"
+ana.x.default_selector = "example"
+ana.x.default_producer = "example"
 cfg.x.default_weight_producer = "example"
-cfg.x.default_ml_model = None
+ana.x.default_ml_model = None
 cfg.x.default_inference_model = "example"
 cfg.x.default_categories = ("incl",)
 cfg.x.default_variables = ("n_jet", "jet1_pt")

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1612,10 +1612,15 @@ class ArrayFunction(Derivable):
     ) -> None:
         super().__init__()
 
-        if not hasattr(self, "config_inst") and hasattr(self, "config_insts"):
-            self.config_inst = self.config_insts[0]
-        elif not hasattr(self, "config_inst") and not hasattr(self, "config_insts"):
-            return
+        # NOTE: it might be necessary/advantageous to skip CSP init functions when no config_inst is present
+        # currently this is not needed since all tasks are either a *ConfigTask* or a
+        # *MultiConfigTask* (which sets config_inst = config_insts[0]). However, we should keep
+        # in mind that this might be problematic in the future.
+
+        # if not hasattr(self, "config_inst") and hasattr(self, "config_insts"):
+        #     self.config_inst = self.config_insts[0]
+        # elif not hasattr(self, "config_inst") and not hasattr(self, "config_insts"):
+        #     return
 
         # add class-level attributes as defaults for unset arguments (no_value)
         if call_func == law.no_value:

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1612,6 +1612,11 @@ class ArrayFunction(Derivable):
     ) -> None:
         super().__init__()
 
+        if not hasattr(self, "config_inst") and hasattr(self, "config_insts"):
+            self.config_inst = self.config_insts[0]
+        elif not hasattr(self, "config_inst") and not hasattr(self, "config_insts"):
+            return
+
         # add class-level attributes as defaults for unset arguments (no_value)
         if call_func == law.no_value:
             call_func = self.__class__.call_func

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -44,11 +44,11 @@ class CalibratorMixin(AnalysisTask):
     calibrator = luigi.Parameter(
         default=RESOLVE_DEFAULT,
         description="the name of the calibrator to be applied; default: value of the "
-        "'default_calibrator' config",
+        "'default_calibrator' analysis aux",
     )
     calibrator.__annotations__ = " ".join("""
         the name of the calibrator to be applied; default: value of the
-        'default_calibrator' config""".split())
+        'default_calibrator' analysis aux""".split())
 
     # decides whether the task itself runs the calibrator and implements its shifts
     register_calibrator_sandbox = False
@@ -266,7 +266,7 @@ class CalibratorsMixin(AnalysisTask):
     calibrators = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
         description="comma-separated names of calibrators to be applied; default: value of the "
-        "'default_calibrator' config",
+        "'default_calibrator' analysis aux",
         brace_expand=True,
         parse_empty=True,
     )
@@ -472,7 +472,7 @@ class SelectorMixin(AnalysisTask):
     selector = luigi.Parameter(
         default=RESOLVE_DEFAULT,
         description="the name of the selector to be applied; default: value of the "
-        "'default_selector' config",
+        "'default_selector' analysis aux",
     )
 
     # decides whether the task itself runs the selector and implements its shifts
@@ -782,7 +782,7 @@ class ProducerMixin(AnalysisTask):
     producer = luigi.Parameter(
         default=RESOLVE_DEFAULT,
         description="the name of the producer to be applied; default: value of the "
-        "'default_producer' config",
+        "'default_producer' analysis aux",
     )
 
     # decides whether the task itself runs the producer and implements its shifts
@@ -1009,7 +1009,7 @@ class ProducersMixin(AnalysisTask):
     producers = law.CSVParameter(
         default=(RESOLVE_DEFAULT,),
         description="comma-separated names of producers to be applied; default: value of the "
-        "'default_producer' config",
+        "'default_producer' analysis aux",
         brace_expand=True,
         parse_empty=True,
     )
@@ -1402,7 +1402,7 @@ class MLModelMixin(ConfigTask, MLModelMixinBase):
     ml_model = luigi.Parameter(
         default=RESOLVE_DEFAULT,
         description="the name of the ML model to be applied; default: value of the "
-        "'default_ml_model' config",
+        "'default_ml_model' analysis aux",
     )
 
     allow_empty_ml_model = True

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -504,21 +504,13 @@ class MLTraining(
                         self,
                         config=config_inst.name,
                         dataset=dataset_inst.name,
-                        calibrators=_calibrators,
-                        selector=_selector,
-                        producers=_producers,
                         fold=fold,
                         tree_index=-1)
                     for fold in range(self.ml_model_inst.folds)
                 ]
                 for dataset_inst in dataset_insts
             }
-            for (config_inst, dataset_insts), _calibrators, _selector, _producers in zip(
-                self.ml_model_inst.used_datasets.items(),
-                self.calibrators,
-                self.selectors,
-                self.producers,
-            )
+            for config_inst, dataset_insts in self.ml_model_inst.used_datasets.items()
         }
         reqs["stats"] = {
             config_inst.name: {
@@ -526,18 +518,10 @@ class MLTraining(
                     self,
                     config=config_inst.name,
                     dataset=dataset_inst.name,
-                    calibrators=_calibrators,
-                    selector=_selector,
-                    producers=_producers,
                     tree_index=-1)
                 for dataset_inst in dataset_insts
             }
-            for (config_inst, dataset_insts), _calibrators, _selector, _producers in zip(
-                self.ml_model_inst.used_datasets.items(),
-                self.calibrators,
-                self.selectors,
-                self.producers,
-            )
+            for config_inst, dataset_insts in self.ml_model_inst.used_datasets.items()
         }
 
         # ml model requirements
@@ -556,9 +540,6 @@ class MLTraining(
                         self,
                         config=config_inst.name,
                         dataset=dataset_inst.name,
-                        calibrators=_calibrators,
-                        selector=_selector,
-                        producers=_producers,
                         fold=f,
                     )
                     for f in range(self.ml_model_inst.folds)
@@ -566,13 +547,9 @@ class MLTraining(
                 ]
                 for dataset_inst in dataset_insts
             }
-            for (config_inst, dataset_insts), _calibrators, _selector, _producers in zip(
-                self.ml_model_inst.used_datasets.items(),
-                self.calibrators,
-                self.selectors,
-                self.producers,
-            )
+            for config_inst, dataset_insts in self.ml_model_inst.used_datasets.items()
         }
+        # TODO: stats reqs missing here
 
         # ml model requirements
         reqs["model"] = self.ml_model_inst.requires(self)

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -638,9 +638,6 @@ class MLEvaluation(
         reqs["models"] = self.reqs.MLTraining.req_different_branching(
             self,
             configs=(self.config_inst.name,),
-            calibrators=(self.calibrators,),
-            selectors=(self.selector,),
-            producers=(self.producers,),
         )
 
         reqs["events"] = self.reqs.ProvideReducedEvents.req(self)
@@ -663,9 +660,6 @@ class MLEvaluation(
             "models": self.reqs.MLTraining.req_different_branching(
                 self,
                 configs=(self.config_inst.name,),
-                calibrators=(self.calibrators,),
-                selectors=(self.selector,),
-                producers=(self.producers,),
                 branch=-1,
             ),
             "events": self.reqs.ProvideReducedEvents.req(self, _exclude=self.exclude_params_branch),


### PR DESCRIPTION
This PR restructures the inheritance structure a bit to allow using mixins from CSPs in MultiConfigTasks.

- Mixins classes from CSPs are now inheriting from the AnalysisTask instead of the ConfigTask
    - this means that default CSPs now need to be set in the analysis_inst instead of the config_inst
- The MLTraining task now inherits from the CalibratorsMixin, SelectorMixin and ProducersMixin
    - This simplifies the resolving of CSPs for MLTraining as this is now taken care via the mixin classes
    - The MLTraining now needs to require the same CSPs for each config. If necessary, CSPs can be configured config dependant as shown in #391
- With MultiConfigTasks, there might be tasks that do not define a `config_inst`. Since many CSP inits expect that a config_inst is present, I added some code that sets the `config_inst` attribute to the first value of the `config_insts`. However, this might lead to inconsistencies between configs so we should keep an eye on that.



TODO:

- [x] Fix tests
- [ ] Decide on how to handle inits for MultiConfigTask
- [ ] Decide which Mixins should be AnalysisTask and which should be ConfigTask (WeightProducerMixin and InferenceModelMixin?)




Closes #391 