### PR TITLE
Corrected paths used in union.py task

### DIFF
--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -265,7 +265,7 @@ class CreateDatacards(
             outputs = self.output()
             writer = DatacardWriter(self.inference_model_inst, {cat_obj.name: hists})
             with outputs["card"].localize("w") as tmp_card, outputs["shapes"].localize("w") as tmp_shapes:
-                writer.write(tmp_card.path, tmp_shapes.path, shapes_path_ref=outputs["shapes"].basename)
+                writer.write(tmp_card.abspath, tmp_shapes.abspath, shapes_path_ref=outputs["shapes"].basename)
 
 
 CreateDatacardsWrapper = wrapper_factory(

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -160,7 +160,7 @@ class CreateCutflowHistograms(
                     histograms[var_key] = h.Weight()
 
         for arr, pos in self.iter_chunked_io(
-            inputs["selection"]["masks"].path,
+            inputs["selection"]["masks"].abspath,
             source_type="awkward_parquet",
             read_columns=load_columns,
         ):

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -426,7 +426,7 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
 
         # helper function to fetch generic files
         def fetch_file(src, counter=[0]):
-            dst = os.path.join(tmp_dir.path, self.create_unique_basename(src))
+            dst = os.path.join(tmp_dir.abspath, self.create_unique_basename(src))
             src = src[0] if isinstance(src, tuple) else src
             if src.startswith(("http://", "https://")):
                 # download via wget

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -887,7 +887,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
                 else law.MirroredDirectoryTarget
             )
             return mirrored_target_cls(
-                path=local_target.path,
+                path=local_target.abspath,
                 remote_target=wlcg_target,
                 local_target=local_target,
             )
@@ -1390,7 +1390,7 @@ class CommandTask(AnalysisTask):
         if "cwd" not in kwargs and self.run_command_in_tmp:
             tmp_dir = law.LocalDirectoryTarget(is_tmp=True)
             tmp_dir.touch()
-            kwargs["cwd"] = tmp_dir.path
+            kwargs["cwd"] = tmp_dir.abspath
         self.publish_message("cwd: {}".format(kwargs.get("cwd", os.getcwd())))
 
         # call it

--- a/columnflow/tasks/framework/decorators.py
+++ b/columnflow/tasks/framework/decorators.py
@@ -72,10 +72,10 @@ def view_output_plots(
                 continue
             if output.path.endswith((".pdf", ".png")):
                 if not isinstance(output, law.LocalTarget):
-                    task.logger.warning(f"cannot show non-local plot at '{output.path}'")
+                    task.logger.warning(f"cannot show non-local plot at '{output.abspath}'")
                     continue
                 elif output.path not in view_paths:
-                    view_paths.append(output.path)
+                    view_paths.append(output.abspath)
 
         # loop through paths and view them
         for path in view_paths:

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -172,7 +172,7 @@ class CreateHistograms(
             mode="r",
         ) as inps:
             for (events, *columns), pos in self.iter_chunked_io(
-                [inp.path for inp in inps],
+                [inp.abspath for inp in inps],
                 source_type=len(file_targets) * ["awkward_parquet"] + [None] * len(reader_targets),
                 read_columns=(len(file_targets) + len(reader_targets)) * [read_columns],
                 chunk_size=self.weight_producer_inst.get_min_chunk_size(),

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -204,7 +204,7 @@ class PrepareMLEvents(
             mode="r",
         ) as inps:
             for (events, *columns), pos in self.iter_chunked_io(
-                [inp.path for inp in inps],
+                [inp.abspath for inp in inps],
                 source_type=len(files) * ["awkward_parquet"] + [None] * len(reader_targets),
                 read_columns=(len(files) + len(reader_targets)) * [read_columns],
             ):
@@ -253,7 +253,7 @@ class PrepareMLEvents(
                     # save as parquet via a thread in the same pool
                     chunk = tmp_dir.child(f"file_{f}_{pos.index}.parquet", type="f")
                     output_chunks[f][pos.index] = chunk
-                    self.chunked_io.queue(sorted_ak_to_parquet, (fold_events, chunk.path))
+                    self.chunked_io.queue(sorted_ak_to_parquet, (fold_events, chunk.abspath))
 
             # merge output files of all folds
             for _output_chunks, output in zip(output_chunks, outputs["mlevents"].targets):
@@ -778,7 +778,7 @@ class MLEvaluation(
             mode="r",
         ) as inps:
             for (events, *columns), pos in self.iter_chunked_io(
-                [inp.path for inp in inps],
+                [inp.abspath for inp in inps],
                 source_type=len(file_targets) * ["awkward_parquet"] + [None] * len(reader_targets),
                 read_columns=(len(file_targets) + len(reader_targets)) * [read_columns],
             ):
@@ -828,7 +828,7 @@ class MLEvaluation(
                 # save as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
                 output_chunks[pos.index] = chunk
-                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
@@ -1033,7 +1033,7 @@ class PlotMLResultsBase(
                     "which is not implemented yet.",
                 )
 
-            events = ak.from_parquet(inp["mlcolumns"].path)
+            events = ak.from_parquet(inp["mlcolumns"].abspath)
 
             # masking with leaf categories
             category_mask = False

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -144,7 +144,7 @@ class ProduceColumns(
                 # save as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
                 output_chunks[pos.index] = chunk
-                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -122,11 +122,11 @@ class UniteColumns(
         read_columns = {Route(c) for c in read_columns}
 
         # iterate over chunks of events and diffs
-        files = [inputs["events"]["events"].path]
+        files = [inputs["events"]["events"].abspath]
         if self.producer_insts:
-            files.extend([inp["columns"].path for inp in inputs["producers"]])
+            files.extend([inp["columns"].abspath for inp in inputs["producers"]])
         if self.ml_model_insts:
-            files.extend([inp["mlcolumns"].path for inp in inputs["ml"]])
+            files.extend([inp["mlcolumns"].abspath for inp in inputs["ml"]])
         for (events, *columns), pos in self.iter_chunked_io(
             files,
             source_type=len(files) * ["awkward_parquet"],
@@ -150,9 +150,9 @@ class UniteColumns(
             chunk = tmp_dir.child(f"file_{pos.index}.{self.file_type}", type="f")
             output_chunks[pos.index] = chunk
             if self.file_type == "parquet":
-                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
             else:  # root
-                self.chunked_io.queue(sorted_ak_to_root, (events, chunk.path))
+                self.chunked_io.queue(sorted_ak_to_root, (events, chunk.abspath))
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]


### PR DESCRIPTION
After fixing mirror targets in law (ff594e7670d236b6676773d6e5d5eb6b42c4d4c5), the paths used in union.py should resolve to absolute path and not only the path.