### PR TITLE
fix missing shift bins in plotting task

### DIFF
--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -190,7 +190,7 @@ class PlotVariablesBase(
                         }]
                         h = h[{"process": sum}]
 
-                        # create expexted shift bins and fill them with the nominal histogram
+                        # create expected shift bins and fill them with the nominal histogram
                         expected_shifts = set(plot_shifts) & process_shift_map[process_inst.name]
                         add_missing_shifts(h, expected_shifts, str_axis="shift", nominal_bin="nominal")
 


### PR DESCRIPTION
This PR implements handling of missing shift bins in different configs/datasets corresponding to one process.
We can review+merge this directly into #566 and continue the review of the main branch, or we merge #566 first and create a separate PR afterwards.

The logic is as follows:
- per process, all shifts that are defined in one of the datasets corresponding to this processes are gathered via upstream task dependencies
- if a shift is requested for a process and part of the plot_shifts, but the shift is missing for a dataset corresponding to this process, we fill the missing shift bins with the content of the nominal bin