### PR TITLE
Consistent units for htcondor_memory and htcondor_disk

### DIFF
--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -568,9 +568,9 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
     )
     htcondor_memory = law.BytesParameter(
         default=law.NO_FLOAT,
-        unit="MB",
+        unit="GB",
         significant=False,
-        description="requested memory in MB; empty value leads to the cluster default setting; "
+        description="requested memory in GB; empty value leads to the cluster default setting; "
         "empty default",
     )
     htcondor_disk = law.BytesParameter(
@@ -707,13 +707,11 @@ class HTCondorWorkflow(AnalysisTask, law.htcondor.HTCondorWorkflow, RemoteWorkfl
 
         # request memory
         if self.htcondor_memory is not None and self.htcondor_memory > 0:
-            config.custom_content.append(("Request_Memory", self.htcondor_memory))
+            config.custom_content.append(("Request_Memory", f"{self.htcondor_memory} Gb"))
 
         # request disk space
         if self.htcondor_disk is not None and self.htcondor_disk > 0:
-            # TODO: the exact conversion might be flavor dependent in the future, use kB for npw
-            # e.g. https://confluence.desy.de/pages/viewpage.action?pageId=128354529
-            config.custom_content.append(("RequestDisk", self.htcondor_disk * 1024**2))
+            config.custom_content.append(("RequestDisk", f"{self.htcondor_disk} Gb"))
 
         # render variables
         config.render_variables["cf_bootstrap_name"] = "htcondor_standalone"


### PR DESCRIPTION
This is a small PR that makes the units of the `htcondor_memory` and `htcondor_disk` settings consistent. They were MB and GB before, and now are both GB.

I also dropped the implicit conversion in the job file, since htcondor supports providing explicit units.