### PR TITLE
Fix issues with CMSSW sandboxes

### DIFF
--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -333,7 +333,8 @@ setup_cmssw() {
 
     # prepend persistent path fragments again to ensure priority for local packages and
     # remove the conda based python fragments since there are too many overlaps between packages
-    export PYTHONPATH="${CF_PERSISTENT_PATH}:$( echo ${PYTHONPATH} | sed "s|${CF_CONDA_PYTHONPATH}||g" )"
+    # export PYTHONPATH="${CF_PERSISTENT_PATH}:$( echo ${PYTHONPATH} | sed "s|${CF_CONDA_PYTHONPATH}||g" )"
+    export PYTHONPATH="${CF_PERSISTENT_PATH}:$( echo ${PYTHONPATH} )"
     export PATH="${CF_PERSISTENT_PATH}:${PATH}"
 
     # mark this as a bash sandbox for law

--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -332,8 +332,6 @@ setup_cmssw() {
     cd "${orig_dir}"
 
     # prepend persistent path fragments again to ensure priority for local packages and
-    # remove the conda based python fragments since there are too many overlaps between packages
-    # export PYTHONPATH="${CF_PERSISTENT_PATH}:$( echo ${PYTHONPATH} | sed "s|${CF_CONDA_PYTHONPATH}||g" )"
     export PYTHONPATH="${CF_PERSISTENT_PATH}:$( echo ${PYTHONPATH} )"
     export PATH="${CF_PERSISTENT_PATH}:${PATH}"
 

--- a/sandboxes/cmssw_columnar.sh
+++ b/sandboxes/cmssw_columnar.sh
@@ -23,7 +23,7 @@ action() {
         # install a venv into ${CMSSW_BASE}/venvs, which is included by BundleCMSSWSandbox
         CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_create_venv columnar &&
         source "${CMSSW_BASE}/venvs/columnar/bin/activate" "" &&
-        pip install -r "${CF_BASE}/sandboxes/columnar.txt" &&
+        pip install -I -r "${CF_BASE}/sandboxes/columnar.txt" &&
         CF_VENV_BASE="${CMSSW_BASE}/venvs" cf_make_venv_relocatable columnar
     }
     cf_cmssw_custom_setup() {


### PR DESCRIPTION
As was pointed out in issue #535 and discussions #525 and #442 , CMSSW sandboxes currently don't work as intended. There are two causes for this behavior that are fixed by this PR:

- the `cmssw_columnar` sandbox doesn't work on htcondor. This is due to overlapping dependencies between the columnar and dev sandboxes when the columnar requirements are installed with `pip install`. Fixed by performing the installation in isolation mode (`pip install -I`)
- the CMSSW sandboxes can only process local files because `gfal2` is not available. This is a result of manually removing the path to the micromamba environment from the `PYTHONPATH`. Fixed by not doing that anymore.

This is a very small PR, but I think a review would be beneficial mainly because of the second point - based on the comment in the code, there was a reason for this choice. I have tested the implementation in this PR and found no issues, but perhaps I missed something.

Closes #535 