### PR TITLE
Various smaller CMS run 3 changes

### DIFF
--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -70,6 +70,8 @@ class BTagSFConfig:
     uses={"Jet.{pt,eta,hadronFlavour}"},
     # only run on mc
     mc_only=True,
+    # configurable weight name
+    weight_name="btag_weight",
     # function to determine the correction file
     get_btag_file=(lambda self, external_files: external_files.btag_sf_corr),
     # function to determine the btag sf config
@@ -119,7 +121,7 @@ def btag_weights(
 
         - "ignore": the *jet_mask* is extended to exclude jets with b_score < 0
         - "remove": the scale factor is set to 0 for jets with b_score < 0, resulting in an overall
-            btag_weight of 0 for the event
+            btag weight of 0 for the event
         - "raise": an exception is raised
 
     The verbosity of the handling of jets with negative b-score can be
@@ -167,11 +169,11 @@ def btag_weights(
         if negative_b_score_action == "ignore":
             msg_func(
                 f"{msg} The *jet_mask* will be adjusted to exclude these jets, resulting in a "
-                "*btag_weight* of 1 for these jets.",
+                "btag weight of 1 for these jets.",
             )
         elif negative_b_score_action == "remove":
             msg_func(
-                f"{msg} The *btag_weight* will be set to 0 for these jets.",
+                f"{msg} The btag weight will be set to 0 for these jets.",
             )
         elif negative_b_score_action == "raise":
             raise Exception(msg)
@@ -239,21 +241,21 @@ def btag_weights(
     shift_inst = self.global_shift_inst
     if shift_inst.is_nominal:
         # nominal weight and those of all method intrinsic uncertainties
-        events = add_weight("central", None, "btag_weight")
+        events = add_weight("central", None, self.weight_name)
         for syst_name, col_name in self.btag_uncs.items():
             for direction in ["up", "down"]:
                 name = col_name.format(year=self.config_inst.campaign.x.year)
                 events = add_weight(
                     syst_name,
                     direction,
-                    f"btag_weight_{name}_{direction}",
+                    f"{self.weight_name}_{name}_{direction}",
                 )
                 if syst_name in ["cferr1", "cferr2"]:
                     # for c flavor uncertainties, multiply the uncertainty with the nominal btag weight
                     events = set_ak_column(
                         events,
-                        f"btag_weight_{name}_{direction}",
-                        events.btag_weight * events[f"btag_weight_{name}_{direction}"],
+                        f"{self.weight_name}_{name}_{direction}",
+                        events[self.weight_name] * events[f"{self.weight_name}_{name}_{direction}"],
                         value_type=np.float32,
                     )
     elif self.shift_is_known_jec_source:
@@ -261,11 +263,11 @@ def btag_weights(
         events = add_weight(
             f"jes{'' if self.jec_source == 'Total' else self.jec_source}",
             shift_inst.direction,
-            f"btag_weight_jec_{self.jec_source}_{shift_inst.direction}",
+            f"{self.weight_name}_jec_{self.jec_source}_{shift_inst.direction}",
         )
     else:
         # any other shift, just produce the nominal weight
-        events = add_weight("central", None, "btag_weight")
+        events = add_weight("central", None, self.weight_name)
 
     return events
 
@@ -307,18 +309,18 @@ def btag_weights_init(self: Producer) -> None:
     # add uncertainty sources of the method itself
     if shift_inst.is_nominal:
         # nominal column
-        self.produces.add("btag_weight")
+        self.produces.add(self.weight_name)
         # all varied columns
         for col_name in self.btag_uncs.values():
             name = col_name.format(year=self.config_inst.campaign.x.year)
             for direction in ["up", "down"]:
-                self.produces.add(f"btag_weight_{name}_{direction}")
+                self.produces.add(f"{self.weight_name}_{name}_{direction}")
     elif self.shift_is_known_jec_source:
         # jec varied column
-        self.produces.add(f"btag_weight_jec_{self.jec_source}_{shift_inst.direction}")
+        self.produces.add(f"{self.weight_name}_jec_{self.jec_source}_{shift_inst.direction}")
     else:
         # only the nominal column
-        self.produces.add("btag_weight")
+        self.produces.add(self.weight_name)
 
 
 @btag_weights.requires

--- a/columnflow/production/cms/electron.py
+++ b/columnflow/production/cms/electron.py
@@ -168,8 +168,7 @@ def electron_weights_setup(
 
 @electron_weights.init
 def electron_weights_init(self: Producer, **kwargs) -> None:
-    weight_name = self.weight_name
-    self.produces |= {weight_name, f"{weight_name}_up", f"{weight_name}_down"}
+    self.produces.add(f"{self.weight_name}{{,_up,_down}}")
 
 
 # custom electron weight that runs trigger SFs

--- a/columnflow/production/cms/electron.py
+++ b/columnflow/production/cms/electron.py
@@ -46,7 +46,7 @@ class ElectronSFConfig:
 
 
 @producer(
-    uses={"Electron.{pt,eta,deltaEtaSC}"},
+    uses={"Electron.{pt,eta,phi,deltaEtaSC}"},
     # produces in the init
     # only run on mc
     mc_only=True,
@@ -55,7 +55,7 @@ class ElectronSFConfig:
     # function to determine the electron weight config
     get_electron_config=(lambda self: ElectronSFConfig.new(self.config_inst.x.electron_sf_names)),
     weight_name="electron_weight",
-    supported_versions=(1, 2),
+    supported_versions=(1, 2, 3),
 )
 def electron_weights(
     self: Producer,
@@ -99,13 +99,15 @@ def electron_weights(
         events.Electron.deltaEtaSC[electron_mask]
     ), axis=1)
     pt = flat_np_view(events.Electron.pt[electron_mask], axis=1)
+    phi = flat_np_view(events.Electron.phi[electron_mask], axis=1)
 
     variable_map = {
         "year": self.electron_config.campaign,
         "WorkingPoint": self.electron_config.working_point,
         "Path": self.electron_config.hlt_path,
-        "eta": sc_eta,
         "pt": pt,
+        "eta": sc_eta,
+        "phi": phi,
     }
 
     # loop over systematics

--- a/columnflow/production/cms/electron.py
+++ b/columnflow/production/cms/electron.py
@@ -136,6 +136,12 @@ def electron_weights(
     return events
 
 
+@electron_weights.init
+def electron_weights_init(self: Producer, **kwargs) -> None:
+    # add the product of nominal and up/down variations to produced columns
+    self.produces.add(f"{self.weight_name}{{,_up,_down}}")
+
+
 @electron_weights.requires
 def electron_weights_requires(self: Producer, reqs: dict) -> None:
     if "external_files" in reqs:
@@ -166,11 +172,6 @@ def electron_weights_setup(
     # check versions
     if self.supported_versions and self.electron_sf_corrector.version not in self.supported_versions:
         raise Exception(f"unsupported electron sf corrector version {self.electron_sf_corrector.version}")
-
-
-@electron_weights.init
-def electron_weights_init(self: Producer, **kwargs) -> None:
-    self.produces.add(f"{self.weight_name}{{,_up,_down}}")
 
 
 # custom electron weight that runs trigger SFs

--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -122,6 +122,12 @@ def muon_weights(
     return events
 
 
+@muon_weights.init
+def muon_weights_init(self: Producer, **kwargs) -> None:
+    # add the product of nominal and up/down variations to produced columns
+    self.produces.add(f"{self.weight_name}{{,_up,_down}}")
+
+
 @muon_weights.requires
 def muon_weights_requires(self: Producer, reqs: dict) -> None:
     if "external_files" in reqs:
@@ -152,11 +158,6 @@ def muon_weights_setup(
     # check versions
     if self.supported_versions and self.muon_sf_corrector.version not in self.supported_versions:
         raise Exception(f"unsupported muon sf corrector version {self.muon_sf_corrector.version}")
-
-
-@muon_weights.init
-def muon_weights_init(self: Producer, **kwargs) -> None:
-    self.produces.add(f"{self.weight_name}{{,_up,_down}}")
 
 
 # custom muon weight that runs trigger SFs

--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -156,8 +156,7 @@ def muon_weights_setup(
 
 @muon_weights.init
 def muon_weights_init(self: Producer, **kwargs) -> None:
-    weight_name = self.weight_name
-    self.produces |= {weight_name, f"{weight_name}_up", f"{weight_name}_down"}
+    self.produces.add(f"{self.weight_name}{{,_up,_down}}")
 
 
 # custom muon weight that runs trigger SFs


### PR DESCRIPTION
This PR adds a couple smaller updates to adapt to changes in correctionlib files for run 3 (e.g. new electron SFs, jet veto map, etc.)

In particular, this PR:

- Adds a mechanism to the central jet veto map selector to account for additional veto map queries as required by the [CMS 2023BPix recipe](https://cms-jerc.web.cern.ch/Recommendations/#jet-veto-maps). For 2023BPix, the veto maps should be `&`'ed with the negation of a second map. This was rather straight forward, using the same corrector.
- Generalize `btag_weights` to configure a custom weight name
- Add jet phi to variables for JEC.
- Add electron phi to variables for SFs.
- Smaller "compactifications" of used/produced columns.