### PR TITLE
include omitted branch in MergeReducedEvents

### DIFF
--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -464,7 +464,7 @@ class MergeReducedEvents(
             "events": self.reqs.ReduceEvents.req_different_branching(
                 self,
                 workflow="local",
-                branches=((min(self.branch_data), max(self.branch_data)),),
+                branches=((min(self.branch_data), max(self.branch_data) + 1),),
                 _exclude={"branch"},
             ),
         }


### PR DESCRIPTION
 I just tested the changes from this PR and saw that the cf.MergeReducedEvents only merges N-1 files per branch when I have a merge_factor N, meaning that some files will be omitted during the merging. I also checked with one dataset where all files are supposed to be merged into one and the selected events from the last branch are missing. This was not the case before updating to this PR.

With this minor fix, all branches are (hopefully) considered again. I also checked that merging of previously produced `ProduceColumns` with newly produced results from `MergeReducedEvents` is possible