### PR TITLE
Small fixes for weight calculation and stitching

### DIFF
--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -339,6 +339,9 @@ def normalization_weights_init(self: Producer) -> None:
     """
     Initializes the normalization weights producer by setting up the normalization weight column.
     """
+    if getattr(self, "dataset_inst", None) is None:
+        return
+
     self.produces.add(self.weight_name)
     if self.allow_stitching:
         self.stitching_datasets = self.get_stitching_datasets()

--- a/columnflow/selection/stats.py
+++ b/columnflow/selection/stats.py
@@ -148,15 +148,15 @@ def increment_stats(
                     f"but found a sequence: {obj}",
                 )
             if len(obj) == 1:
-                weights = ak.values_astype(obj[0], float)
+                weights = ak.values_astype(obj[0], np.float64)
             elif len(obj) == 2:
-                weights, weight_mask = ak.values_astype(obj[0], float), obj[1]
+                weights, weight_mask = ak.values_astype(obj[0], np.float64), obj[1]
             else:
                 raise Exception(f"cannot interpret as weights and optional mask: '{obj}'")
         elif op == self.NUM:
             weight_mask = obj
         else:  # SUM
-            weights = ak.values_astype(obj, float)
+            weights = ak.values_astype(obj, np.float64)
 
         # when mask is an Ellipsis, it cannot be AND joined to other masks, so convert to true mask
         if weight_mask is Ellipsis:

--- a/columnflow/selection/stats.py
+++ b/columnflow/selection/stats.py
@@ -148,15 +148,15 @@ def increment_stats(
                     f"but found a sequence: {obj}",
                 )
             if len(obj) == 1:
-                weights = obj[0]
+                weights = ak.values_astype(obj[0], float)
             elif len(obj) == 2:
-                weights, weight_mask = obj
+                weights, weight_mask = ak.values_astype(obj[0], float), obj[1]
             else:
                 raise Exception(f"cannot interpret as weights and optional mask: '{obj}'")
         elif op == self.NUM:
             weight_mask = obj
         else:  # SUM
-            weights = obj
+            weights = ak.values_astype(obj, float)
 
         # when mask is an Ellipsis, it cannot be AND joined to other masks, so convert to true mask
         if weight_mask is Ellipsis:


### PR DESCRIPTION
This PR adds:

* **NEW Feature** in [`columnflow/production/normalization.py`](diffhunk://#diff-dde4366913ffb5374861aac3e1928725eefa5cb61765b6db1d442a06331d7927R200-R203): creates a column with "inclusive" normalization weights to simulate behavior of datasets, when unstitched.

* **BUG FIX** in [`columnflow/selection/stats.py`](diffhunk://#diff-db8f9c06a1b154d06053e3f72b9147ada3fca66b15481795f7e842dbfea043a3L151-R159): Ensured that weights are cast to float using `ak.values_astype` to prevent precision-related errors (since `np.float32` is used by default for the weights).