### PR TITLE
do not remove anything from plotting work tree

### DIFF
--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -212,11 +212,6 @@ class PlotVariablesBaseSingleShift(
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
-
-        # no need to require merged histograms since each branch already requires them as a workflow
-        if self.workflow == "local":
-            reqs.pop("merged_hists", None)
-
         return reqs
 
     def requires(self):
@@ -322,11 +317,6 @@ class PlotVariablesBaseMultiShifts(
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
-
-        # no need to require merged histograms since each branch already requires them as a workflow
-        if self.workflow == "local":
-            reqs.pop("merged_hists", None)
-
         return reqs
 
     def requires(self):


### PR DESCRIPTION
Currently, we remove everything above the `MergeHistograms` level when requesting any plotting function. As discussed in the last in-person dev meeting, this decreases the time it takes to start the actual task itself. However, this has some negative interference with other convenience functionalities, such as printing the status within the task tree or removing outputs for levels above 1.

This PR changes this behavior again.

Closes #520 