### PR TITLE
Preserve original parquet file structure after merging.

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -6,10 +6,9 @@ Helpers and utilities for working with columnar libraries.
 
 from __future__ import annotations
 
-# __all__ = []
+__all__ = []
 
 import os
-import gc
 import re
 import math
 import time
@@ -2674,6 +2673,7 @@ class DaskArrayReader(object):
         # backwards compatibility: when row group splitting is enbaled (the default), detect whether
         # the input file was written with support for that; a file does not support splitting in
         # case nested nodes separated by "*.list.element.*" (rather than "*.list.item.*") are found
+        # (to be removed in the future)
         if open_options.get("split_row_groups"):
             nodes = ak.ak_from_parquet.metadata(path)[0]
             cre = re.compile(r"^.+\.list\.element(|\..+)$")
@@ -2699,7 +2699,7 @@ class DaskArrayReader(object):
             # mapping of partition indices to cache information (chunks still to be handled and a
             # cached array) that changes during the read process in _materialize_via_partitions
             self.partition_cache = {
-                p: DotDict(chunks=[], array=None)
+                p: DotDict(chunks=set(), array=None)
                 for p in range(self.dak_array.npartitions)
             }
 
@@ -2720,11 +2720,10 @@ class DaskArrayReader(object):
         return self.dak_array is None
 
     def close(self) -> None:
-        # free memory and perform an eager, overly cautious gc round
+        # free memory
         self.dak_array = None
         if getattr(self, "partition_cache", None):
             self.partition_cache.clear()
-        gc.collect()
 
     def materialize(self, *args, **kwargs) -> ak.Array:
         """
@@ -2802,7 +2801,7 @@ class DaskArrayReader(object):
                         if p_start >= _entry_stop > _entry_start:
                             break
                         partitions.append(p)
-                        self.partition_cache[p].chunks.append(_chunk_index)
+                        self.partition_cache[p].chunks.add(_chunk_index)
                     self.chunk_to_partitions[_chunk_index] = partitions
 
         # read partitions one at a time and store parts that make up the chunk for concatenation
@@ -2810,7 +2809,7 @@ class DaskArrayReader(object):
         for p in self.chunk_to_partitions[chunk_index]:
             # obtain the array
             with self.partition_locks[p]:
-                # remove this chunk for the list of chunks to be handled
+                # remove this chunk from the list of chunks to be handled
                 self.partition_cache[p].chunks.remove(chunk_index)
 
                 if self.partition_cache[p].array is None:
@@ -2833,8 +2832,8 @@ class DaskArrayReader(object):
         # construct the full array
         arr = parts[0] if len(parts) == 1 else ak.concatenate(parts, axis=0)
 
+        # cleanup
         del parts
-        gc.collect()
 
         return arr
 
@@ -3431,7 +3430,6 @@ class ChunkedIOHandler(object):
 
         # reset some attributes
         del self.source_objects[:]
-        gc.collect()
         self.n_entries = None
 
         # open all sources and make sure they have the same number of entries
@@ -3442,7 +3440,11 @@ class ChunkedIOHandler(object):
             self.read_columns_list,
         )):
             # open the source
-            obj, n = source_handler.open(source, open_options=open_options, read_columns=read_columns)
+            obj, n = source_handler.open(
+                source,
+                open_options=open_options,
+                read_columns=(sorted(read_columns) if read_columns else read_columns),
+            )
             # check entries
             if i == 0:
                 self.n_entries = n
@@ -3468,9 +3470,8 @@ class ChunkedIOHandler(object):
         for (obj, source_handler) in zip(self.source_objects, self.source_handlers):
             source_handler.close(obj)
 
-        # just delete the file cache and reset some attributes
+        # delete the file cache
         del self.source_objects[:]
-        gc.collect()
 
     def queue(self, *args, **kwargs) -> None:
         """
@@ -3489,7 +3490,12 @@ class ChunkedIOHandler(object):
 
         # create a list of read functions
         read_funcs = [
-            partial(source_handler.read, obj, read_options=read_options, read_columns=read_columns)
+            partial(
+                source_handler.read,
+                obj,
+                read_options=read_options,
+                read_columns=(sorted(read_columns) if read_columns else read_columns),
+            )
             for obj, source_handler, read_options, read_columns in zip(
                 self.source_objects,
                 self.source_handlers,
@@ -3536,17 +3542,15 @@ class ChunkedIOHandler(object):
                 # find the first done result and remove it from the list
                 # this will do nothing in the first iteration
                 result_obj = no_result
-                for i, result in enumerate(list(results)):
-                    if not result.ready():
-                        continue
-
-                    result_obj = result.get()
-                    results.pop(i)
-                    break
+                for i, result in enumerate(results):
+                    if result.ready():
+                        result_obj = result.get()
+                        results.pop(i)
+                        break
 
                 # if no result was ready, sleep and try again
                 if results and result_obj == no_result:
-                    time.sleep(0.05)
+                    time.sleep(0.02)
                     continue
 
                 # immediately try to fill up the pool
@@ -3560,21 +3564,24 @@ class ChunkedIOHandler(object):
                         print(self.iter_message.format(pos=result_obj.chunk_pos))
 
                     # probably overly-cautious, but run garbage collection before and after
-                    gc.collect()
                     t1 = time.perf_counter()
                     try:
                         yield (result_obj.chunk, result_obj.chunk_pos)
                     finally:
                         duration = time.perf_counter() - t1
                         logger_perf.debug(
-                            f"processing of chunk {result_obj.chunk_pos.index} took " +
-                            law.util.human_duration(seconds=duration),
+                            f"processing of chunk {result_obj.chunk_pos.index} took "
+                            f"{law.util.human_duration(seconds=duration)}",
                         )
-                    gc.collect()
-        finally:
+                del result_obj
+            self.pool.close()
+        except:
             self.pool.terminate()
+            raise
+        finally:
             self.pool.join()
             self.pool = None
+            del results
 
     def __del__(self):
         """

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2676,7 +2676,8 @@ class DaskArrayReader(object):
         # case nested nodes separated by "*.list.element.*" (rather than "*.list.item.*") are found
         if open_options.get("split_row_groups"):
             nodes = ak.ak_from_parquet.metadata(path)[0]
-            if any(".list.element." in node for node in nodes):
+            cre = re.compile(r"^.+\.list\.element(|\..+)$")
+            if any(map(cre.match, nodes)):
                 logger.warning(
                     f"while reading input parquet file from {path}, 'split_row_groups' is enabled "
                     "but the file does not support it; it was probably created with an older "

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -2671,17 +2671,7 @@ class DaskArrayReader(object):
 
         # open the file
         open_options = open_options or {}
-        open_options["split_row_groups"] = False
         self.dak_array = dak.from_parquet(path, **open_options)
-        if materialization_strategy == self.MaterializationStrategy.SLICES:
-            # NOTE: by calling the `persist` method, the dask array is directly materialized in memory
-            # to prevent that the dask array is materialized multiple times. This prevents us from
-            # loading data in a chunked manner, which is not ideal for large datasets, but at the
-            # moment we do not have a better solution.
-            # This fix should be removed once we find a solution to only materialize the data
-            # from the sliced array that is actually needed.
-            self.dak_array = self.dak_array.persist()
-
         self.path = path
 
         # strategy dependent attributes and setup
@@ -3353,6 +3343,7 @@ class ChunkedIOHandler(object):
 
         # default open options
         open_options = open_options or {}
+        open_options.setdefault("split_row_groups", True)  # preserve input file partitions
 
         # inject read_columns
         if read_columns and "columns" not in open_options:

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -112,7 +112,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
                 f"for dataset {self.dataset_inst.name} ({self.dataset_info_inst.n_files})",
             )
 
-        self.logger.info(f"found {len(lfns)} lfn(s) for dataset {self.dataset}")
+        self.logger.info(f"found {len(lfns):_} lfn(s) for dataset {self.dataset}")
 
         tmp = law.LocalFileTarget(is_tmp=True)
         tmp.dump(lfns, indent=4, formatter="json")
@@ -241,7 +241,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
                 input_stat = input_file.exists(stat=True)
                 duration = time.perf_counter() - t1
                 i += 1
-                logger.info(f"file {lfn} does{'' if input_stat else ' not'} exist at fs {selected_fs}")
+                logger.info(f"lfn {lfn} does{'' if input_stat else ' not'} exist at fs {selected_fs}")
 
                 # when the stat query took longer than some duration, eagerly try the next fs
                 # and check if it responds faster and if so, take it instead
@@ -272,7 +272,7 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
                     )
                     break
             else:
-                raise Exception(f"LFN {lfn} not found at any remote fs {fs}")
+                raise Exception(f"lfn {lfn} not found at any remote fs {fs}")
 
             # log the file size
             input_size = law.util.human_bytes(input_stat.st_size, fmt=True)

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -927,6 +927,11 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             "compression": "ZSTD",
             "compression_level": 1,
             "use_dictionary": dict_encoding,
+            # ensure that after merging, the resulting parquet structure is the same as that of the
+            # input files, e.g. do not switch from "*.list.item.*" to "*.list.element*." structures,
+            # see https://github.com/scikit-hep/awkward/issues/3331 and
+            # https://github.com/apache/arrow/issues/31731
+            "use_compliant_nested_type": False,
         }
 
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -6,7 +6,6 @@ Lightweight mixins task classes.
 
 from __future__ import annotations
 
-import gc
 import time
 import itertools
 from collections import Counter
@@ -2412,7 +2411,7 @@ class ChunkedIOMixin(AnalysisTask):
         # iterate in the handler context
         with handler:
             self.chunked_io = handler
-            msg = f"iterate through {handler.n_entries} events in {handler.n_chunks} chunks ..."
+            msg = f"iterate through {handler.n_entries:_} events in {handler.n_chunks} chunks ..."
             try:
                 # measure runtimes excluding IO
                 loop_durations = []
@@ -2434,9 +2433,8 @@ class ChunkedIOMixin(AnalysisTask):
             finally:
                 self.chunked_io = None
 
-        # eager, overly cautious gc
+        # eager cleanup
         del handler
-        gc.collect()
 
 
 class HistHookMixin(ConfigTask):

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -232,7 +232,7 @@ class ReduceEvents(
 
         # some logs
         self.publish_message(
-            f"reduced {n_all} to {n_reduced} events ({safe_div(n_reduced, n_all) * 100:.2f}%)",
+            f"reduced {n_all:_} to {n_reduced:_} events ({safe_div(n_reduced, n_all) * 100:.2f}%)",
         )
 
         # merge output files

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -228,7 +228,7 @@ class ReduceEvents(
                 # save as parquet via a thread in the same pool
                 chunk = tmp_dir.child(f"file_{lfn_index}_{pos.index}.parquet", type="f")
                 output_chunks[pos.index] = chunk
-                self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
+                self.chunked_io.queue(sorted_ak_to_parquet, (ak.to_packed(events), chunk.abspath))
 
         # some logs
         self.publish_message(


### PR DESCRIPTION
This PR updates the merging of parquet files after chunked processing.

Our processing happens in three steps.

1. Chunks of events are loaded and processed by *task array functions*.
2. The resulting *new* columns are saved in parquet files via `ak.to_parquet`. **Here, we rely on awkward to pass specific settings to the underlying parquet writer**.
3. After all chunks are processed, we merge these parquet files. **This merging is happening without awkward, using a bare `pyarrow.parquet.ParquetWriter` instance**. However, for full consistency with the format expected by awkward and dask_awkward when reading these files again in a downstream task, a setting `use_compliant_nested_type=False` was missing. This setting makes sure that the internal node / tree structure is consistent w.r.t. the input files and not changed as described [here](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow-parquet-parquetwriter).

Memory is stable now over multiple processes. I removed previous workarounds.

@mafrahm Would you mind running your previous tests to confirm this fix?

Fixes #583.