### PR TITLE
Control workflow resources via law.cfg

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -54,8 +54,10 @@ default_selection_hists_optional: True
 skip_ensure_proxy: False
 
 # some remote workflow parameter defaults
+# (resources like memory and disk can also be set in [resources] with more granularity)
 htcondor_flavor: $CF_HTCONDOR_FLAVOR
 htcondor_share_software: False
+htcondor_memory: -1
 htcondor_disk: -1
 slurm_flavor: $CF_SLURM_FLAVOR
 slurm_partition: $CF_SLURM_PARTITION
@@ -119,6 +121,19 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 # example:
 ; run3_2023__cf.CalibrateEvents__nomin*: prod1
 ; cf.CalibrateEvents: prod2
+
+
+[resources]
+
+# default sources of remote workflows
+# keys can have the same format as described above in [versions] to pinpoint specific tasks
+# values should be comma-separated strings in the form "RESOURCE=VALUE", where RESOURCE should refer
+# to a valid task parameter (e.g. max_runtime, htcondor_memory, etc.) so that VALUE can be parsed
+# by the respective parameter instance at runtime
+# same as for [versions], the order of options is important as it defines the resolution order
+# example:
+; run3_2023__cf.CalibrateEvents__nomin*: htcondor_memory=5GB
+; run3_2023__cf.CalibrateEvents: htcondor_memory=2GB
 
 
 [job]

--- a/columnflow/tasks/cms/base.py
+++ b/columnflow/tasks/cms/base.py
@@ -17,7 +17,7 @@ from columnflow.tasks.framework.remote import (
 from columnflow.util import expand_path
 
 
-class CrabWorkflow(AnalysisTask, law.cms.CrabWorkflow, RemoteWorkflowMixin):
+class CrabWorkflow(RemoteWorkflowMixin, law.cms.CrabWorkflow):
 
     # example for a parameter whose value is propagated to the crab job configuration
     crab_memory = law.BytesParameter(

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -24,6 +24,8 @@ from columnflow.util import is_regex, DotDict
 from columnflow.types import Sequence, Callable, Any, T
 
 
+logger = law.logger.get_logger(__name__)
+
 # default analysis and config related objects
 default_analysis = law.config.get_expanded("analysis", "default_analysis")
 default_config = law.config.get_expanded("analysis", "default_config")
@@ -97,6 +99,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
     # cached and parsed sections of the law config for faster lookup
     _cfg_outputs_dict = None
     _cfg_versions_dict = None
+    _cfg_resources_dict = None
 
     @classmethod
     def modify_param_values(cls, params: dict) -> dict:
@@ -218,6 +221,36 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             cls._cfg_versions_dict = cls._structure_cfg_items(items)
 
         return cls._cfg_versions_dict
+
+    @classmethod
+    def _get_cfg_resources_dict(cls):
+        if cls._cfg_resources_dict is None and law.config.has_section("resources"):
+            # helper to split resource values into key-value pairs themselves
+            def parse(key: str, value: str) -> tuple[str, list[tuple[str, Any]]]:
+                params = []
+                for part in value.split(","):
+                    part = part.strip()
+                    if not part:
+                        continue
+                    if "=" not in part:
+                        logger.warning_once(
+                            f"invalid_resource_{key}",
+                            f"resource for key {key} contains invalid instruction {part}, skipping",
+                        )
+                        continue
+                    param, value = (s.strip() for s in part.split("=", 1))
+                    params.append((param, value))
+                return key, params
+
+            # collect config item pairs
+            items = [
+                parse(key, value)
+                for key, value in law.config.items("resources")
+                if value
+            ]
+            cls._cfg_resources_dict = cls._structure_cfg_items(items)
+
+        return cls._cfg_resources_dict
 
     @classmethod
     def get_default_version(cls, inst: AnalysisTask, params: dict[str, Any]) -> str | None:

--- a/law.cfg
+++ b/law.cfg
@@ -50,8 +50,10 @@ default_selection_hists_optional: True
 skip_ensure_proxy: False
 
 # some remote workflow parameter defaults
+# (resources like memory and disk can also be set in [resources] with more granularity)
 htcondor_flavor: $CF_HTCONDOR_FLAVOR
 htcondor_share_software: False
+htcondor_memory: -1
 htcondor_disk: -1
 slurm_flavor: $CF_SLURM_FLAVOR
 slurm_partition: $CF_SLURM_PARTITION
@@ -119,6 +121,19 @@ lfn_sources: wlcg_fs_desy_store, wlcg_fs_infn_redirector, wlcg_fs_global_redirec
 # example:
 ; run3_2023__cf.CalibrateEvents__nomin*: prod1
 ; cf.CalibrateEvents: prod2
+
+
+[resources]
+
+# default sources of remote workflows
+# keys can have the same format as described above in [versions] to pinpoint specific tasks
+# values should be comma-separated strings in the form "RESOURCE=VALUE", where RESOURCE should refer
+# to a valid task parameter (e.g. max_runtime, htcondor_memory, etc.) so that VALUE can be parsed
+# by the respective parameter instance at runtime
+# same as for [versions], the order of options is important as it defines the resolution order
+# example:
+; run3_2023__cf.CalibrateEvents__nomin*: htcondor_memory=5GB
+; run3_2023__cf.CalibrateEvents: htcondor_memory=2GB
 
 
 [job]


### PR DESCRIPTION
This PR adds a feature to remote workflows that allows them to read resource values from the law.cfg file.

Example section in law.cfg:

```ini
[resources]
run3_2023__cf.CalibrateEvents: htcondor_memory=5GB, htcondor_disk=20GB
f.CalibrateEvents: htcondor_memory=2GB
```

The **keys** are interpreted identically to those in `[outputs] and [versions]`, that we use to pinpoint task output locations and default versions. Thus, the order of options matters as the resolution is performed in that order and stops once a match is found.

**Values** can be comma-separated values, with each one corresponding to parameter=value pairs. Parameters must be names of actual parameters, and their values are parsed using the underlying parameter instances.

In the scenario above, `cf.CalibrateEvents` tasks running with a config named `run3_2023` have increased htcondor memory on disk resources, while for all other configs, only a specific, lower memory constraint is in place.

As for versions, the value is only accepted by the task if no other value was specified by the user (e.g. via `CalibrateEvents.req(self, htcondor_memory=...)` in requirements or `--htcondor-memory ...` on the cli).