### PR TITLE
Integrate chapter about systematic uncertainties into docs

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -205,8 +205,9 @@ cfg.add_shift(name="tune_down", id=2, type="shape", tags={"disjoint_from_nominal
 
 # fake jet energy correction shift, with aliases flaged as "selection_dependent", i.e. the aliases
 # affect columns that might change the output of the event selection
-cfg.add_shift(name="jec_up", id=20, type="shape")
-cfg.add_shift(name="jec_down", id=21, type="shape")
+cfg.add_shift(name="jec_up", id=20, type="shape", tags={"jec"})
+cfg.add_shift(name="jec_down", id=21, type="shape", tags={"jec"})
+# add column aliases for shift jec
 add_shift_aliases(
     cfg,
     "jec",

--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -221,6 +221,7 @@ add_shift_aliases(
 # event weights due to muon scale factors
 cfg.add_shift(name="mu_up", id=10, type="shape")
 cfg.add_shift(name="mu_down", id=11, type="shape")
+# add column aliases for shift mu
 add_shift_aliases(cfg, "mu", {"muon_weight": "muon_weight_{direction}"})
 
 # external files

--- a/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
@@ -81,6 +81,14 @@ def jet_selection(
         },
     )
 
+@jet_selection.init
+def jet_selection_init(self: Selector) -> None:
+    # register shifts
+    self.shifts |= {
+        shift_inst.name
+        for shift_inst in self.config_inst.shifts
+        if shift_inst.has_tag(("jec", "jer"))
+    }
 
 #
 # exposed selectors

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -6,7 +6,7 @@ Helpers and utilities for working with columnar libraries.
 
 from __future__ import annotations
 
-__all__ = []
+# __all__ = []
 
 import os
 import gc

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -6,14 +6,16 @@ API Reference
 
    calibration/index
    categorization/index
-   production/index
-   selection/index
    categorization/index
    inference/index
    ml/index
    plotting/index
+   production/index
+   selection/index
    tasks/index
-   util
+   weights/index
    columnar_util
    config_util
    types
+   util
+

--- a/docs/api/weights/all_weights.rst
+++ b/docs/api/weights/all_weights.rst
@@ -1,0 +1,9 @@
+``all_weights``
+===============
+
+.. currentmodule:: columnflow.weight.all_weights
+.. automodule:: columnflow.weight.all_weights
+    :autosummary:
+    :members:
+    :undoc-members:
+

--- a/docs/api/weights/empty.rst
+++ b/docs/api/weights/empty.rst
@@ -1,0 +1,9 @@
+``empty``
+=========
+
+.. currentmodule:: columnflow.weight.empty
+.. automodule:: columnflow.weight.empty
+    :autosummary:
+    :members:
+    :undoc-members:
+

--- a/docs/api/weights/index.rst
+++ b/docs/api/weights/index.rst
@@ -1,0 +1,14 @@
+``columnflow.weight``
+=====================
+
+.. currentmodule:: columnflow.weight
+.. automodule:: columnflow.weight
+    :autosummary:
+    :members:
+    :undoc-members:
+
+.. toctree::
+    :maxdepth: 1
+
+    all_weights
+    empty

--- a/docs/user_guide/building_blocks/config_objects.md
+++ b/docs/user_guide/building_blocks/config_objects.md
@@ -131,6 +131,8 @@ A more detailed description of the usage of categories in columnflow is given in
 Similarly to categories, Channels are built to investigate specific parts of the phase space and are described in the [Channel and Category](https://python-order.readthedocs.io/en/latest/quickstart.html#channel-and-category) part of the Quickstart section of the order documentation.
 They can be added to the Config object using {external+order:py:meth}`order.config.Config.add_channel()`.
 
+(shift)=
+
 ### Shift
 
 In order to implement systematic variations in the Config object, the {external+order:py:class}`order.shift.Shift` class can be used.
@@ -181,7 +183,7 @@ An example is given below:
 ```{literalinclude} ../../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
 :language: python
 :start-after: "# columns to keep after certain steps"
-:end-before: "# event weight columns as keys in an OrderedDict, mapped to shift instances they depend on"
+:end-before: "})"
 ```
 
 (custom_retrieval_of_dataset_files_section)=

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -8,6 +8,7 @@ User Guide
    building_blocks/index
    sandbox.md
    ml.md
+   shifts.md
    plotting.md
    examples.md
    debugging.md

--- a/docs/user_guide/shifts.md
+++ b/docs/user_guide/shifts.md
@@ -3,7 +3,7 @@
 
 Many aspects of the work of analyzers revolve around systematic uncertainties on the modeling of the simulation or in the conditions during data taking.
 columnflow is designed to support various types of systematic uncertainties, also referred to as *shifts*.
-We distinguish two general classes of uncertainties: 
+We distinguish two general classes of uncertainties:  
 
 - **rate uncertainties** only modify the overall yield of a distribution.
 - **shape uncertainties** can modify both the yield and the shape of distributions.
@@ -99,7 +99,6 @@ This way, the workflow is now fully aware of the shift.
 You can test your implementation e.g. by running the {py:class}`~columnflow.tasks.plotting.PlotShiftedVariables1D` task.
 For more information, see the [plotting overview](../task_overview/plotting_tasks.md).
 
-
 To include this shift in a statistical inference model, we need to add it as a parameter (see CMS analysis example):
 
 ```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/inference/example.py
@@ -113,15 +112,13 @@ In particular, note that this type of uncertainty needs to define the keyword ar
 
 ## Uncertainties that modify the selection efficiency
 
-A more complex type of shape uncertainty arises from effects that can modify vital quantities for analysis decisions. 
+A more complex type of shape uncertainty arises from effects that can modify vital quantities for analysis decisions.
 One example for this class of uncertainties are calibrations of objects such as jets, which modify the four-momenta content of these objects.
 Since these calibrations are generally subject to uncertainties, the corresponding variations can propagate throughout the analysis workflow and modify for example selection efficiencies in the analysis phase space.
 The following will discuss the implementation of such uncertainties based on the energy calibration of jets at CMS.
 
 columnflow provides the {py:class}`~columnflow.calibration.cms.jets.jec` Calibrator module that performs the jet energy calibration.
 Apart from the nominal calibration, this module also saves the varied quantities, see e.g. the following code snippet:
-
-
 
 Note that in this case, the exact list of source of uncertainty is provided by the config instance itself.
 For more information, please consider reading through the {py:class}`~columnflow.calibration.cms.jets.jec` documentation and the config of the analysis example.
@@ -153,7 +150,6 @@ As explained above, the jet energy calibration and its variations can have a non
 Therefore, the module that defines this phase space needs to consider these variations.
 This is generally done within the {py:class}`~columnflow.tasks.selection.SelectEvents` task, where {py:class}`~columnflow.selection.Selector` instances derive boolean masks based on criteria on for example the four-momenta of the objects.
 In the scope of this example, the jet selection is the relevant module, and we add the shifts accordingly in the selection of the CMS analysis example:
-
 
 ```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
 :dedent:

--- a/docs/user_guide/shifts.md
+++ b/docs/user_guide/shifts.md
@@ -78,10 +78,10 @@ For convenience, we provide the {py:func}`~columnflow.config_util.add_shift_alia
 Note that this function makes some assumptions on the naming of the varied quantities and the shifts.
 
 Finally, we can now configure the modules within the workflow to use this shift.
-As mentioned above, this class of systematic uncertainties does not change any selection efficiencies.
+As mentioned above, this class of systematic uncertainties does not affect the selection acceptance.
 Therefore, it is sufficient to consider the varied quantities in the {py:class}`~columnflow.tasks.histograms.CreateHistograms` task.
 
-The calculation of the final event weight is handles by the {py:class}`~columnflow.weight.WeightProducer` instance you specify at command-line level.
+The calculation of the final event weight is handled by the {py:class}`~columnflow.weight.WeightProducer` instance you specify at command-line level.
 Consequently, this module needs to be aware of the shift.
 This can be done with the internal {py:attr}`~columnflow.columnar_util.TaskArrayFunction.shifts` set, see e.g. the analysis example for a weight producer:
 
@@ -114,7 +114,7 @@ In particular, note that this type of uncertainty needs to define the keyword ar
 
 A more complex type of shape uncertainty arises from effects that can modify vital quantities for analysis decisions.
 One example for this class of uncertainties are calibrations of objects such as jets, which modify the four-momenta content of these objects.
-Since these calibrations are generally subject to uncertainties, the corresponding variations can propagate throughout the analysis workflow and modify for example selection efficiencies in the analysis phase space.
+Since these calibrations are generally subject to uncertainties, the corresponding variations can propagate throughout the analysis workflow and modify event and object selection acceptances.
 The following will discuss the implementation of such uncertainties based on the energy calibration of jets at CMS.
 
 columnflow provides the {py:class}`~columnflow.calibration.cms.jets.jec` Calibrator module that performs the jet energy calibration.
@@ -177,7 +177,7 @@ Such measures can be necessary to account for complicated, untracktable effects,
 In such cases, it is common practice to generate dedicated samples that need to traverse the complete workflow.
 
 Facilitating this situtation requires a certain amount of (columnflow-external) overhead.
-Currently, the metadata database that stores the information about the datasets and processes needs to defined with a {external+order:py:class}`~order.dataset.DatasetInfo` object.
+Currently, the metadata database that stores the information about the datasets and processes needs to be defined with a {external+order:py:class}`~order.dataset.DatasetInfo` object.
 This object needs to define the nominal as well as the varied datasets in the {external+order:py:attr}`~order.dataset.Dataset.info` attribute.
 For more information, please consider the corresponding section in the [general columnflow structure](./structure.md#analysis-campaign-and-config) section.
 

--- a/docs/user_guide/shifts.md
+++ b/docs/user_guide/shifts.md
@@ -1,0 +1,79 @@
+
+# Systematic Uncertainties
+
+Many aspects of the work of analyzers revolves around systematic uncertainties on the modeling of the simulation or in the conditions during data taking.
+columnflow is designed to support various types of systematic uncertainties, also referred to as *shifts*.
+
+The following section describe how to configure your modules to correctly register and use these shifts.
+
+## Uncertainties that only modify the yield
+
+The easiest class of systematic uncertainties to implement are shifts that only modify the overall yield in the final template for a given process.
+One common example for such parameters within high-energy physics is the uncertainty on the measurement of the luminosity, which directly affects the expected number of events.
+
+Consider the following example from the analysis template for the configuration of the luminosity and its uncertainties:
+
+```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+:dedent:
+:language: python
+:start-at: '# lumi values in inverse pb'
+:end-before: '# names of muon correction sets and working points'
+```
+
+Note that the luminosity is defined as a {external+scinum:py:class}`scinum.Number` object to define the nominal values as well as multiple sources of uncertainties in one place.
+
+These uncertainties do not impact the workflow itself since they do not modify the selection efficiency or require the processing of additional samples.
+Therefore, no additional steps are necessary to register this shift in the workflow, provided you do not want to use it for plotting tasks.
+For an example on the latter please see {ref}`section on weight-based uncertainties <weight_based_uncertainties>`.
+
+Since this uncertainty is defined in the config instance, it's accessible at any point within the workflow.
+Consequently, this uncertainty can be integrated into a statistical inference model like this:
+
+```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/inference/example.py
+:dedent:
+:language: python
+:start-at: '# lumi'
+:end-before: '# tune uncertainty'
+```
+
+(weight_based_uncertainties)=
+
+## Weight-based uncertainties
+
+This class of shifts consists of uncertainties that enter the analysis with the application of weights to events or individual objects.
+Popular examples for this type of uncertainty are scale factors to generally improve the compatibility between observed data and simulation before the measurement.
+Since these factors are usually measured in dedicated control regions, they are also subject to both statistical and systematic uncertainties that need to be taken into account in the final statistical inference.
+The following example is based on scale factors for muons.
+
+columnflow provides the {py:class}`~columnflow.production.cms.muon.muon_weights` Producer to calculate the weights for scale factors.
+This module creates three columns: one for weights derived from the nominal scale factors and columns where the scale factors are varied within the 68% confidence intervals of the measurement (up and down variations).
+In order to derive templates that correspond to these variations, we need to tell the workflow that the varied versions of this weight when creating the templates.
+
+As explained in the [config section](building_blocks/config_objects.md#shift), the shift needs to be registered in the config.
+As demonstrated in the cms analysis example, this can be done like so:
+
+```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+:dedent:
+:language: python
+:start-at: '# event weights due to muon scale factors'
+:end-before: '# add column aliases for shift mu'
+```
+
+Next, we define a column alias as auxiliary information for each of these shifts.
+This can later be used to switch out the name of a given column (e.g. `muon_weight`) with a varied version of the quantity (e.g. `muon_weight_up`).
+For convenience, we provide the {py:func}`~columnflow.config_util.add_shift_aliases` function to easily add the alias for both variations of the shift at once:
+
+```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+:dedent:
+:language: python
+:start-at: '# add column aliases for shift mu'
+:end-before: '# external files'
+```
+
+Note that this function makes some assumptions on the naming of the varied quantities and the shifts.
+
+Finally, we can now configure the modules within the workflow to use this shift.
+As mentioned above, this class of systematic uncertainties does not change any selection efficiencies.
+Therefore, it is sufficient to consider the varied quantities in the {py:class}`~columnflow.tasks.histograms.CreateHistograms` task.
+
+

--- a/docs/user_guide/shifts.md
+++ b/docs/user_guide/shifts.md
@@ -76,4 +76,18 @@ Finally, we can now configure the modules within the workflow to use this shift.
 As mentioned above, this class of systematic uncertainties does not change any selection efficiencies.
 Therefore, it is sufficient to consider the varied quantities in the {py:class}`~columnflow.tasks.histograms.CreateHistograms` task.
 
+The calculation of the final event weight is handles by the {py:class}`~columnflow.weight.WeightProducer` instance you specify at command-line level.
+Consequently, this module needs to be aware of the shift.
+This can be done with the internal `shift` set, see e.g. the analysis example for a weight producer:
 
+```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/weight/example.py
+:dedent:
+:language: python
+:pyobject: example_init
+```
+
+Here, we use the {py:func}`~columnflow.config_util.get_shifts_from_sources` function to extract all shifts for source `mu` from the config inst.
+Whenever a shift that we defined above is requested, the WeightProducer will internally switch to the column defined in the `column_alias` auxiliary information that we defined earlier.
+This way, the workflow is now fully aware of the shift.
+You can test your implementation e.g. by running the {py:class}`columnflow.tasks.plotting.PlotShiftedVariables1D` task.
+For more information, see the [plotting overview](../task_overview/plotting_tasks.md).

--- a/docs/user_guide/shifts.md
+++ b/docs/user_guide/shifts.md
@@ -146,7 +146,7 @@ Next, the aliases for the varied columns are added in accordance with the naming
 Note that as opposed to the previous example, we use the `name` of the shift to construct the final name of the column containing the varied values.
 
 Finally, we need to make the relevant modules aware of the shift.
-As explained above, the jet energy calibration and its variations can have a non-trivial effect on the selection efficiency in the final analysis phase space.
+As explained above, the jet energy calibration and its variations can have a non-trivial effect on the selection acceptance in the final analysis phase space.
 Therefore, the module that defines this phase space needs to consider these variations.
 This is generally done within the {py:class}`~columnflow.tasks.selection.SelectEvents` task, where {py:class}`~columnflow.selection.Selector` instances derive boolean masks based on criteria on for example the four-momenta of the objects.
 In the scope of this example, the jet selection is the relevant module, and we add the shifts accordingly in the selection of the CMS analysis example:

--- a/docs/user_guide/shifts.md
+++ b/docs/user_guide/shifts.md
@@ -175,3 +175,24 @@ Including this type of shifts in the statistical inference model is very similar
 ```
 
 ## Uncertainties with dedicated datasets
+
+The final class of systematic variation that is considered in columnflow concern shifts that require dedicated datasets.
+Such measures can be necessary to account for complicated, untracktable effects, such as a modification of one of the parameters of a Monte Carlo generator early-on in the chain to generate simulated samples.
+In such cases, it is common practice to generate dedicated samples that need to traverse the complete workflow.
+
+Facilitating this situtation requires a certain amount of (columnflow-external) overhead.
+Currently, the metadata database that stores the information about the datasets and processes needs to defined with a {external+order:py:class}`~order.dataset.DatasetInfo` object.
+This object needs to define the nominal as well as the varied datasets in the {external+order:py:attr}`~order.dataset.Dataset.info` attribute.
+For more information, please consider the corresponding section in the [general columnflow structure](./structure.md#analysis-campaign-and-config).
+
+The names as defined in this structure should correspond to the names of the final shifts in the analysis.
+For example, the shift for the `tune` shifts can be defined as shown in the CMS analysis example:
+
+```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+:dedent:
+:language: python
+:start-at: '# tune shifts are covered by dedicated, varied datasets, so tag the shift as "disjoint_from_nominal"'
+:end-before: '# fake jet energy correction shift, with aliases flaged as "selection_dependent", i.e. the aliases'
+```
+
+Since the name of the dataset corresponds to the shift name, this will trigger the entire workflow independently from the nominal dataset and without applying any additional shifts.

--- a/docs/user_guide/shifts.md
+++ b/docs/user_guide/shifts.md
@@ -176,17 +176,17 @@ Including this type of shifts in the statistical inference model is very similar
 
 ## Uncertainties with dedicated datasets
 
-The final class of systematic variation that is considered in columnflow concern shifts that require dedicated datasets.
+The final class of systematic variations that is considered in columnflow concerns shifts that require dedicated datasets.
 Such measures can be necessary to account for complicated, untracktable effects, such as a modification of one of the parameters of a Monte Carlo generator early-on in the chain to generate simulated samples.
 In such cases, it is common practice to generate dedicated samples that need to traverse the complete workflow.
 
 Facilitating this situtation requires a certain amount of (columnflow-external) overhead.
 Currently, the metadata database that stores the information about the datasets and processes needs to defined with a {external+order:py:class}`~order.dataset.DatasetInfo` object.
 This object needs to define the nominal as well as the varied datasets in the {external+order:py:attr}`~order.dataset.Dataset.info` attribute.
-For more information, please consider the corresponding section in the [general columnflow structure](./structure.md#analysis-campaign-and-config).
+For more information, please consider the corresponding section in the [general columnflow structure](./structure.md#analysis-campaign-and-config) section.
 
 The names as defined in this structure should correspond to the names of the final shifts in the analysis.
-For example, the shift for the `tune` shifts can be defined as shown in the CMS analysis example:
+For example, the shift for the `tune` uncertainties can be defined as shown in the CMS analysis example:
 
 ```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
 :dedent:
@@ -196,3 +196,12 @@ For example, the shift for the `tune` shifts can be defined as shown in the CMS 
 ```
 
 Since the name of the dataset corresponds to the shift name, this will trigger the entire workflow independently from the nominal dataset and without applying any additional shifts.
+
+Integrating this uncertainty into a statistical inference model works the same as shown previously:
+
+```{literalinclude} ../../analysis_templates/cms_minimal/__cf_module_name__/inference/example.py
+:dedent:
+:language: python
+:start-at: '# tune uncertainty'
+:end-at: ')'
+```


### PR DESCRIPTION
This PR implements a chapter on systematic uncertainties and how they are implemented in columnflow in the docs.
In particular, the following things are discussed

- Simple rate uncertainties (example: Lumi)
- weight-based shape uncertainties (example: muon scale factors)
- shape uncertainties that impact the selected analysis phase space (example: jet energy corrections)
- shape uncertainties with dedicated datasets (example: tune uncertainty)

Each kind of uncertainty is explained by giving a motivation/use case, and the already existing code examples from the CMS analysis template are used explicitely.

Apart from this, this PR implements some minor changes:

- minor bug fix: the `columnar_utils` module is currently empty in the docs because the `__all__` list is set empty. Fixed by commenting this behavior out for now
- the `WeightProducer` modules are integrated in the api docs
- the jet selection now implements the jec as a shift

To have a look at the updated docs, you can do the following (from your analysis directory)

```bash
# checkout this branch
cd modules/columnflow
git fetch
git checkout origin/docs/systematics
cd ../..
# run your setup
source setup.sh YOUR_SETUP_NAME
# build the docs
./modules/columnflow/tests/run_docs
# host a local server
cd modules/columnflow/docs/_build/html
python3 -m http.server 8088
```

You can then look around in the docs in your browser under the address `http://localhost:8088` 