### PR TITLE
Add --htcondor-disk parameter.

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -56,6 +56,7 @@ skip_ensure_proxy: False
 # some remote workflow parameter defaults
 htcondor_flavor: $CF_HTCONDOR_FLAVOR
 htcondor_share_software: False
+htcondor_disk: -1
 slurm_flavor: $CF_SLURM_FLAVOR
 slurm_partition: $CF_SLURM_PARTITION
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -142,7 +142,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         _prefer_cli = law.util.make_set(kwargs.get("_prefer_cli", [])) | {
             "version", "workflow", "job_workers", "poll_interval", "walltime", "max_runtime",
             "retries", "acceptance", "tolerance", "parallel_jobs", "shuffle_jobs", "htcondor_cpus",
-            "htcondor_gpus", "htcondor_memory", "htcondor_pool", "pilot",
+            "htcondor_gpus", "htcondor_memory", "htcondor_disk", "htcondor_pool", "pilot",
         }
         kwargs["_prefer_cli"] = _prefer_cli
 

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -528,6 +528,11 @@ class RemoteWorkflowMixin(object):
 
 _default_htcondor_flavor = law.config.get_expanded("analysis", "htcondor_flavor", law.NO_STR)
 _default_htcondor_share_software = law.config.get_expanded_boolean("analysis", "htcondor_share_software", False)
+_default_htcondor_disk = law.util.parse_bytes(
+    law.config.get_expanded_float("analysis", "htcondor_disk", law.NO_FLOAT),
+    input_unit="GB",
+    unit="GB",
+)
 
 
 class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkflowMixin):
@@ -569,11 +574,11 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
         "empty default",
     )
     htcondor_disk = law.BytesParameter(
-        default=law.NO_FLOAT,
+        default=_default_htcondor_disk,
         unit="GB",
         significant=False,
         description="requested disk space in GB; empty value leads to the cluster default setting; "
-        "empty default",
+        f"{'empty default' if _default_htcondor_disk <= 0 else 'default: ' + str(_default_htcondor_disk)}",
     )
     htcondor_flavor = luigi.ChoiceParameter(
         default=_default_htcondor_flavor,

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -568,6 +568,13 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
         description="requested memeory in MB; empty value leads to the cluster default setting; "
         "empty default",
     )
+    htcondor_disk = law.BytesParameter(
+        default=law.NO_FLOAT,
+        unit="GB",
+        significant=False,
+        description="requested disk space in GB; empty value leads to the cluster default setting; "
+        "empty default",
+    )
     htcondor_flavor = luigi.ChoiceParameter(
         default=_default_htcondor_flavor,
         choices=(
@@ -696,6 +703,12 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
         # request memory
         if self.htcondor_memory is not None and self.htcondor_memory > 0:
             config.custom_content.append(("Request_Memory", self.htcondor_memory))
+
+        # request disk space
+        if self.htcondor_disk is not None and self.htcondor_disk > 0:
+            # TODO: the exact conversion might be flavor dependent in the future, use kB for npw
+            # e.g. https://confluence.desy.de/pages/viewpage.action?pageId=128354529
+            config.custom_content.append(("RequestDisk", self.htcondor_disk * 1024**2))
 
         # render variables
         config.render_variables["cf_bootstrap_name"] = "htcondor_standalone"

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -570,7 +570,7 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
         default=law.NO_FLOAT,
         unit="MB",
         significant=False,
-        description="requested memeory in MB; empty value leads to the cluster default setting; "
+        description="requested memory in MB; empty value leads to the cluster default setting; "
         "empty default",
     )
     htcondor_disk = law.BytesParameter(

--- a/law.cfg
+++ b/law.cfg
@@ -52,6 +52,7 @@ skip_ensure_proxy: False
 # some remote workflow parameter defaults
 htcondor_flavor: $CF_HTCONDOR_FLAVOR
 htcondor_share_software: False
+htcondor_disk: -1
 slurm_flavor: $CF_SLURM_FLAVOR
 slurm_partition: $CF_SLURM_PARTITION
 


### PR DESCRIPTION
This PR adds a parameter `--htcondor-disk` which sets the RequestDisk ClassAd for htcondor submission files. The default is empty, meaning that no ClassAd is set. However, this is configurable through the `law.cfg`.