### PR TITLE
Make input columns for deterministic seeds configurable.

### DIFF
--- a/columnflow/production/cms/seeds.py
+++ b/columnflow/production/cms/seeds.py
@@ -21,6 +21,17 @@ ak = maybe_import("awkward")
 logger = law.logger.get_logger(__name__)
 
 
+def create_seed(val: int, n_hex: int = 16) -> int:
+    """
+    Create a seed from an integer value by hashing it and returning the trailing 64 bit integer.
+    """
+    return int(hashlib.sha256(bytes(str(val), "utf-8")).hexdigest()[:-(n_hex + 1):-1], base=16)
+
+
+# store a vectorized version (only interface, not actually simd'ing)
+create_seed_vec = np.vectorize(create_seed, otypes=[np.uint64])
+
+
 @producer(
     uses={
         # global columns for event seed
@@ -33,7 +44,9 @@ logger = law.logger.get_logger(__name__)
     # columns to be loaded to infer counts of objects
     object_count_columns=list(map(optional, [
         "Jet.nConstituents", "FatJet.pt", "SubJet.pt", "Photon.pt", "Muon.jetIdx",
-        "Electron.jetIdx", "Tau.jetIdx", "SV.pt", "GenJet.pt", "GenPart.pt",
+        "Electron.jetIdx", "Tau.jetIdx", "SV.pt",
+        "GenJet.pt",
+        "GenPart.pt",
     ])),
     # columns of object integer fields (can have overlap to object_count_columns)
     object_columns=list(map(optional, [
@@ -55,7 +68,7 @@ def deterministic_event_seeds(self: Producer, events: ak.Array, **kwargs) -> ak.
         4. reverse it and int-cast the leading 16 characters, leading to a 64 bit int
     """
     # started from an already hashed seed based on event, run and lumi info multiplied with primes
-    seed = self.create_seed(
+    seed = create_seed_vec(
         np.asarray(
             self.primes[7] * ak.values_astype(events.event, np.uint64) +
             self.primes[5] * ak.values_astype(events.run, np.uint64) +
@@ -106,7 +119,7 @@ def deterministic_event_seeds(self: Producer, events: ak.Array, **kwargs) -> ak.
         seed = seed + primes * ak.values_astype(hashed, np.uint64)
 
     # create and store them
-    seed = ak.Array(self.create_seed(np.asarray(seed)))
+    seed = ak.Array(create_seed_vec(np.asarray(seed)))
     events = set_ak_column(events, "deterministic_seed", seed, value_type=np.uint64)
 
     # uniqueness test across the chunk for debugging
@@ -137,15 +150,8 @@ def deterministic_event_seeds_setup(
     reader_targets: InsertableDict,
 ) -> None:
     """
-    Setup function that defines the vectorized seed creation function once and stores it in the
-    py:attr:`create_seed` attribute.
+    Setup function that defines conventions methods needed during the producer function.
     """
-    def create_seed(val: int, n_hex: int = 16) -> int:
-        return int(hashlib.sha256(bytes(str(val), "utf-8")).hexdigest()[:-(n_hex + 1):-1], base=16)
-
-    # store a vectorized version (only interface, not actually simd'ing)
-    self.create_seed = np.vectorize(create_seed, otypes=[np.uint64])
-
     # store primes in array
     self.primes = np.array(primes, dtype=np.uint64)
 
@@ -166,26 +172,22 @@ def deterministic_event_seeds_setup(
 
 
 @producer(
-    uses={deterministic_event_seeds},
     produces={"Jet.deterministic_seed"},
 )
 def deterministic_jet_seeds(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     """
     Produces deterministic seeds for each jet and stores them in *events* which is also returned.
-    The seeds are based on the event seeds produced by :py:func:`deterministic_event_seeds` which is
-    also used to access the py:attr:`create_seed` function. The strategy for producing seeds is
-    identical.
+    The jet seeds are based on the event seeds like the ones produced by
+    :py:func:`deterministic_event_seeds` which is not called by this producer for the purpose of
+    of modularity. The strategy for producing seeds is identical.
     """
-    # create the event seeds
-    events = self[deterministic_event_seeds](events, **kwargs)
-
     # create the per jet seeds
     primes = self.primes[events.deterministic_seed % len(self.primes)]
     jet_seed = events.deterministic_seed + (
         primes * ak.values_astype(ak.local_index(events.Jet, axis=1) + self.primes[50], np.uint64)
     )
     np_jet_seed = np.asarray(ak.flatten(jet_seed))
-    np_jet_seed[:] = self[deterministic_event_seeds].create_seed(np_jet_seed)
+    np_jet_seed[:] = create_seed_vec(np_jet_seed)
 
     # store them
     events = set_ak_column(events, "Jet.deterministic_seed", jet_seed, value_type=np.uint64)

--- a/columnflow/production/cms/seeds.py
+++ b/columnflow/production/cms/seeds.py
@@ -44,9 +44,7 @@ create_seed_vec = np.vectorize(create_seed, otypes=[np.uint64])
     # columns to be loaded to infer counts of objects
     object_count_columns=list(map(optional, [
         "Jet.nConstituents", "FatJet.pt", "SubJet.pt", "Photon.pt", "Muon.jetIdx",
-        "Electron.jetIdx", "Tau.jetIdx", "SV.pt",
-        "GenJet.pt",
-        "GenPart.pt",
+        "Electron.jetIdx", "Tau.jetIdx", "SV.pt", "GenJet.pt", "GenPart.pt",
     ])),
     # columns of object integer fields (can have overlap to object_count_columns)
     object_columns=list(map(optional, [

--- a/columnflow/production/cms/seeds.py
+++ b/columnflow/production/cms/seeds.py
@@ -95,7 +95,6 @@ def deterministic_event_seeds(self: Producer, events: ak.Array, **kwargs) -> ak.
         r = Route(c)
         if (values := self.apply_route(events, r)) is None:
             continue
-        print("add", c)
         values = values + i
         loc = ak.local_index(values) + 1
         hashed = (


### PR DESCRIPTION
As a follow-up to #575, this PR makes the columns used for the deterministic seed determination configurable. The configs distinguish between three types of columns:

- `event_columns`: Columns that lead to existing event-level integer fields.
- `object_count_columns`: Columns to load that allow querying for the number of objects in a collection.
- `object_columns`: Columns that lead to object-level integer fields. Per unique collection (`Jet.`, `Muon.`, ...), one of these columns should be placed in `object_count_columns` instead of any other non-integer column (e.g. `Jet.pt`), in order to save IO.

As before, the default columns are optional to not break existing code.

Also, the code and comments switched between "columns", "fields", and "routes". I removed all occurrences of "field" for consistency.