### PR TITLE
Store all pdf weights in pdf_weights producer

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1149,6 +1149,35 @@ def full_like(layout_array: ak.Array, value: Any, *, dtype: Any = None, **kwargs
     return ak.without_parameters(ak.full_like(layout_array, value, dtype=dtype, **kwargs))
 
 
+def fill_at(
+    ak_array: ak.Array,
+    where: ak.Array,
+    route: Route | str,
+    value: float | int,
+    *,
+    value_type: type | str | None = None,
+) -> ak.Array:
+    """
+    Fills a column identified through *route* in an *ak_array* with a *value* where a
+    corresponding *where* mask is *True*.
+
+    :param ak_array: The input array.
+    :param where: The boolean mask where to fill the value.
+    :param route: The route describing the column to fill.
+    :param value: The value to fill.
+    :param value_type: The data type of the value. Inferred from value if not set.
+    :return: A new array with the value filled at the specified route.
+    """
+    # cast to route
+    route = Route(route)
+
+    # create new values with selective values
+    new_values = ak.where(where, value, route.apply(ak_array))
+
+    # insert back
+    return set_ak_column(ak_array, route, new_values, value_type=value_type)
+
+
 def attach_behavior(
     ak_array: ak.Array,
     type_name: str,

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -4,13 +4,15 @@
 Column production methods related to the PDF weights.
 """
 
+from __future__ import annotations
+
 import functools
 
 import law
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
-from columnflow.columnar_util import set_ak_column, full_like
+from columnflow.columnar_util import set_ak_column, full_like, fill_at
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -18,8 +20,9 @@ ak = maybe_import("awkward")
 
 logger = law.logger.get_logger(__name__)
 
-# helper
+# helpers
 set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
+fill_at_f32 = functools.partial(fill_at, value_type=np.float32)
 
 
 @producer(
@@ -33,6 +36,7 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 def pdf_weights(
     self: Producer,
     events: ak.Array,
+    invalid_weights_action: str = "raise",
     outlier_threshold: float = 0.5,
     outlier_action: str = "ignore",
     outlier_log_mode: str = "warning",
@@ -47,6 +51,13 @@ def pdf_weights(
     For the per-event evaluation, the producer assumes that the nominal entry is always the first
     LHEPdfWeight value and that the nominal weight is already included in the LHEWeight.
     It can only be called with MC datasets.
+
+    The *invalid_weights_action* defines the procedure of how to handle events with a an unexpected
+    number of pdf weights (not 101 or 103). Supported modes are:
+
+        - ``"raise"``: an exception is raised
+        - ``"ignore"``: nominal weight is set to one, up/down weights too if not storing all weights
+            and an empty vector for all weights otherwise
 
     The *outlier_action* defines the procedure of how to handle events with a pdf
     uncertainty above the *outlier_threshold*. Supported modes are:
@@ -67,29 +78,28 @@ def pdf_weights(
 
         - https://arxiv.org/pdf/1510.03865.pdf
     """
-    known_actions = ("ignore", "remove", "raise")
-    if outlier_action not in known_actions:
-        raise ValueError(
-            f"unknown outlier_action '{outlier_action}', "
-            f"known values are {','.join(known_actions)}",
-        )
-    known_log_modes = ("none", "info", "debug", "warning")
-    if outlier_log_mode not in known_log_modes:
-        raise ValueError(
-            f"unknown outlier_log_mode '{outlier_log_mode}', "
-            f"known values are {','.join(known_log_modes)}",
-        )
+    _raise_unknown_action("invalid_weights_action", invalid_weights_action, ("ignore", "raise"))
+    _raise_unknown_action("outlier_action", outlier_action, ("ignore", "remove", "raise"))
+    _raise_unknown_action("outlier_log_mode", outlier_log_mode, ("none", "info", "debug", "warning"))
 
     # check for the correct amount of weights
     n_weights = ak.num(events.LHEPdfWeight, axis=1)
-    bad_mask = (n_weights != 101) & (n_weights != 103)
-    ones = np.ones(len(events), dtype=np.float32)
+    invalid_mask = (n_weights != 101) & (n_weights != 103)
+
+    # handle invalid number of weights when configured to raise
+    if invalid_weights_action == "raise" and ak.any(invalid_mask):
+        bad_values = ",".join(map(str, set(n_weights[invalid_mask])))
+        raise ValueError(
+            f"the number of LHEPdfWeights is expected to be 101 or 103, but also found values "
+            f"'{bad_values}' in dataset {self.dataset_inst.name}",
+        )
 
     # write ones in case there are no weights at all
-    if ak.all(bad_mask):
-        logger.warning("no valid 'LHEPdfWeight' found, saving ones for weights")
+    ones = np.ones(len(events), dtype=np.float32)
+    empty = full_like(events.LHEPdfWeight[:, :0], 0)
+    if ak.all(invalid_mask):
+        logger.warning("no 'LHEPdfWeight' vector with correct length found, setting weights to 1")
         if self.store_all_weights:
-            empty = full_like(events.LHEPdfWeight[:, :0], 0)
             events = set_ak_column_f32(events, "pdf_weights", empty)
             events = set_ak_column_f32(events, "pdf_weight", ones)
         else:
@@ -99,9 +109,9 @@ def pdf_weights(
         return events
 
     # complain when the number of weights is unexpected
-    if ak.any(bad_mask):
-        bad_values = ",".join(map(str, set(n_weights[bad_mask])))
-        frac = ak.sum(bad_mask) / len(events) * 100
+    if ak.any(invalid_mask):
+        bad_values = ",".join(map(str, set(n_weights[invalid_mask])))
+        frac = ak.sum(invalid_mask) / len(events) * 100
         logger.warning(
             "the number of LHEPdfWeights is expected to be 101 or 103, but also found values "
             f"'{bad_values}' in dataset {self.dataset_inst.name}, will set pdf weights to 1 for "
@@ -109,7 +119,7 @@ def pdf_weights(
         )
 
     # log a message if nominal != 1
-    pdf_weight_nominal = events.LHEPdfWeight[~bad_mask, 0]
+    pdf_weight_nominal = ak.where(invalid_mask, ones, events.LHEPdfWeight[:, 0])
     if ak.any(pdf_weight_nominal != 1):
         bad_values = ",".join(map(str, set(pdf_weight_nominal[pdf_weight_nominal != 1])))
         logger.debug(
@@ -121,7 +131,8 @@ def pdf_weights(
 
     # normalize all 100 weights by the nominal one, assumed to be the first value
     # (for datasets with 103 weights, the last two weights are related to alpha_s variations)
-    pdf_weights = ak.without_parameters(events.LHEPdfWeight[~bad_mask, 1:101]) / pdf_weight_nominal
+    pdf_weights = ak.where(invalid_mask, empty, ak.without_parameters(events.LHEPdfWeight[:, 1:101]))
+    pdf_weights = pdf_weights / pdf_weight_nominal
 
     # store the nominal weight which is always 1 after normalization
     events = set_ak_column_f32(events, "pdf_weight", ones)
@@ -134,8 +145,9 @@ def pdf_weights(
 
     # PDF uncertainty as half the width of the central 68% CL
     pdf_weights = ak.sort(pdf_weights, axis=1)
-    stddev = np.zeros(len(events), dtype=np.float32)
-    stddev[~bad_mask] = (pdf_weights[:, 83] - pdf_weights[:, 15]) / 2
+    stddev = (pdf_weights[:, 83:84] - pdf_weights[:, 15:16]) / 2
+    stddev = ak.fill_none(ak.pad_none(stddev, 1, axis=1, clip=True), 0)[:, 0]
+    stddev = ak.values_astype(ak.where(invalid_mask, 0, stddev), np.float32)
 
     # store columns
     events = set_ak_column_f32(events, "pdf_weight_up", 1 + stddev)
@@ -153,11 +165,11 @@ def pdf_weights(
 
         if outlier_action == "remove":
             # set all pdf weights to 0 when the *outlier_threshold* is passed
-            events = set_ak_column_f32(events, "pdf_weight", ak.where(outlier_mask, 0, events.pdf_weight))
-            events = set_ak_column_f32(events, "pdf_weight_up", ak.where(outlier_mask, 0, events.pdf_weight_up))
-            events = set_ak_column_f32(events, "pdf_weight_down", ak.where(outlier_mask, 0, events.pdf_weight_down))
-
+            events = fill_at_f32(events, outlier_mask, "pdf_weight", 0)
+            events = fill_at_f32(events, outlier_mask, "pdf_weight_up", 0)
+            events = fill_at_f32(events, outlier_mask, "pdf_weight_down", 0)
             msg += "; the nominal/up/down pdf_weight columns have been set to 0 for these events"
+
         elif outlier_action == "raise":
             raise Exception(msg)
 
@@ -178,9 +190,9 @@ def pdf_weights(
             "LHEPdfWeights with values 0 have been found; the nominal/up/down pdf_weight "
             "columns have been set to 0 for these events",
         )
-        events = set_ak_column_f32(events, "pdf_weight", ak.where(invalid_pdf_weight, 0, events.pdf_weight))
-        events = set_ak_column_f32(events, "pdf_weight_up", ak.where(invalid_pdf_weight, 0, events.pdf_weight_up))
-        events = set_ak_column_f32(events, "pdf_weight_down", ak.where(invalid_pdf_weight, 0, events.pdf_weight_down))
+        events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_up", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_down", 0)
 
     return events
 
@@ -189,3 +201,8 @@ def pdf_weights(
 def pdf_weight_init(self: Producer) -> None:
     # add produced columns: nominal+all, or nominal+up+down
     self.produces.add("pdf_weight{,s}" if self.store_all_weights else "pdf_weight{,_up,_down}")
+
+
+def _raise_unknown_action(attr: str, action: str, known_actions: tuple[str]) -> None:
+    if action not in known_actions:
+        raise ValueError(f"unknown {attr} '{action}', known values are {','.join(known_actions)}")


### PR DESCRIPTION
This PR updates our CMS-related PDF weight producer with an option that allows it to store all (usually 100) weights per event.

Difference to the original `LHEPdfWeight`:

- Only the first 100 weights are stored, not 102 (which are usually alpha_s variations)
- The weights are stored normalized w.r.t. the nominal weight.

---

I also fixed a small bug in the determination of the combined variations (using only the first 100, instead of 102 weights), and updated the outlier log.