### PR TITLE
fix padding when there are no genjets in a chunk

### DIFF
--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -820,7 +820,7 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     max_gen_jet_idx = ak.max(valid_gen_jet_idxs)
     padded_gen_jets = ak.pad_none(
         events[gen_jet_name],
-        max_gen_jet_idx + 1 if max_gen_jet_idx is not None else 0,
+        0 if max_gen_jet_idx is None else (max_gen_jet_idx + 1),
     )
 
     # gen jets that match the reconstructed jets

--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -817,7 +817,11 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     valid_gen_jet_idxs = ak.mask(gen_jet_idx, gen_jet_idx >= 0)
 
     # pad list of gen jets to prevent index error on match lookup
-    padded_gen_jets = ak.pad_none(events[gen_jet_name], ak.max(valid_gen_jet_idxs) + 1)
+    max_gen_jet_idx = ak.max(valid_gen_jet_idxs)
+    padded_gen_jets = ak.pad_none(
+        events[gen_jet_name],
+        max_gen_jet_idx + 1 if max_gen_jet_idx is not None else 0,
+    )
 
     # gen jets that match the reconstructed jets
     matched_gen_jets = padded_gen_jets[valid_gen_jet_idxs]


### PR DESCRIPTION
In rare cases, when calibrating FatJets, there are chunks where not a single genJet is present. In these cases, we get `ak.max(valid_gen_jet_idxs) = None`, which lead to errors in the previous implementation. With this fix, we pad our gen jets to length 0 when this happens. 

I checked that this minor fix does not modify existing results in any form using `cf_diff`.