### PR TITLE
Handle missing selector steps in `CreateCutflowHistograms` and related plot tasks.

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -68,6 +68,10 @@ chunked_io_debug: False
 # checked (raising an exception) for non-finite values before saving them to disk
 check_finite_output: cf.CalibrateEvents, cf.SelectEvents, cf.ProduceColumns
 
+# how to treat inexistent selector steps passed to cf.CreateCutflowHistograms: throw an error,
+# silently skip them, or add a dummy step to the output (allowed values: error, skip, dummy)
+missing_selector_step_strategy: error
+
 # csv list of task families that inherit from ChunkedReaderMixin and whose input columns should be
 # checked (raising an exception) for overlaps between fields when created a merged input array
 check_overlapping_inputs: None

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -20,6 +20,7 @@ from columnflow.plotting.plot_util import (
     apply_variable_settings,
     apply_process_settings,
     apply_density_to_hists,
+    hists_merge_cutflow_steps,
     get_position,
     get_profile_variations,
     blind_sensitive_bins,
@@ -248,6 +249,7 @@ def plot_cutflow(
 
     hists = apply_process_settings(hists, process_settings)
     hists = apply_density_to_hists(hists, density)
+    hists = hists_merge_cutflow_steps(hists)
 
     # setup plotting config
     plot_config = prepare_plot_config(

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -706,6 +706,8 @@ class PlotCutflowVariables1D(
                 step_hists = OrderedDict(
                     (process_inst.copy_shallow(), h[{"step": hist.loc(step)}])
                     for process_inst, h in hists.items()
+                    # skip missing steps
+                    if step in h.axes["step"]
                 )
 
                 # call the plot function
@@ -728,6 +730,8 @@ class PlotCutflowVariables1D(
                 process_hists = OrderedDict(
                     (step, h[{"step": hist.loc(step)}])
                     for step in self.chosen_steps
+                    # skip missing steps
+                    if step in h.axes["step"]
                 )
 
                 # call the plot function

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -64,6 +64,18 @@ class CreateCutflowHistograms(
     # strategy for handling missing source columns when adding aliases on event chunks
     missing_column_alias_strategy = "original"
 
+    # strategy for handling selector steps not defined by selectors
+    missing_selector_step_strategy = luigi.ChoiceParameter(
+        significant=False,
+        default=law.config.get_default("analysis", "missing_selector_step_strategy", "error"),
+        choices=("error", "skip", "dummy"),
+        description="how to handle selector steps that are not defined by the selector; if 'error', an "
+        "exception will be thrown; if 'skip', the selector step will be ignored; if 'dummy' the "
+        "output histogram will contain an entry for the step identical to the previous one; the "
+        "default can be configured via the law config entry *missing_selector_step_strategy* in "
+        "the *analysis* section; if no default is specified there, 'error' is assumed",
+    )
+
     def create_branch_map(self):
         # dummy branch map
         return [None]
@@ -189,6 +201,8 @@ class CreateCutflowHistograms(
                 # helper to build the point for filling, except for the step which does
                 # not support broadcasting
                 def get_point(mask=Ellipsis):
+                    if mask is True:
+                        mask = Ellipsis
                     n_events = len(events) if mask is Ellipsis else ak.sum(mask)
                     point = {
                         "process": events.process_id[mask],
@@ -217,11 +231,21 @@ class CreateCutflowHistograms(
                 mask = True
                 for step in steps:
                     if step not in arr.steps.fields:
-                        raise ValueError(
-                            f"step '{step}' is not defined by selector {self.selector}",
-                        )
-                    # incrementally update the mask and fill the point
-                    mask = mask & arr.steps[step]
+                        if self.missing_selector_step_strategy == "error":
+                            raise ValueError(
+                                f"step '{step}' is not defined by selector {self.selector}",
+                            )
+                        elif self.missing_selector_step_strategy == "skip":
+                            continue
+                        elif self.missing_selector_step_strategy == "dummy":
+                            pass
+                        else:
+                            assert False
+                    else:
+                        # incrementally update the mask
+                        mask = mask & arr.steps[step]
+
+                    # fill the point
                     fill_data = get_point(mask)
                     fill_hist(
                         histograms[var_key],

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -158,7 +158,7 @@ class CreateCutflowHistograms(
                         hist.Hist.new
                         .IntCat([], name="category", growth=True)
                         .IntCat([], name="process", growth=True)
-                        .StrCat(steps, name="step")
+                        .StrCat([], name="step", growth=True)
                         .IntCat([], name="shift", growth=True)
                     )
                     # add variable axes
@@ -350,6 +350,7 @@ class PlotCutflow(
                 branch=0,
                 dataset=d,
                 variables=(self.variable,),
+                missing_selector_step_strategy="skip",
             )
             for d in self.datasets
         }

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -235,12 +235,8 @@ class CreateCutflowHistograms(
                             raise ValueError(
                                 f"step '{step}' is not defined by selector {self.selector}",
                             )
-                        elif self.missing_selector_step_strategy == "skip":
+                        if self.missing_selector_step_strategy == "skip":
                             continue
-                        elif self.missing_selector_step_strategy == "dummy":
-                            pass
-                        else:
-                            assert False
                     else:
                         # incrementally update the mask
                         mask = mask & arr.steps[step]

--- a/law.cfg
+++ b/law.cfg
@@ -66,6 +66,10 @@ chunked_io_debug: False
 # cf.MLEvaluation, cf.UniteColumns
 check_finite_output: None
 
+# how to treat inexistent selector steps passed to cf.CreateCutflowHistograms: throw an error,
+# silently skip them, or add a dummy step to the output (allowed values: error, skip, dummy)
+missing_selector_step_strategy: error
+
 # csv list of task families that inherit from ChunkedReaderMixin and whose input columns should be
 # checked (raising an exception) for overlaps between fields when created a merged input array
 # supported tasks are: cf.SelectEvents, cf.ReduceEvents, cf.ProduceColumns, cf.PrepareMLEvents,


### PR DESCRIPTION
This PR addresses an edge case in cutflow-related tasks where processes define different sets of `selector_steps` (cf. #567)

A new law config parameter `analysis.missing_selector_step_strategy` is introduced:
* `error` (default): an exception is raised if a requested selector step is not defined by any process
* `skip`: the selector step is ignored and the produced histogram will not contain a corresponding entry in the `step` axis)
* `dummy`: the selector step is ignored, but the produced histogram will contain a corresponding entry in the `step` axis that is identical to the previous step (i.e. the missing step is treated as not having any effect on the event selection).

On the plotting side, histograms with different `step` axes are pre-processed to insert any missing steps before being passed, ensuring that all `step` axes are identical. The values and variances for the inserted `step` bins are taken from the previous existing step in the sequence.

To facilitate the dynamic resolution of steps per process and merging of histograms for plotting, the `step` axis of all cutflow histograms is initialized with an empty list and `growth=True`.

Closes #567.