### PR TITLE
Flip stack plot order.

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -6,9 +6,15 @@ Example plot function.
 
 from __future__ import annotations
 
+__all__ = []
+
 from columnflow.types import Sequence
 from columnflow.util import maybe_import, try_float
-from columnflow.plotting.plot_util import get_position, get_cms_label
+from columnflow.plotting.plot_util import (
+    get_position,
+    get_cms_label,
+    remove_label_placeholders,
+)
 
 hist = maybe_import("hist")
 np = maybe_import("numpy")
@@ -175,6 +181,7 @@ def plot_all(
     "ratio_kwargs": dict (optional),
 
     The *style_config* expects fields (all optional):
+    "gridspec_cfg": dict,
     "ax_cfg": dict,
     "rax_cfg": dict,
     "legend_cfg": dict,
@@ -192,37 +199,43 @@ def plot_all(
         with a logarithmic scale.
     :return: tuple of plot figure and axes
     """
-    # available plot methods mapped to their names
+    # general mplhep style
+    plt.style.use(mplhep.style.CMS)
+
+    # setup figure and axes
+    rax = None
+    grid_spec = {"left": 0.15, "right": 0.95, "top": 0.95, "bottom": 0.1}
+    grid_spec |= style_config.get("gridspec_cfg", {})
+    if not skip_ratio:
+        grid_spec |= {"height_ratios": [3, 1], "hspace": 0}
+        fig, axs = plt.subplots(2, 1, gridspec_kw=grid_spec, sharex=True)
+        (ax, rax) = axs
+    else:
+        fig, ax = plt.subplots(gridspec_kw=grid_spec)
+        axs = (ax,)
+
+    # invoke all plots methods
     plot_methods = {
         func.__name__: func
         for func in [draw_error_bands, draw_stack, draw_hist, draw_profile, draw_errorbars]
     }
-
-    plt.style.use(mplhep.style.CMS)
-
-    rax = None
-    if not skip_ratio:
-        fig, axs = plt.subplots(2, 1, gridspec_kw=dict(height_ratios=[3, 1], hspace=0), sharex=True)
-        (ax, rax) = axs
-    else:
-        fig, ax = plt.subplots()
-        axs = (ax,)
-
     for key, cfg in plot_config.items():
+        # check if required fields are present
         if "method" not in cfg:
             raise ValueError(f"no method given in plot_cfg entry {key}")
-        method = cfg["method"]
-
         if "hist" not in cfg:
             raise ValueError(f"no histogram(s) given in plot_cfg entry {key}")
-        hist = cfg["hist"]
-        kwargs = cfg.get("kwargs", {})
-        plot_methods[method](ax, hist, **kwargs)
 
+        # invoke the method
+        method = cfg["method"]
+        h = cfg["hist"]
+        plot_methods[method](ax, h, **cfg.get("kwargs", {}))
+
+        # repeat for ratio axes if configured
         if not skip_ratio and "ratio_kwargs" in cfg:
             # take ratio_method if the ratio plot requires a different plotting method
             method = cfg.get("ratio_method", method)
-            plot_methods[method](rax, hist, **cfg["ratio_kwargs"])
+            plot_methods[method](rax, h, **cfg.get("ratio_kwargs", {}))
 
     # axis styling
     ax_kwargs = {
@@ -241,17 +254,26 @@ def plot_all(
     # prioritize style_config ax settings
     ax_kwargs.update(style_config.get("ax_cfg", {}))
 
-    # ax configs that can not be handled by `ax.set`
-    minorxticks = ax_kwargs.pop("minorxticks", None)
-    minoryticks = ax_kwargs.pop("minoryticks", None)
+    # some settings cannot be handled by ax.set
+    xminorticks = ax_kwargs.pop("xminorticks", ax_kwargs.pop("minorxticks", None))
+    yminorticks = ax_kwargs.pop("yminorticks", ax_kwargs.pop("minoryticks", None))
+    xloc = ax_kwargs.pop("xloc", None)
+    yloc = ax_kwargs.pop("yloc", None)
 
+    # set all values
     ax.set(**ax_kwargs)
 
-    if minorxticks is not None:
-        ax.set_xticks(minorxticks, minor=True)
-    if minoryticks is not None:
-        ax.set_xticks(minoryticks, minor=True)
+    # set manual configs
+    if xminorticks is not None:
+        ax.set_xticks(xminorticks, minor=True)
+    if yminorticks is not None:
+        ax.set_xticks(yminorticks, minor=True)
+    if xloc is not None:
+        ax.set_xlabel(ax.get_xlabel(), loc=xloc)
+    if yloc is not None:
+        ax.set_ylabel(ax.get_ylabel(), loc=yloc)
 
+    # ratio plot
     if not skip_ratio:
         # hard-coded line at 1
         rax.axhline(y=1.0, linestyle="dashed", color="gray")
@@ -262,11 +284,25 @@ def plot_all(
             "yscale": "linear",
         }
         rax_kwargs.update(style_config.get("rax_cfg", {}))
+
+        # some settings cannot be handled by ax.set
+        xloc = rax_kwargs.pop("xloc", None)
+        yloc = rax_kwargs.pop("yloc", None)
+
+        # set all values
         rax.set(**rax_kwargs)
 
+        # set manual configs
+        if xloc is not None:
+            rax.set_xlabel(rax.get_xlabel(), loc=xloc)
+        if yloc is not None:
+            rax.set_ylabel(rax.get_ylabel(), loc=yloc)
+
+        # remove x-label from main axis
         if "xlabel" in rax_kwargs:
             ax.set_xlabel("")
 
+    # label alignment
     fig.align_labels()
 
     # legend
@@ -277,6 +313,9 @@ def plot_all(
             "loc": "upper right",
         }
         legend_kwargs.update(style_config.get("legend_cfg", {}))
+
+        if "title" in legend_kwargs:
+            legend_kwargs["title"] = remove_label_placeholders(legend_kwargs["title"])
 
         # retrieve the legend handles and their labels
         handles, labels = ax.get_legend_handles_labels()
@@ -304,21 +343,22 @@ def plot_all(
         if callable(update_handles_labels):
             update_handles_labels(ax, handles, labels, n_cols)
 
-        # assume all `StepPatch` objects are part of MC stack
-        in_stack = [
-            isinstance(handle, mpl.patches.StepPatch)
-            for handle in handles
-        ]
+        if kwargs.get("flip_stack", False):
+            # assume all `StepPatch` objects are part of MC stack
+            in_stack = [
+                isinstance(handle, mpl.patches.StepPatch)
+                for handle in handles
+            ]
 
-        # reverse order of entries that are part of the stack
-        if any(in_stack):
-            def revere_entries(entries, mask):
-                entries = np.array(entries, dtype=object)
-                entries[mask] = entries[mask][::-1]
-                return list(entries)
+            # reverse order of entries that are part of the stack
+            if any(in_stack):
+                def revere_entries(entries, mask):
+                    entries = np.array(entries, dtype=object)
+                    entries[mask] = entries[mask][::-1]
+                    return list(entries)
 
-            handles = revere_entries(handles, in_stack)
-            labels = revere_entries(labels, in_stack)
+                handles = revere_entries(handles, in_stack)
+                labels = revere_entries(labels, in_stack)
 
         # make legend using ordered handles/labels
         ax.legend(handles, labels, **legend_kwargs)
@@ -347,6 +387,7 @@ def plot_all(
         cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
         mplhep.cms.label(**cms_label_kwargs)
 
+    # finalization
     fig.tight_layout()
 
     return fig, axs

--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -343,23 +343,6 @@ def plot_all(
         if callable(update_handles_labels):
             update_handles_labels(ax, handles, labels, n_cols)
 
-        if kwargs.get("flip_stack", False):
-            # assume all `StepPatch` objects are part of MC stack
-            in_stack = [
-                isinstance(handle, mpl.patches.StepPatch)
-                for handle in handles
-            ]
-
-            # reverse order of entries that are part of the stack
-            if any(in_stack):
-                def revere_entries(entries, mask):
-                    entries = np.array(entries, dtype=object)
-                    entries[mask] = entries[mask][::-1]
-                    return list(entries)
-
-                handles = revere_entries(handles, in_stack)
-                labels = revere_entries(labels, in_stack)
-
         # make legend using ordered handles/labels
         ax.legend(handles, labels, **legend_kwargs)
 

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -6,6 +6,8 @@ Example plot functions for one-dimensional plots.
 
 from __future__ import annotations
 
+__all__ = []
+
 from collections import OrderedDict
 
 import law
@@ -14,7 +16,7 @@ from columnflow.types import Iterable
 from columnflow.util import maybe_import
 from columnflow.plotting.plot_all import plot_all
 from columnflow.plotting.plot_util import (
-    prepare_plot_config,
+    prepare_stack_plot_config,
     prepare_style_config,
     remove_residual_axis,
     apply_variable_settings,
@@ -44,13 +46,12 @@ def plot_variable_per_process(
     density: bool | None = False,
     shape_norm: bool | None = False,
     yscale: str | None = "",
-    hide_errors: bool | None = None,
     process_settings: dict | None = None,
     variable_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
     """
-    TODO.
+    TODO: misleading function name, it should somehow contain "stack" and not "per_proceess"
     """
     remove_residual_axis(hists, "shift")
 
@@ -63,11 +64,7 @@ def plot_variable_per_process(
     hists = apply_process_settings(hists, process_settings)
     hists = apply_density_to_hists(hists, density)
 
-    plot_config = prepare_plot_config(
-        hists,
-        shape_norm=shape_norm,
-        hide_errors=hide_errors,
-    )
+    plot_config = prepare_stack_plot_config(hists, shape_norm=shape_norm, **kwargs)
 
     default_style_config = prepare_style_config(
         config_inst, category_inst, variable_inst, density, shape_norm, yscale,
@@ -236,7 +233,6 @@ def plot_cutflow(
     density: bool | None = False,
     shape_norm: bool = False,
     yscale: str | None = None,
-    hide_errors: bool | None = None,
     process_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
@@ -250,11 +246,7 @@ def plot_cutflow(
     hists = hists_merge_cutflow_steps(hists)
 
     # setup plotting config
-    plot_config = prepare_plot_config(
-        hists,
-        shape_norm=shape_norm,
-        hide_errors=hide_errors,
-    )
+    plot_config = prepare_stack_plot_config(hists, shape_norm=shape_norm, **kwargs)
 
     if shape_norm:
         # switch normalization to normalizing to `initial step` bin

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -477,7 +477,6 @@ def prepare_stack_plot_config(
     hists: OrderedDict,
     shape_norm: bool | None = False,
     hide_errors: bool | None = None,
-    flip_stack: bool = False,
     **kwargs,
 ) -> OrderedDict:
     """
@@ -512,13 +511,6 @@ def prepare_stack_plot_config(
                 mc_colors.append(process_inst.color1)
                 mc_edgecolors.append(process_inst.color2)
                 mc_labels.append(process_inst.label)
-
-    # flip lists that constitute the mc stack
-    if mc_hists and flip_stack:
-        mc_hists = mc_hists[::-1]
-        mc_colors = mc_colors[::-1]
-        mc_edgecolors = mc_edgecolors[::-1]
-        mc_labels = mc_labels[::-1]
 
     h_data, h_mc, h_mc_stack = None, None, None
     if data_hists:

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -6,6 +6,8 @@ Some utils for plot functions.
 
 from __future__ import annotations
 
+__all__ = []
+
 import re
 import operator
 import functools
@@ -266,9 +268,13 @@ def apply_process_settings(
             )
 
         # remove remaining placeholders
-        proc_inst.label = re.sub("__[A-Z0-9]+__", "", proc_inst.label)
+        proc_inst.label = remove_label_placeholders(proc_inst.label)
 
     return hists
+
+
+def remove_label_placeholders(label: str) -> str:
+    return re.sub("__[A-Z0-9]+__", "", label)
 
 
 def apply_variable_settings(
@@ -467,17 +473,18 @@ def prepare_style_config(
     return style_config
 
 
-def prepare_plot_config(
+def prepare_stack_plot_config(
     hists: OrderedDict,
     shape_norm: bool | None = False,
     hide_errors: bool | None = None,
+    flip_stack: bool = False,
+    **kwargs,
 ) -> OrderedDict:
     """
     Prepares a plot config with one entry to create plots containing a stack of
     backgrounds with uncertainty bands, unstacked processes as lines and
     data entrys with errorbars.
     """
-
     # separate histograms into stack, lines and data hists
     mc_hists, mc_colors, mc_edgecolors, mc_labels = [], [], [], []
     line_hists, line_colors, line_labels, line_hide_errors = [], [], [], []
@@ -506,14 +513,19 @@ def prepare_plot_config(
                 mc_edgecolors.append(process_inst.color2)
                 mc_labels.append(process_inst.label)
 
+    # flip lists that constitute the mc stack
+    if mc_hists and flip_stack:
+        mc_hists = mc_hists[::-1]
+        mc_colors = mc_colors[::-1]
+        mc_edgecolors = mc_edgecolors[::-1]
+        mc_labels = mc_labels[::-1]
+
     h_data, h_mc, h_mc_stack = None, None, None
     if data_hists:
         h_data = sum(data_hists[1:], data_hists[0].copy())
     if mc_hists:
         h_mc = sum(mc_hists[1:], mc_hists[0].copy())
-        # reverse hists when building MC stack so that the
-        # first process is on top
-        h_mc_stack = hist.Stack(*mc_hists[::-1])
+        h_mc_stack = hist.Stack(*mc_hists)
 
     # setup plotting configs
     plot_config = OrderedDict()
@@ -526,10 +538,10 @@ def prepare_plot_config(
             "hist": h_mc_stack,
             "kwargs": {
                 "norm": mc_norm,
-                "label": mc_labels[::-1],
-                "color": mc_colors[::-1],
-                "edgecolor": mc_edgecolors[::-1],
-                "linewidth": [(0 if c is None else 1) for c in mc_colors[::-1]],
+                "label": mc_labels,
+                "color": mc_colors,
+                "edgecolor": mc_edgecolors,
+                "linewidth": [(0 if c is None else 1) for c in mc_colors],
             },
         }
 


### PR DESCRIPTION
This PR adjust the order of processes in stack plots.

As per recommendation, the process that is lowest in the legend should also be lowest in the stack plot. This was not the case yet but comes with this PR. To revert to the old behavior, there is a `flip_stack` option now.

~~Would you need this legacy option @mafrahm @dsavoiu ? If not, we can also drop it and remove the code necessary for flipping legend handles.~~

---

This PR also includes a couple smaller plot updates, mostly on the configurability of the `grid_spec` (of the axes) itself, plus some code cleanup.