### PR TITLE
Prefer true / false over 1 / 0 in shell scripts.

### DIFF
--- a/analysis_templates/cms_minimal/setup.sh
+++ b/analysis_templates/cms_minimal/setup.sh
@@ -27,13 +27,26 @@ setup___cf_short_name_lc__() {
     #   __cf_short_name_uc___SETUP
     #       A flag that is set to 1 after the setup was successful.
 
+    #
+    # load cf setup helpers
+    #
+
+    local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
+    local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
+    local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
+    local cf_base="${this_dir}/modules/columnflow"
+    CF_SKIP_SETUP="true" source "${cf_base}/setup.sh" "" || return "$?"
+
+    #
     # prevent repeated setups
-    if [ "${__cf_short_name_uc___SETUP}" = "1" ]; then
+    #
+
+    cf_export_bool __cf_short_name_uc___SETUP
+    if ${__cf_short_name_uc___SETUP} && ! ${CF_ON_SLURM}; then
         >&2 echo "the __cf_analysis_name__ analysis was already succesfully setup"
         >&2 echo "re-running the setup requires a new shell"
         return "1"
     fi
-
 
     #
     # prepare local variables
@@ -43,7 +56,6 @@ setup___cf_short_name_lc__() {
     local this_file="$( ${shell_is_zsh} && echo "${(%):-%x}" || echo "${BASH_SOURCE[0]}" )"
     local this_dir="$( cd "$( dirname "${this_file}" )" && pwd )"
     local orig="${PWD}"
-    local env_is_remote="$( [ "${CF_REMOTE_ENV}" = "1" ] && echo "true" || echo "false" )"
     local setup_name="${1:-default}"
     local setup_is_default="false"
     [ "${setup_name}" = "default" ] && setup_is_default="true"
@@ -54,7 +66,6 @@ setup___cf_short_name_lc__() {
         setopt globdots
     fi
 
-
     #
     # global variables
     # (__cf_short_name_uc__ = __cf_analysis_name__, CF = columnflow)
@@ -62,16 +73,13 @@ setup___cf_short_name_lc__() {
 
     # start exporting variables
     export __cf_short_name_uc___BASE="${this_dir}"
-    export CF_BASE="${this_dir}/modules/columnflow"
+    export CF_BASE="${cf_base}"
     export CF_REPO_BASE="${__cf_short_name_uc___BASE}"
     export CF_REPO_BASE_ALIAS="__cf_short_name_uc___BASE"
     export CF_SETUP_NAME="${setup_name}"
 
-    # load cf setup helpers
-    CF_SKIP_SETUP="1" source "${CF_BASE}/setup.sh" "" || return "$?"
-
     # interactive setup
-    if ! ${env_is_remote}; then
+    if ! ${CF_REMOTE_ENV}; then
         cf_setup_interactive_body() {
             # pre-export the CF_FLAVOR which will be cms
             export CF_FLAVOR="cms"
@@ -89,7 +97,6 @@ setup___cf_short_name_lc__() {
     export CF_CONDA_BASE="${CF_CONDA_BASE:-${CF_SOFTWARE_BASE}/conda}"
     export CF_VENV_BASE="${CF_VENV_BASE:-${CF_SOFTWARE_BASE}/venvs}"
     export CF_CMSSW_BASE="${CF_CMSSW_BASE:-${CF_SOFTWARE_BASE}/cmssw}"
-
 
     #
     # common variables
@@ -116,15 +123,13 @@ setup___cf_short_name_lc__() {
         done
     fi
 
-
     #
     # git hooks
     #
 
-    if ! ${env_is_remote}; then
+    if ! ${CF_REMOTE_ENV}; then
         cf_setup_git_hooks || return "$?"
     fi
-
 
     #
     # law setup
@@ -133,7 +138,7 @@ setup___cf_short_name_lc__() {
     export LAW_HOME="${LAW_HOME:-${__cf_short_name_uc___BASE}/.law}"
     export LAW_CONFIG_FILE="${LAW_CONFIG_FILE:-${__cf_short_name_uc___BASE}/law.cfg}"
 
-    if ! ${env_is_remote} && which law &> /dev/null; then
+    if ! ${CF_REMOTE_ENV} && which law &> /dev/null; then
         # source law's bash completion scipt
         source "$( law completion )" ""
 
@@ -145,7 +150,7 @@ setup___cf_short_name_lc__() {
     fi
 
     # finalize
-    export __cf_short_name_uc___SETUP="1"
+    export __cf_short_name_uc___SETUP="true"
 }
 
 main() {
@@ -163,6 +168,6 @@ main() {
 }
 
 # entry point
-if [ "${__cf_short_name_uc___SKIP_SETUP}" != "1" ]; then
+if [ "${__cf_short_name_uc___SKIP_SETUP}" != "true" ]; then
     main "$@"
 fi

--- a/columnflow/__init__.py
+++ b/columnflow/__init__.py
@@ -24,28 +24,28 @@ m = re.match(r"^(\d+)\.(\d+)\.(\d+)(-.+)?$", __version__)
 version = tuple(map(int, m.groups()[:3])) + (m.group(4),)
 
 #: Boolean denoting whether the environment is in a local environment (based on ``CF_LOCAL_ENV``).
-env_is_local = law.util.flag_to_bool(os.getenv("CF_LOCAL_ENV", "0"))
+env_is_local = law.util.flag_to_bool(os.getenv("CF_LOCAL_ENV", "false"))
 
 #: Boolean denoting whether the environment is in a remote job (based on ``CF_REMOTE_ENV``).
-env_is_remote = law.util.flag_to_bool(os.getenv("CF_REMOTE_ENV", "0"))
+env_is_remote = law.util.flag_to_bool(os.getenv("CF_REMOTE_ENV", "false"))
 
 #: Boolean denoting whether the environment is in a remote job on the WLCG (based on ``CF_ON_GRID``).
-env_is_grid = law.util.flag_to_bool(os.getenv("CF_ON_GRID", "0"))
+env_is_grid = law.util.flag_to_bool(os.getenv("CF_ON_GRID", "false"))
 
 #: Boolean denoting whether the environment is in a remote job on a HTCondor cluster (based on ``CF_ON_HTCONDOR``).
-env_is_htcondor = law.util.flag_to_bool(os.getenv("CF_ON_HTCONDOR", "0"))
+env_is_htcondor = law.util.flag_to_bool(os.getenv("CF_ON_HTCONDOR", "false"))
 
 #: Boolean denoting whether the environment is in a remote job on a Slurm cluster (based on ``CF_ON_SLURM``).
-env_is_slurm = law.util.flag_to_bool(os.getenv("CF_ON_SLURM", "0"))
+env_is_slurm = law.util.flag_to_bool(os.getenv("CF_ON_SLURM", "false"))
 
 #: Boolean denoting whether the environment is in a CI env (based on ``CF_CI_ENV``).
-env_is_ci = law.util.flag_to_bool(os.getenv("CF_CI_ENV", "0"))
+env_is_ci = law.util.flag_to_bool(os.getenv("CF_CI_ENV", "false"))
 
 #: Boolean denoting whether the environment is in a readthedocs env (based on ``CF_RTD_ENV``, or ``READTHEDOCS``).
-env_is_rtd = law.util.flag_to_bool(os.getenv("CF_RTD_ENV" if "CF_RTD" in os.environ else "READTHEDOCS", "0"))
+env_is_rtd = law.util.flag_to_bool(os.getenv("CF_RTD_ENV" if "CF_RTD" in os.environ else "READTHEDOCS", "false"))
 
 #: Boolean denoting whether the environment is used for development (based on ``CF_DEV``).
-env_is_dev = not env_is_remote and law.util.flag_to_bool(os.getenv("CF_DEV", "0"))
+env_is_dev = not env_is_remote and law.util.flag_to_bool(os.getenv("CF_DEV", "false"))
 
 #: String refering to the "flavor" of the cf setup.
 flavor = os.getenv("CF_FLAVOR")

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -7,8 +7,8 @@
 # Bootstrap function for standalone htcondor jobs.
 bootstrap_htcondor_standalone() {
     # set env variables
-    export CF_REMOTE_ENV="1"
-    export CF_ON_HTCONDOR="1"
+    export CF_REMOTE_ENV="true"
+    export CF_ON_HTCONDOR="true"
     export CF_HTCONDOR_FLAVOR="{{cf_htcondor_flavor}}"
     export CF_CERN_USER="{{cf_cern_user}}"
     export CF_CERN_USER_FIRSTCHAR="${CF_CERN_USER:0:1}"
@@ -129,8 +129,8 @@ bootstrap_htcondor_standalone() {
 # Bootstrap function for slurm jobs.
 bootstrap_slurm() {
     # set env variables
-    export CF_REMOTE_ENV="1"
-    export CF_ON_SLURM="1"
+    export CF_REMOTE_ENV="true"
+    export CF_ON_SLURM="true"
     export CF_SLURM_FLAVOR="{{cf_slurm_flavor}}"
     export CF_REPO_BASE="{{cf_repo_base}}"
     export CF_WLCG_CACHE_ROOT="${LAW_JOB_HOME}/cf_wlcg_cache"

--- a/sandboxes/_setup_cmssw.sh
+++ b/sandboxes/_setup_cmssw.sh
@@ -2,7 +2,7 @@
 
 # Script that installs, removes and / or sources a CMSSW environment. Distinctions are made
 # depending on whether the installation is already present, and whether the script is called as part
-# of a remote (law) job (CF_REMOTE_ENV=1).
+# of a remote (law) job (CF_REMOTE_ENV=true).
 #
 # In case a function or executable named "cf_cmssw_custom_install" is defined, it is invoked inside
 # the src directory of the CMSSW checkout after a first "scram build" pass and followed by a second
@@ -39,9 +39,10 @@
 #      is defined, its value is used instead.
 #
 # Note on remote jobs:
-# When the CF_REMOTE_ENV variable is found to be "1" (usually set by a remote job bootstrap script),
-# no mode is supported and no installation will happen but the desired CMSSW setup is reused from a
-# pre-compiled CMSSW bundle that is fetched from a local or remote location and unpacked.
+# When the CF_REMOTE_ENV variable is set (usually set by a remote job bootstrap script) and
+# true-ish, no mode is supported and no installation will happen but the desired CMSSW setup is
+# reused from a pre-compiled CMSSW bundle that is fetched from a local or remote location and
+# unpacked.
 
 setup_cmssw() {
     local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
@@ -56,7 +57,7 @@ setup_cmssw() {
     fi
 
     # source the main setup script to access helpers
-    CF_SKIP_SETUP="1" source "${this_dir}/../setup.sh" "" || return "$?"
+    CF_SKIP_SETUP="true" source "${this_dir}/../setup.sh" "" || return "$?"
 
 
     #
@@ -72,7 +73,7 @@ setup_cmssw() {
     fi
 
     # force install mode for remote jobs
-    [ "${CF_REMOTE_ENV}" = "1" ] && mode="install"
+    ${CF_REMOTE_ENV} && mode="install"
 
     # value checks
     if [ "${mode}" != "install" ] && [ "${mode}" != "clear" ] && [ "${mode}" != "reinstall" ] && [ "${mode}" != "update" ]; then
@@ -134,7 +135,7 @@ setup_cmssw() {
     # ensure CF_CMSSW_BASE exists
     mkdir -p "${CF_CMSSW_BASE}"
 
-    if [ "${CF_REMOTE_ENV}" != "1" ]; then
+    if ! ${CF_REMOTE_ENV}; then
         # optionally remove the current installation
         if [ "${mode}" = "clear" ] || [ "${mode}" = "reinstall" ]; then
             echo "removing current installation at ${install_path} (mode '${mode}')"
@@ -255,7 +256,7 @@ setup_cmssw() {
     fi
 
     # handle remote job environments
-    if [ "${CF_REMOTE_ENV}" = "1" ]; then
+    if ${CF_REMOTE_ENV}; then
         # fetch, unpack and setup the bundle
         if [ ! -d "${install_path}" ]; then
             if [ -z "${CF_WLCG_TOOLS}" ] || [ ! -f "${CF_WLCG_TOOLS}" ]; then

--- a/sandboxes/_setup_venv.sh
+++ b/sandboxes/_setup_venv.sh
@@ -2,7 +2,7 @@
 
 # Script that installs and sources a virtual environment. Distinctions are made depending on whether
 # the venv is already present, and whether the script is called as part of a remote (law) job
-# (CF_REMOTE_ENV=1).
+# (CF_REMOTE_ENV=true).
 #
 # Four environment variables are expected to be set before this script is called:
 #   CF_SANDBOX_FILE
@@ -41,10 +41,10 @@
 #      but the exit code remains unchanged.
 #
 # Note on remote jobs:
-# When the CF_REMOTE_ENV variable is found to be "1" (usually set by a remote job bootstrap script),
-# no mode is supported and an error is printed when it is set to a non-empty value. In any case, no
-# installation will happen but the setup is reused from a pre-compiled software bundle that is
-# fetched from a local or remote location and unpacked.
+# When the CF_REMOTE_ENV variable is set (usually set by a remote job bootstrap script) and
+# true-ish, no mode is supported and an error is printed when it is set to a non-empty value. In any
+# case, no installation will happen but the setup is reused from a pre-compiled software bundle that
+# is fetched from a local or remote location and unpacked.
 
 setup_venv() {
     local shell_is_zsh="$( [ -z "${ZSH_VERSION}" ] && echo "false" || echo "true" )"
@@ -59,7 +59,7 @@ setup_venv() {
     fi
 
     # source the main setup script to access helpers
-    CF_SKIP_SETUP="1" source "${this_dir}/../setup.sh" "" || return "$?"
+    CF_SKIP_SETUP="true" source "${this_dir}/../setup.sh" "" || return "$?"
 
 
     #
@@ -83,7 +83,7 @@ setup_venv() {
         >&2 echo "unknown venv setup mode '${mode}'"
         return "1"
     fi
-    if [ "${CF_REMOTE_ENV}" = "1" ] && [ "${mode}" != "install" ]; then
+    if ${CF_REMOTE_ENV} && [ "${mode}" != "install" ]; then
         >&2 echo "the venv setup mode must be 'install' or empty in remote jobs, but got '${mode}'"
         return "2"
     fi
@@ -169,7 +169,7 @@ setup_venv() {
     local ret="0"
 
     # handle local environments
-    if [ "${CF_REMOTE_ENV}" != "1" ]; then
+    if ! ${CF_REMOTE_ENV}; then
         # optionally remove the current installation
         if [ "${mode}" = "reinstall" ]; then
             echo "removing current installation at ${install_path_repr} (mode '${mode}')"
@@ -301,7 +301,7 @@ setup_venv() {
     fi
 
     # handle remote job environments
-    if [ "${CF_REMOTE_ENV}" = "1" ]; then
+    if ${CF_REMOTE_ENV}; then
         # in this case, the environment is inside a remote job, i.e., these variables are present:
         # CF_JOB_BASH_SANDBOX_URIS, CF_JOB_BASH_SANDBOX_PATTERNS and CF_JOB_BASH_SANDBOX_NAMES
         if [ ! -f "${CF_SANDBOX_FLAG_FILE}" ]; then
@@ -350,7 +350,7 @@ setup_venv() {
     export CF_VENV_NAME="${CF_VENV_NAME}"
     export CF_VENV_HASH="${install_hash}"
     export CF_VENV_NAME_HASHED="${venv_name_hashed}"
-    export CF_DEV="$( [[ "${CF_VENV_NAME}" == *_dev ]] && echo "1" || echo "0" )"
+    export CF_DEV="$( [[ "${CF_VENV_NAME}" == *_dev ]] && echo "true" || echo "false" )"
 
     # mark this as a bash sandbox for law
     export LAW_SANDBOX="bash::$( cf_sandbox_file_hash -p "${sandbox_file}" )"


### PR DESCRIPTION
This PR affects only setup scripts. So far, we *sometimes* used integers 0 and 1 for flags that should actually be stored as real booleans. This lead to ambiguities in cases where an actual boolean value was expected, e.g. when using a variable in the law.cfg for an option that expects "true" or "false" and that cannot interpret "1".

This PR changes that in a backwards compatible way. All flags that are expected throughout cf are converted at the earliest instance possible.

Things not only become consistent but also far more readable and expressive.