### PR TITLE
Exclude Over/Underflow bins in ROOT file when writing Datacards

### DIFF
--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -310,10 +310,9 @@ class InferenceModel(Derivable):
             ("config_data_datasets", list(map(str, config_data_datasets or []))),
             ("data_from_processes", list(map(str, data_from_processes or []))),
             ("flow_strategy", (
-                flow_strategy if
-                isinstance(flow_strategy, FlowStrategy)
-                else FlowStrategy[flow_strategy])
-            ),
+                flow_strategy
+                if isinstance(flow_strategy, FlowStrategy)
+                else FlowStrategy[flow_strategy])),
             ("mc_stats", mc_stats),
             ("empty_bin_value", empty_bin_value),
             ("processes", []),

--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -312,7 +312,8 @@ class InferenceModel(Derivable):
             ("flow_strategy", (
                 flow_strategy
                 if isinstance(flow_strategy, FlowStrategy)
-                else FlowStrategy[flow_strategy])),
+                else FlowStrategy[flow_strategy]
+            )),
             ("mc_stats", mc_stats),
             ("empty_bin_value", empty_bin_value),
             ("processes", []),

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -362,7 +362,7 @@ class DatacardWriter(object):
         # create the output file
         out_file = uproot.recreate(shapes_path)
 
-        # helper to remove underflow and overflow values
+        # helper to handle and apply flow strategy to histogram
         def handle_flow(cat_obj, h, name):
             # stop early if flow is ignored altogether
             if cat_obj.flow_strategy == FlowStrategy.ignore:


### PR DESCRIPTION
When writing the Datacards, rates exclude flow, while the corresponding ROOT file does not.
To create a match between both the Over and Underflow bin is set to 0. 