### PR TITLE
remove unnecessary job submission when setting MergeReductionStats.n_…

### DIFF
--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -399,6 +399,8 @@ class MergeReducedEvents(
         f"removed after successful merging; default: {default_keep_reduced_events}",
     )
 
+    max_merge_factor = 50
+
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
 
     # upstream requirements
@@ -415,7 +417,7 @@ class MergeReducedEvents(
         Required by law.tasks.ForestMerge.
         """
         # return as many inputs as leafs are present to create the output of this tree, capped at 50
-        return min(self.file_merging, 50)
+        return min(self.file_merging, self.max_merge_factor)
 
     def is_sandboxed(self):
         # when the task is a merge forest, consider it sandboxed
@@ -443,7 +445,7 @@ class MergeReducedEvents(
     def merge_workflow_requires(self):
         return {
             "stats": self.reqs.MergeReductionStats.req(self),
-            "events": self.reqs.ReduceEvents.req(self, _exclude={"branches"}),
+            "events": self.reqs.ReduceEvents.req_different_branching(self, branches=((0, -1),)),
         }
 
     def merge_requires(self, start_branch, end_branch):


### PR DESCRIPTION
Running a command such as this:
```
law run cf.MergeReducedEvents --cf.ReduceEvents-{workflow=htcondor,pilot} --workers 2
```

submits the `ReduceEvents` workflow twice, once with the number of branches requires for the `MergeReductionStats` task (set to 10 per default) and once for all branches. While this PR does not fix this issue when using the default, it is solved when a user disables the feature to require only a subset of branches for the `MergeReductionStats` by setting the `MergeReductionStats.n_inputs` attribute to -1.

It would be nice if we could also fix the default behavior. Otherwise I'd propose to set the `MergeReductionStats.n_inputs` attribute to -1 per default because at the moment it mainly produces unnecessary overhead

I also added the `max_merge_factor` attribute to allow further customization of the merging.