### PR TITLE
Update package versions in sandboxes.

### DIFF
--- a/sandboxes/cf.txt
+++ b/sandboxes/cf.txt
@@ -1,8 +1,8 @@
-# version 12
+# version 13
 
-tenacity!=8.4.0
-luigi~=3.5.1
+#tenacity!=8.4.0
+luigi~=3.5.2
 scinum~=2.2.0
 six~=1.16.0
-pyyaml~=6.0.1
+pyyaml~=6.0.2
 typing_extensions~=4.12.2

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,12 +1,20 @@
-# version 14
+# version 16
 
-awkward==2.6.6
-uproot==5.3.9
-pyarrow==16.1.0
-dask-awkward==2024.6.0
+# exact versions for core array packages
+awkward==2.7.1
+uproot==5.5.1
+pyarrow==18.0.0
+dask-awkward==2024.9.0
+correctionlib==2.6.4
+# newer coffea versions use the vector library in a suboptimal way:
+# when loading only the pt column of a "vector" array, the field cannot be accessed
+# since a check is in place to ensure that the three other columns (eta,phi,mass)
+# are present as well; however, we might not need them yet still cannot access pt;
+# see BUGREPORT-TO-BE-ADDED
 coffea==2024.6.1
-correctionlib==2.6.1
+
+# minimum versions for general packages
 tabulate~=0.9.0
-zstandard~=0.22.0
+zstandard~=0.23.0
 lz4~=4.3.3
-xxhash~=3.4.1
+xxhash~=3.5.0

--- a/sandboxes/dev.txt
+++ b/sandboxes/dev.txt
@@ -1,11 +1,12 @@
-# version 9
+# version 10
 
+# last version to support python 3.9
 ipython~=8.18.1
-pytest~=8.2.2
-pytest-cov~=5.0.0
-flake8~=7.1.0
+pytest~=8.3.3
+pytest-cov~=6.0.0
+flake8~=7.1.1
 flake8-commas~=4.0.0
 flake8-quotes~=3.4.0
-pipdeptree~=2.23.0
-pymarkdownlnt~=0.9.20
-uniplot~=0.13.0
+pipdeptree~=2.23.4
+pymarkdownlnt~=0.9.25
+uniplot~=0.15.1

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,4 +1,4 @@
-# version 8
+# version 9
 
 -r columnar.txt
 


### PR DESCRIPTION
Before working on finalizing #222, we should update versions of packages in our current sandboxes, which is done in this PR.

The versions of all array core packages were updated as well, leading to some speed ups during processing. as it is right now, coffea cannot be updated. I left a note in the `columnar.txt` file where we also should paste a link to a bug report once opened (I need to confirm this, but this should not hold back the PR).

Could you try this too @haddadanas ?

@mafrahm 