### PR TITLE
Make attach_coffea_behavior functional.

### DIFF
--- a/columnflow/production/util.py
+++ b/columnflow/production/util.py
@@ -9,54 +9,9 @@ from __future__ import annotations
 from columnflow.types import Sequence, Union
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
-from columnflow.columnar_util import set_ak_column, attach_behavior
+from columnflow.columnar_util import attach_coffea_behavior as attach_coffea_behavior_fn
 
 ak = maybe_import("awkward")
-
-
-#: Information on behavior of certain collections to (re-)attach it via attach_coffea_behavior.
-default_collections = {
-    "Jet": {
-        "type_name": "Jet",
-        "check_attr": "metric_table",
-        "skip_fields": "*Idx*G",
-    },
-    "FatJet": {
-        "type_name": "FatJet",
-        "check_attr": "metric_table",
-        "skip_fields": "*Idx*G",
-    },
-    "SubJet": {
-        "type_name": "Jet",
-        "check_attr": "metric_table",
-        "skip_fields": "*Idx*G",
-    },
-    "Muon": {
-        "type_name": "Muon",
-        "check_attr": "metric_table",
-        "skip_fields": "*Idx*G",
-    },
-    "Electron": {
-        "type_name": "Electron",
-        "check_attr": "metric_table",
-        "skip_fields": "*Idx*G",
-    },
-    "Tau": {
-        "type_name": "Tau",
-        "check_attr": "metric_table",
-        "skip_fields": "*Idx*G",
-    },
-    # NOTE: disabled at the moment since the MissingET in coffea handles columns such as
-    #       "MET.pt_jer/jec_up/down" as systematics itself and attaching this behavior creates
-    #       multiple MET objects per event (that still, for some reason, are identical); it would
-    #       be nice if one could entirely disable this coffea feature as we are treating systematics
-    #       on our own
-    # "MET": {
-    #     "type_name": "MissingET",
-    #     "check_attr": "metric_table",
-    #     "skip_fields": "*Idx*G",
-    # },
-}
 
 
 @producer(call_force=True)
@@ -72,49 +27,15 @@ def attach_coffea_behavior(
     This might become relevant in case some of the collections have been invalidated in a potential
     previous step. All information on source collection names, :external+coffea:doc:`index` type
     names, attributes to check whether the correct behavior is already attached, and fields to
-    potentially skip is taken from :py:obj:`default_collections`.
+    potentially skip is taken from :py:obj:`columnar_util.default_coffea_collections`.
 
     However, this information is updated by *collections* when it is a dict. In case it is a list,
-    its items are interpreted as names of collections defined as keys in
-    :py:obj:`default_collections` for which the behavior should be attached.
+    its items are interpreted as names of collections defined as keys in the default collections for
+    which the behavior should be attached.
 
     :param events: Array containing the events
-    :param collections: Attach behavior for these collections. If :py:class:`dict`, the
-        :py:obj:`default_collections` are updated with the information in *collections*. If
-        :py:class:`list`, only update this set of *collections* as specified in the
-        :py:obj:`default_collections`.
+    :param collections: Attach behavior for these collections. Defaults to
+        :py:obj:`columnar_util.default_coffea_collections`.
     :return: Array with correct behavior attached for collections
     """
-    # update or reduce collection info
-    _collections = default_collections
-    if isinstance(collections, dict):
-        _collections = _collections.copy()
-        _collections.update(collections)
-    elif isinstance(collections, (list, tuple)):
-        _collections = {
-            name: info
-            for name, info in _collections.items()
-            if name in collections
-        }
-
-    for name, info in _collections.items():
-        if not info:
-            continue
-
-        # get the collection to update
-        if name not in events.fields:
-            continue
-        coll = events[name]
-
-        # when a check_attr is defined, do nothing in case it already exists
-        if info.get("check_attr") and getattr(coll, info["check_attr"], None) is not None:
-            continue
-
-        # default infos
-        type_name = info.get("type_name") or name
-        skip_fields = info.get("skip_fields")
-
-        # apply the behavior
-        events = set_ak_column(events, name, attach_behavior(coll, type_name, skip_fields=skip_fields))
-
-    return events
+    return attach_coffea_behavior_fn(events, collections=collections)

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -120,6 +120,7 @@ class CreateHistograms(
         from columnflow.columnar_util import (
             Route, update_ak_array, add_ak_aliases, has_ak_column, fill_hist,
         )
+        from columnflow.columnar_util import attach_coffea_behavior
 
         # prepare inputs
         inputs = self.input()
@@ -197,6 +198,9 @@ class CreateHistograms(
                     remove_src=True,
                     missing_strategy=self.missing_column_alias_strategy,
                 )
+
+                # attach coffea behavior aiding functional variable expressions
+                events = attach_coffea_behavior(events)
 
                 # build the full event weight
                 if hasattr(self.weight_producer_inst, "skip_func") and not self.weight_producer_inst.skip_func():


### PR DESCRIPTION
This PR adds three changes:

- Separate functional part of the `attach_coffea_behavior` into a function in our columnar utils. This way, it can be called as a producer (as before) and also in different contexts.
- Enables the MET and PuppiMET behaviors again, as the reason why it was disabled is obsolete.
- Calls `attach_coffea_behavior` right before histogramming so that functional variable expressions can make use of it.