### PR TITLE
Bugfix only missing merge histograms

### DIFF
--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -10,7 +10,7 @@ __all__ = []
 
 import re
 import itertools
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 import law
 import order as od
@@ -509,3 +509,39 @@ def verify_config_processes(config: od.Config, warn: bool = False) -> None:
         raise Exception(msg)
 
     print(f"{law.util.colored('WARNING', 'red')}: {msg}")
+
+
+def group_shifts(
+    shifts: od.Shift | Sequence[od.Shift],
+) -> tuple[od.Shift | None, dict[str, tuple[od.Shift, od.Shift]]]:
+    """
+    Takes several :py:class:`order.Shift` instances *shifts* and groups them according to their
+    shift source. The nominal shift, if present, is returned separately. The remaining shifts are
+    grouped by their source and the corresponding up and down shifts are stored in a dictionary.
+    Example:
+
+    .. code-block:: python
+
+        # assuming the following shifts exist
+        group_shifts([nominal, x_up, y_up, y_down, x_down])
+        # -> (nominal, {"x": (x_up, x_down), "y": (y_up, y_down)})
+
+    An exception is raised in case a shift source is represented only by its up or down shift.
+    """
+    nominal = None
+    grouped = defaultdict(lambda: [None, None])
+
+    up_sources = set()
+    down_sources = set()
+    for shift in law.util.make_list(shifts):
+        if shift.name == "nominal":
+            nominal = shift
+        else:
+            grouped[shift.source][shift.is_up] = shift
+            (up_sources if shift.is_up else down_sources).add(shift.source)
+
+    # check completeness of shifts
+    if (diff := up_sources.symmetric_difference(down_sources)):
+        raise ValueError(f"shift sources {diff} are not complete and cannot be grouped")
+
+    return nominal, dict(grouped)

--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -8,12 +8,17 @@ from __future__ import annotations
 
 __all__ = []
 
+import order as od
+
 from columnflow.types import Sequence
 from columnflow.util import maybe_import, try_float
+from columnflow.config_util import group_shifts
 from columnflow.plotting.plot_util import (
     get_position,
     get_cms_label,
     remove_label_placeholders,
+    apply_label_placeholders,
+    check_nominal_shift,
 )
 
 hist = maybe_import("hist")
@@ -21,18 +26,19 @@ np = maybe_import("numpy")
 mpl = maybe_import("matplotlib")
 plt = maybe_import("matplotlib.pyplot")
 mplhep = maybe_import("mplhep")
-od = maybe_import("order")
 
 
-def draw_error_bands(
+def draw_stat_error_bands(
     ax: plt.Axes,
     h: hist.Hist,
     norm: float | Sequence | np.ndarray = 1.0,
     **kwargs,
 ) -> None:
-    # compute relative errors
-    rel_error = h.variances()**0.5 / h.values()
-    rel_error[np.isnan(rel_error)] = 0.0
+    assert len(h.axes) == 1
+
+    # compute relative statistical errors
+    rel_stat_error = h.variances()**0.5 / h.values()
+    rel_stat_error[np.isnan(rel_stat_error)] = 0.0
 
     # compute the baseline
     # fill 1 in places where both numerator and denominator are 0, and 0 for remaining nan's
@@ -40,19 +46,117 @@ def draw_error_bands(
     baseline[(h.values() == 0) & (norm == 0)] = 1.0
     baseline[np.isnan(baseline)] = 0.0
 
-    defaults = {
+    bar_kwargs = {
         "x": h.axes[0].centers,
+        "bottom": baseline * (1 - rel_stat_error),
+        "height": baseline * 2 * rel_stat_error,
+        **kwargs,
         "width": h.axes[0].edges[1:] - h.axes[0].edges[:-1],
-        "height": baseline * 2 * rel_error,
-        "bottom": baseline * (1 - rel_error),
         "hatch": "///",
-        "facecolor": "none",
         "linewidth": 0,
-        "color": "black",
+        "color": "none",
+        "edgecolor": "black",
         "alpha": 1.0,
     }
-    defaults.update(kwargs)
-    ax.bar(**defaults)
+    ax.bar(**bar_kwargs)
+
+
+def draw_syst_error_bands(
+    ax: plt.Axes,
+    h: hist.Hist,
+    syst_hists: Sequence[hist.Hist],
+    shift_insts: Sequence[od.Shift],
+    norm: float | Sequence | np.ndarray = 1.0,
+    method: str = "quadratic_sum",
+    **kwargs,
+) -> None:
+    assert len(h.axes) == 1
+    assert method in ("quadratic_sum", "envelope")
+
+    check_nominal_shift(shift_insts)
+    nominal_shift, shift_groups = group_shifts(shift_insts)
+    if nominal_shift is None:
+        raise ValueError("no nominal shift found in the list of shift instances")
+
+    # create pairs of shifts mapping from up -> down and vice versa
+    shift_pairs = {}
+    for up_shift, down_shift in shift_groups.values():
+        shift_pairs[up_shift] = down_shift
+        shift_pairs[down_shift] = up_shift
+
+    # stack histograms separately per shift, falling back to the nominal one when missing
+    shift_stacks: dict[od.Shift, hist.Hist] = {}
+    for shift_inst in sum(shift_groups.values(), []):
+        for _h in syst_hists:
+            # when the shift is present, the flipped shift must exist as well
+            shift_ax = _h.axes["shift"]
+            sid = nominal_shift.id
+            if shift_inst.id in shift_ax:
+                if shift_pairs[shift_inst].id not in shift_ax:
+                    raise RuntimeError(
+                        f"shift {shift_inst} found in histogram but {shift_pairs[shift_inst]} is "
+                        f"missing; existing shift ids: {','.join(map(str, list(shift_ax)))}",
+                    )
+                sid = shift_inst.id
+            # store the slice
+            _h = _h[{"shift": hist.loc(sid)}]
+            if shift_inst not in shift_stacks:
+                shift_stacks[shift_inst] = _h
+            else:
+                shift_stacks[shift_inst] += _h
+
+    # loop over bins, subtract nominal yields from stacked yields and merge differences into
+    # a systematic error per bin using the given method (quadratic sum vs. evelope)
+    # note 1: if the up/down variations of the same shift source point in the same direction, a
+    #         statistical combination is pointless and their minimum/maximum is selected instead
+    # note 2: relative signs are consumed into the meaning of "up" and "down" here as they already
+    #         are combinations evaluated for a specific direction
+    syst_error_up = []
+    syst_error_down = []
+    for b in range(h.axes[0].size):
+        up_diffs = []
+        down_diffs = []
+        for source, (up_shift, down_shift) in shift_groups.items():
+            up_diff = shift_stacks[up_shift].values()[b] - h.values()[b]
+            down_diff = shift_stacks[down_shift].values()[b] - h.values()[b]
+            up_diffs.append(max(up_diff, down_diff, 0))
+            down_diffs.append(min(up_diff, down_diff, 0))
+        # combination based on the method
+        if method == "quadratic_sum":
+            up_diff = sum(d**2 for d in up_diffs)**0.5
+            down_diff = sum(d**2 for d in down_diffs)**0.5
+        else:  # envelope
+            up_diff = max(up_diffs)
+            down_diff = min(down_diffs)
+        # save values
+        syst_error_up.append(up_diff)
+        syst_error_down.append(down_diff)
+
+    # compute relative systematic errors
+    rel_syst_error_up = np.array(syst_error_up) / h.values()
+    rel_syst_error_up[np.isnan(rel_syst_error_up)] = 0.0
+    rel_syst_error_down = np.array(syst_error_down) / h.values()
+    rel_syst_error_down[np.isnan(rel_syst_error_down)] = 0.0
+
+    # compute the baseline
+    # fill 1 in places where both numerator and denominator are 0, and 0 for remaining nan's
+    baseline = h.values() / norm
+    baseline[(h.values() == 0) & (norm == 0)] = 1.0
+    baseline[np.isnan(baseline)] = 0.0
+
+    bar_kwargs = {
+        "x": h.axes[0].centers,
+        "bottom": baseline * (1 - rel_syst_error_down),
+        "height": baseline * (rel_syst_error_up + rel_syst_error_down),
+        **kwargs,
+        "width": h.axes[0].edges[1:] - h.axes[0].edges[:-1],
+        "hatch": "\\\\\\",
+        "linewidth": 0,
+        "color": "none",
+        "edgecolor": "#30c300",
+        "alpha": 1.0,
+    }
+    ax.bar(**bar_kwargs)
 
 
 def draw_stack(
@@ -207,7 +311,7 @@ def plot_all(
     grid_spec = {"left": 0.15, "right": 0.95, "top": 0.95, "bottom": 0.1}
     grid_spec |= style_config.get("gridspec_cfg", {})
     if not skip_ratio:
-        grid_spec |= {"height_ratios": [3, 1], "hspace": 0}
+        grid_spec = {"height_ratios": [3, 1], "hspace": 0, **grid_spec}
         fig, axs = plt.subplots(2, 1, gridspec_kw=grid_spec, sharex=True)
         (ax, rax) = axs
     else:
@@ -217,7 +321,10 @@ def plot_all(
     # invoke all plots methods
     plot_methods = {
         func.__name__: func
-        for func in [draw_error_bands, draw_stack, draw_hist, draw_profile, draw_errorbars]
+        for func in [
+            draw_stat_error_bands, draw_syst_error_bands, draw_stack, draw_hist, draw_profile,
+            draw_errorbars,
+        ]
     }
     for key, cfg in plot_config.items():
         # check if required fields are present
@@ -322,7 +429,7 @@ def plot_all(
 
         # custom argument: entries_per_column
         n_cols = legend_kwargs.get("ncols", 1)
-        entries_per_col = legend_kwargs.pop("entries_per_column", None)
+        entries_per_col = legend_kwargs.pop("cf_entries_per_column", None)
         if callable(entries_per_col):
             entries_per_col = entries_per_col(ax, handles, labels, n_cols)
         if entries_per_col and n_cols > 1:
@@ -339,9 +446,20 @@ def plot_all(
                     labels.insert(i * max_entries + n, "")
 
         # custom hook to adjust handles and labels
-        update_handles_labels = legend_kwargs.pop("update_handles_labels", None)
+        update_handles_labels = legend_kwargs.pop("cf_update_handles_labels", None)
         if callable(update_handles_labels):
             update_handles_labels(ax, handles, labels, n_cols)
+
+        # interpret placeholders
+        apply = []
+        if legend_kwargs.pop("cf_short_labels", False):
+            apply.append("SHORT")
+        if legend_kwargs.pop("cf_line_breaks", False):
+            apply.append("BREAK")
+        labels = [apply_label_placeholders(label, apply=apply) for label in labels]
+
+        # drop remaining placeholders
+        labels = list(map(remove_label_placeholders, labels))
 
         # make legend using ordered handles/labels
         ax.legend(handles, labels, **legend_kwargs)

--- a/columnflow/plotting/plot_functions_2d.py
+++ b/columnflow/plotting/plot_functions_2d.py
@@ -17,7 +17,8 @@ from columnflow.plotting.plot_util import (
     remove_residual_axis,
     apply_variable_settings,
     apply_process_settings,
-    apply_density_to_hists,
+    apply_process_scaling,
+    apply_density,
     get_position,
     reduce_with,
 )
@@ -36,6 +37,7 @@ def plot_2d(
     config_inst: od.Config,
     category_inst: od.Category,
     variable_insts: list[od.Variable],
+    shift_insts: list[od.Shift],
     style_config: dict | None = None,
     density: bool | None = False,
     shape_norm: bool | None = False,
@@ -57,10 +59,10 @@ def plot_2d(
     remove_residual_axis(hists, "shift")
 
     hists = apply_variable_settings(hists, variable_insts, variable_settings)
-
     hists = apply_process_settings(hists, process_settings)
-
-    hists = apply_density_to_hists(hists, density)
+    hists = apply_process_scaling(hists)
+    if density:
+        hists = apply_density(hists, density)
 
     # use CMS plotting style
     plt.style.use(mplhep.style.CMS)

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -18,7 +18,7 @@ import order as od
 import scinum as sn
 
 from columnflow.util import maybe_import, try_int, try_complex
-from columnflow.types import Iterable, Any, Callable
+from columnflow.types import Iterable, Any, Callable, Sequence
 
 math = maybe_import("math")
 hist = maybe_import("hist")
@@ -91,49 +91,6 @@ def round_dynamic(value: int | float) -> int | float:
 
     # return with proper type
     return int(value) if value >= 1 else value
-
-
-def inject_label(
-    label: str,
-    inject: str | int | float,
-    *,
-    placeholder: str | None = None,
-    before_parentheses: bool = False,
-) -> str:
-    """
-    Injects a string *inject* into a *label* at a specific position, determined by different
-    strategies in the following order:
-
-        - If *placeholder* is defined, *label* should contain a substring ``"__PLACEHOLDER__"``
-        which is replaced.
-        - Otherwise, if *before_parentheses* is set to True, the string is inserted before the last
-        pair of parentheses.
-        - Otherwise, the string is appended to the label.
-
-    :param label: The label to inject the string *inject* into.
-    :param inject: The string to inject.
-    :param placeholder: The placeholder to replace in the label.
-    :param before_parentheses: Whether to insert the string before the parentheses in the label.
-    :return: The updated label.
-    """
-    # replace the placeholder
-    if placeholder and f"__{placeholder}__" in label:
-        return label.replace(f"__{placeholder}__", inject)
-
-    # when the label contains trailing parentheses, insert the string before them
-    if before_parentheses and label.endswith(")"):
-        in_parentheses = 1
-        for i in range(len(label) - 2, -1, -1):
-            c = label[i]
-            if c == ")":
-                in_parentheses += 1
-            elif c == "(":
-                in_parentheses -= 1
-            if not in_parentheses:
-                return f"{label[:i]} {inject} {label[i:]}"
-
-    # otherwise, just append
-    return f"{label} {inject}"
 
 
 def apply_settings(
@@ -223,8 +180,7 @@ def apply_process_settings(
     process_settings: dict | None = None,
 ) -> dict:
     """
-    applies settings from `process_settings` dictionary to the `process_insts`;
-    the `scale` setting is directly applied to the histograms
+    applies settings from `process_settings` dictionary to the `process_insts`
     """
     # apply all settings on process insts
     apply_settings(
@@ -233,6 +189,10 @@ def apply_process_settings(
         parent_check=(lambda proc, parent_name: proc.has_parent_process(parent_name)),
     )
 
+    return hists
+
+
+def apply_process_scaling(hists: dict) -> dict:
     # helper to compute the stack integral
     stack_integral = None
 
@@ -240,9 +200,9 @@ def apply_process_settings(
         nonlocal stack_integral
         if stack_integral is None:
             stack_integral = sum(
-                proc_h.sum().value
+                _remove_residual_axis(proc_h, "shift", select_value=0).sum().value
                 for proc, proc_h in hists.items()
-                if not hasattr(proc, "unstack") and not proc.is_data
+                if proc.is_mc and not getattr(proc, "unstack", False)
             )
         return stack_integral
 
@@ -251,7 +211,8 @@ def apply_process_settings(
         scale_factor = getattr(proc_inst, "scale", None) or proc_inst.x("scale", None)
         if scale_factor == "stack":
             # compute the scale factor and round
-            scale_factor = round_dynamic(get_stack_integral() / h.sum().value)
+            h_no_shift = _remove_residual_axis(h, "shift", select_value=0)
+            scale_factor = round_dynamic(get_stack_integral() / h_no_shift.sum().value)
         if try_int(scale_factor):
             scale_factor = int(scale_factor)
             hists[proc_inst] = h * scale_factor
@@ -260,21 +221,37 @@ def apply_process_settings(
                 if scale_factor < 1e5
                 else re.sub(r"e(\+?)(-?)(0*)", r"e\2", f"{scale_factor:.1e}")
             )
-            proc_inst.label = inject_label(
+            proc_inst.label = apply_label_placeholders(
                 proc_inst.label,
-                rf"$\times${scale_factor_str}",
-                placeholder="SCALE",
-                before_parentheses=True,
+                apply="SCALE",
+                scale=scale_factor_str,
             )
 
-        # remove remaining placeholders
-        proc_inst.label = remove_label_placeholders(proc_inst.label)
+        # remove remaining scale placeholders
+        proc_inst.label = remove_label_placeholders(proc_inst.label, drop="SCALE")
 
     return hists
 
 
-def remove_label_placeholders(label: str) -> str:
-    return re.sub("__[A-Z0-9]+__", "", label)
+def remove_label_placeholders(
+    label: str,
+    keep: str | Sequence[str] | None = None,
+    drop: str | Sequence[str] | None = None,
+) -> str:
+    # when placeholders should be kept, determine all existing ones and identify remaining to drop
+    if keep:
+        keep = law.util.make_list(keep)
+        placeholders = re.findall("__([^_]+)__", label)
+        drop = list(set(placeholders) - set(keep))
+
+    # drop specific placeholders or all
+    if drop:
+        drop = law.util.make_list(drop)
+        sel = f"({'|'.join(d.upper() for d in drop)})"
+    else:
+        sel = "[A-Z0-9]+"
+
+    return re.sub(f"__{sel}__", "", label)
 
 
 def apply_variable_settings(
@@ -379,13 +356,10 @@ def use_flow_bins(
     return h_out
 
 
-def apply_density_to_hists(hists: dict, density: bool | None = False) -> dict:
+def apply_density(hists: dict) -> dict:
     """
     Scales number of histogram entries to bin widths.
     """
-    if not density:
-        return hists
-
     for key, hist in hists.items():
         # bin area safe for multi-dimensional histograms
         area = functools.reduce(operator.mul, hist.axes.widths)
@@ -396,22 +370,49 @@ def apply_density_to_hists(hists: dict, density: bool | None = False) -> dict:
     return hists
 
 
-def remove_residual_axis(hists: dict, ax_name: str, max_bins: int = 1) -> dict:
+def _remove_residual_axis(
+    h: hist.Hist,
+    ax_name: str,
+    max_bins: int = 1,
+    select_value: Any = None,
+) -> hist.Hist:
+    # force always returning a copy
+    h = h.copy()
+
+    # nothing to do if the axis is not present
+    if ax_name not in h.axes.name:
+        return h
+
+    # when a selection is given, select the corresponding value
+    if select_value is not None:
+        h = h[{ax_name: [hist.loc(select_value)]}]
+
+    # check remaining axis
+    n_bins = len(h.axes[ax_name])
+    if n_bins > max_bins:
+        raise Exception(
+            f"axis '{ax_name}' of histogram has {n_bins} bins whereas at most {max_bins} bins are "
+            f"accepted for removal of residual axis",
+        )
+
+    # accumulate remaining axis
+    return h[{ax_name: sum}]
+
+
+def remove_residual_axis(
+    hists: dict,
+    ax_name: str,
+    max_bins: int = 1,
+    select_value: Any = None,
+) -> dict:
     """
-    removes axis named 'ax_name' if existing and there is only a single bin in the axis;
+    Removes axis named 'ax_name' if existing and there is only a single bin in the axis;
     raises Exception otherwise
     """
-    for key, hist in list(hists.items()):
-        if ax_name in hist.axes.name:
-            n_bins = len(hist.axes[ax_name])
-            if n_bins > max_bins:
-                raise Exception(
-                    f"{ax_name} axis of histogram for key {key} has {n_bins} values whereas at most "
-                    f"{max_bins} is expected",
-                )
-            hists[key] = hist[{ax_name: sum}]
-
-    return hists
+    return {
+        key: _remove_residual_axis(h, ax_name, max_bins=max_bins, select_value=select_value)
+        for key, h in hists.items()
+    }
 
 
 def prepare_style_config(
@@ -476,7 +477,8 @@ def prepare_style_config(
 def prepare_stack_plot_config(
     hists: OrderedDict,
     shape_norm: bool | None = False,
-    hide_errors: bool | None = None,
+    hide_stat_errors: bool | None = None,
+    shift_insts: Sequence[od.Shift] | None = None,
     **kwargs,
 ) -> OrderedDict:
     """
@@ -484,33 +486,35 @@ def prepare_stack_plot_config(
     backgrounds with uncertainty bands, unstacked processes as lines and
     data entrys with errorbars.
     """
+    check_nominal_shift(shift_insts)
+
     # separate histograms into stack, lines and data hists
     mc_hists, mc_colors, mc_edgecolors, mc_labels = [], [], [], []
-    line_hists, line_colors, line_labels, line_hide_errors = [], [], [], []
-    data_hists, data_hide_errors = [], []
+    mc_syst_hists = []
+    line_hists, line_colors, line_labels, line_hide_stat_errors = [], [], [], []
+    data_hists, data_hide_stat_errors = [], []
     data_label = None
 
     for process_inst, h in hists.items():
         # if given, per-process setting overrides task parameter
-        proc_hide_errors = hide_errors
-        if getattr(process_inst, "hide_errors", None) is not None:
-            proc_hide_errors = process_inst.hide_errors
+        proc_hide_stat_errors = getattr(process_inst, "hide_stat_errors", hide_stat_errors)
         if process_inst.is_data:
-            data_hists.append(h)
-            data_hide_errors.append(proc_hide_errors)
+            data_hists.append(_remove_residual_axis(h, "shift", select_value=0))
+            data_hide_stat_errors.append(proc_hide_stat_errors)
             if data_label is None:
                 data_label = process_inst.label
-        elif process_inst.is_mc:
-            if getattr(process_inst, "unstack", False):
-                line_hists.append(h)
-                line_colors.append(process_inst.color1)
-                line_labels.append(process_inst.label)
-                line_hide_errors.append(proc_hide_errors)
-            else:
-                mc_hists.append(h)
-                mc_colors.append(process_inst.color1)
-                mc_edgecolors.append(process_inst.color2)
-                mc_labels.append(process_inst.label)
+        elif getattr(process_inst, "unstack", False):
+            line_hists.append(_remove_residual_axis(h, "shift", select_value=0))
+            line_colors.append(process_inst.color1)
+            line_labels.append(process_inst.label)
+            line_hide_stat_errors.append(proc_hide_stat_errors)
+        else:
+            mc_hists.append(_remove_residual_axis(h, "shift", select_value=0))
+            mc_colors.append(process_inst.color1)
+            mc_edgecolors.append(process_inst.color2)
+            mc_labels.append(process_inst.label)
+            if "shift" in h.axes.name and h.axes["shift"].size > 1:
+                mc_syst_hists.append(h)
 
     h_data, h_mc, h_mc_stack = None, None, None
     if data_hists:
@@ -555,19 +559,38 @@ def prepare_stack_plot_config(
         }
 
         # suppress error bars by overriding `yerr`
-        if line_hide_errors[i]:
+        if line_hide_stat_errors[i]:
             for key in ("kwargs", "ratio_kwargs"):
                 if key in plot_cfg:
                     plot_cfg[key]["yerr"] = False
 
-    # draw stack error
-    if h_mc_stack is not None and not hide_errors:
+    # draw statistical error for stack
+    if h_mc_stack is not None and not hide_stat_errors:
         mc_norm = sum(h_mc.values()) if shape_norm else 1
-        plot_config["mc_uncert"] = {
-            "method": "draw_error_bands",
+        plot_config["mc_stat_unc"] = {
+            "method": "draw_stat_error_bands",
             "hist": h_mc,
             "kwargs": {"norm": mc_norm, "label": "MC stat. unc."},
             "ratio_kwargs": {"norm": h_mc.values()},
+        }
+
+    # draw systemetic error for stack
+    if h_mc_stack is not None and mc_syst_hists:
+        mc_norm = sum(h_mc.values()) if shape_norm else 1
+        plot_config["mc_syst_unc"] = {
+            "method": "draw_syst_error_bands",
+            "hist": h_mc,
+            "kwargs": {
+                "syst_hists": mc_syst_hists,
+                "shift_insts": shift_insts,
+                "norm": mc_norm,
+                "label": "MC syst. unc.",
+            },
+            "ratio_kwargs": {
+                "syst_hists": mc_syst_hists,
+                "shift_insts": shift_insts,
+                "norm": h_mc.values(),
+            },
         }
 
     # draw data
@@ -588,7 +611,7 @@ def prepare_stack_plot_config(
             }
 
         # suppress error bars by overriding `yerr`
-        if any(data_hide_errors):
+        if any(data_hide_stat_errors):
             for key in ("kwargs", "ratio_kwargs"):
                 if key in plot_cfg:
                     plot_cfg[key]["yerr"] = False
@@ -791,9 +814,9 @@ def blind_sensitive_bins(
     check_if_signal = lambda proc: any(signal == proc or signal.has_process(proc) for signal in signal_procs)
 
     # separate histograms into signals, backgrounds and data hists and calculate sums
-    signals = {proc: hist for proc, hist in hists.items() if proc.is_mc and check_if_signal(proc)}
-    data = {proc: hist.copy() for proc, hist in hists.items() if proc.is_data}
-    backgrounds = {proc: hist for proc, hist in hists.items() if proc.is_mc and proc not in signals}
+    signals = {proc: h for proc, h in hists.items() if proc.is_mc and check_if_signal(proc)}
+    data = {proc: h.copy() for proc, h in hists.items() if proc.is_data}
+    backgrounds = {proc: h for proc, h in hists.items() if proc.is_mc and proc not in signals}
 
     # Return hists unchanged in case any of the three dicts is empty.
     if not signals or not backgrounds or not data:
@@ -803,8 +826,9 @@ def blind_sensitive_bins(
         )
         return hists
 
-    signals_sum = sum(signals.values())
-    backgrounds_sum = sum(backgrounds.values())
+    # get nominal signal and background yield sums per bin
+    signals_sum = sum(remove_residual_axis(signals, "shift", select_value=0).values())
+    backgrounds_sum = sum(remove_residual_axis(backgrounds, "shift", select_value=0).values())
 
     # calculate sensitivity by S / sqrt(S + B)
     sensitivity = signals_sum.values() / np.sqrt(signals_sum.values() + backgrounds_sum.values())
@@ -816,11 +840,69 @@ def blind_sensitive_bins(
         mask[first_ind:last_ind] = True
 
     # set data points in masked region to zero
-    for proc, hist in data.items():
-        hist.values()[mask] = 0
-        hist.variances()[mask] = 0
+    for proc, h in data.items():
+        h.values()[..., mask] = 0
+        h.variances()[..., mask] = 0
 
     # merge all histograms
     hists = law.util.merge_dicts(signals, backgrounds, data)
 
     return hists
+
+
+def apply_label_placeholders(
+    label: str,
+    apply: str | Sequence[str] | None = None,
+    skip: str | Sequence[str] | None = None,
+    **kwargs: Any,
+) -> str:
+    """
+    Interprets placeholders in the format "__NAME__" in a label and returns an updated label.
+    Currently supported placeholders are:
+
+        - SHORT: removes everything (and including) the placeholder
+        - BREAK: inserts a line break
+        - SCALE: inserts a scale factor, passed as "scale" in kwargs; when "scale_format" is given
+                 as well, the scale factor is formatted accordingly
+
+    *apply* and *skip* can be used to de/select certain placeholders.
+    """
+    # handle apply/skip decisions
+    if apply:
+        _apply = set(p.upper() for p in law.util.make_list(apply))
+        do_apply = lambda p: p in _apply
+    elif skip:
+        _skip = set(p.upper() for p in law.util.make_list(skip))
+        do_apply = lambda p: p not in _skip
+    else:
+        do_apply = lambda p: True
+
+    # shortening
+    if do_apply("SHORT"):
+        label = re.sub(r"__SHORT__.*", "", label)
+
+    # lines breaks
+    if do_apply("BREAK"):
+        label = label.replace("__BREAK__", "\n")
+
+    # scale factor
+    if do_apply("SCALE") and "scale" in kwargs and "__SCALE__" in label:
+        scale_str = kwargs.get("scale_format", "$\\times${}").format(kwargs["scale"])
+        label = label.replace("__SCALE__", scale_str)
+
+    return label
+
+
+def check_nominal_shift(shifts: od.Shift | Sequence[od.Shift] | None) -> None:
+    """
+    Selects the so-called "nominal" shift from one or multiple :py:class:`order.Shift` instances
+    *shifts* and checks if its id is in fact 0, which is an assumption made throughout the plotting
+    helpers and functions. A ValueError is raised if the nominal shift is found but has a different
+    id.
+    """
+    if shifts is None:
+        return
+
+    for shift in law.util.make_list(shifts):
+        if shift.name == "nominal" and shift.id != 0:
+            raise ValueError(f"the nominal shift should have id 0 but found {shift}")

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -17,9 +17,9 @@ ak = maybe_import("awkward")
 
 
 class CalibrateEvents(
-    CalibratorMixin,
-    ChunkedIOMixin,
     DatasetTask,
+    ChunkedIOMixin,
+    CalibratorMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -288,7 +288,7 @@ class PlotCutflowBase(
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "plot", f"datasets_{self.datasets_repr}")
+        parts.insert_after(self.config_store_anchor, "plot", f"datasets_{self.datasets_repr}")
         return parts
 
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -89,11 +89,13 @@ class CreateCutflowHistograms(
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
-        reqs["selection"] = self.reqs.MergeSelectionMasks.req(self)
+        reqs["selection"] = self.reqs.MergeSelectionMasks.req(self, tree_index=0, _exclude={"branches"})
         return reqs
 
     def requires(self):
-        return {"selection": self.reqs.MergeSelectionMasks.req(self)}
+        return {
+            "selection": self.reqs.MergeSelectionMasks.req(self, tree_index=0, branch=0),
+        }
 
     def output(self):
         return {

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -288,7 +288,7 @@ class PlotCutflowBase(
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
-        parts.insert_after("config", "plot", f"datasets_{self.datasets_repr}")
+        parts.insert_after(self.store_part_anchor, "plot", f"datasets_{self.datasets_repr}")
         return parts
 
 

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -650,7 +650,7 @@ class PlotCutflowVariables1D(
         "--per-plot parameter",
         allow_empty=True,
     )
-    plot_function_processes = "columnflow.plotting.plot_functions_1d.plot_variable_per_process"
+    plot_function_processes = "columnflow.plotting.plot_functions_1d.plot_variable_stack"
     plot_function_steps = "columnflow.plotting.plot_functions_1d.plot_variable_variants"
 
     per_plot = luigi.ChoiceParameter(
@@ -719,6 +719,7 @@ class PlotCutflowVariables1D(
                     config_inst=self.config_inst,
                     category_inst=category_inst.copy_shallow(),
                     variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
+                    shift_insts=[self.global_shift_inst],
                     style_config={"legend_cfg": {"title": f"Step '{step}'"}},
                     **self.get_plot_parameters(),
                 )

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -756,7 +756,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         For instance, the parts ``{"keyA": "a", "keyB": "b", 2: "c"}`` lead to the path "a/b/c". The
         keys can be used by subclassing tasks to overwrite values.
 
-        :return: Dictionary with parts to create a path to store intermediary results.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = law.util.InsertableDict()
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -990,6 +990,9 @@ class ConfigTask(AnalysisTask):
         description=f"name of the analysis config to use; default: '{default_config}'",
     )
 
+    # the field in the store parts behind which the new part is inserted
+    store_part_anchor = "task_family"
+
     @classmethod
     def resolve_param_values(cls, params: dict) -> dict:
         params = super().resolve_param_values(params)
@@ -1055,11 +1058,11 @@ class ConfigTask(AnalysisTask):
         # store a reference to the config instance
         self.config_inst = self.analysis_inst.get_config(self.config)
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
 
         # add the config name
-        parts.insert_after("task_family", "config", self.config_inst.name)
+        parts.insert_after(self.store_part_anchor, "config", self.config_inst.name)
 
         return parts
 
@@ -1120,6 +1123,9 @@ class ShiftTask(ConfigTask):
     exclude_params_remote_workflow = {"local_shift"}
 
     allow_empty_shift = False
+
+    # the field in the store parts behind which the new part is inserted
+    store_part_anchor = "config"
 
     @classmethod
     def modify_param_values(cls, params):
@@ -1230,12 +1236,12 @@ class ShiftTask(ConfigTask):
             self.global_shift_inst = self.config_inst.get_shift(self.shift)
             self.local_shift_inst = self.config_inst.get_shift(self.local_shift)
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
 
         # add the shift name
         if self.global_shift_inst:
-            parts.insert_after("config", "shift", self.global_shift_inst.name)
+            parts.insert_after(self.store_part_anchor, "shift", self.global_shift_inst.name)
 
         return parts
 
@@ -1323,11 +1329,11 @@ class DatasetTask(ShiftTask):
         )
         self.dataset_info_inst = self.dataset_inst.get_info(key)
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
 
         # insert the dataset
-        parts.insert_after("config", "dataset", self.dataset_inst.name)
+        parts.insert_after(self.store_part_anchor, "dataset", self.dataset_inst.name)
 
         return parts
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -990,6 +990,10 @@ class ConfigTask(AnalysisTask):
         description=f"name of the analysis config to use; default: '{default_config}'",
     )
 
+    # the field in the store parts behind which the new part is inserted
+    # added here for subclasses that typically refer to the store part added by _this_ class
+    config_store_anchor = "config"
+
     @classmethod
     def resolve_param_values(cls, params: dict) -> dict:
         params = super().resolve_param_values(params)
@@ -1120,9 +1124,6 @@ class ShiftTask(ConfigTask):
     exclude_params_remote_workflow = {"local_shift"}
 
     allow_empty_shift = False
-
-    # the field in the store parts behind which the new part is inserted
-    config_store_anchor = "config"
 
     @classmethod
     def modify_param_values(cls, params):

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -990,9 +990,6 @@ class ConfigTask(AnalysisTask):
         description=f"name of the analysis config to use; default: '{default_config}'",
     )
 
-    # the field in the store parts behind which the new part is inserted
-    store_part_anchor = "task_family"
-
     @classmethod
     def resolve_param_values(cls, params: dict) -> dict:
         params = super().resolve_param_values(params)
@@ -1062,7 +1059,7 @@ class ConfigTask(AnalysisTask):
         parts = super().store_parts()
 
         # add the config name
-        parts.insert_after(self.store_part_anchor, "config", self.config_inst.name)
+        parts.insert_after("task_family", "config", self.config_inst.name)
 
         return parts
 
@@ -1125,7 +1122,7 @@ class ShiftTask(ConfigTask):
     allow_empty_shift = False
 
     # the field in the store parts behind which the new part is inserted
-    store_part_anchor = "config"
+    config_store_anchor = "config"
 
     @classmethod
     def modify_param_values(cls, params):
@@ -1241,7 +1238,7 @@ class ShiftTask(ConfigTask):
 
         # add the shift name
         if self.global_shift_inst:
-            parts.insert_after(self.store_part_anchor, "shift", self.global_shift_inst.name)
+            parts.insert_after(self.config_store_anchor, "shift", self.global_shift_inst.name)
 
         return parts
 
@@ -1333,7 +1330,7 @@ class DatasetTask(ShiftTask):
         parts = super().store_parts()
 
         # insert the dataset
-        parts.insert_after(self.store_part_anchor, "dataset", self.dataset_inst.name)
+        parts.insert_after(self.config_store_anchor, "dataset", self.dataset_inst.name)
 
         return parts
 

--- a/columnflow/tasks/framework/histograms.py
+++ b/columnflow/tasks/framework/histograms.py
@@ -33,7 +33,7 @@ class HistogramsUserBase(
 ):
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
         parts.insert_before("version", "datasets", f"datasets_{self.datasets_repr}")
         return parts

--- a/columnflow/tasks/framework/histograms.py
+++ b/columnflow/tasks/framework/histograms.py
@@ -12,8 +12,7 @@ import order as od
 from columnflow.tasks.framework.base import Requirements, ShiftTask
 from columnflow.tasks.framework.mixins import (
     CalibratorsMixin, SelectorStepsMixin, ProducersMixin, MLModelsMixin, WeightProducerMixin,
-    VariablesMixin, DatasetsProcessesMixin, CategoriesMixin,
-    ShiftSourcesMixin,
+    VariablesMixin, DatasetsProcessesMixin, CategoriesMixin, ShiftSourcesMixin,
 )
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import dev_sandbox, maybe_import
@@ -23,14 +22,14 @@ hist = maybe_import("hist")
 
 
 class HistogramsUserBase(
+    CalibratorsMixin,
+    SelectorStepsMixin,
+    ProducersMixin,
+    WeightProducerMixin,
+    MLModelsMixin,
     DatasetsProcessesMixin,
     CategoriesMixin,
     VariablesMixin,
-    MLModelsMixin,
-    WeightProducerMixin,
-    ProducersMixin,
-    SelectorStepsMixin,
-    CalibratorsMixin,
 ):
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
 
@@ -136,8 +135,8 @@ class HistogramsUserBase(
 
 
 class HistogramsUserSingleShiftBase(
-    HistogramsUserBase,
     ShiftTask,
+    HistogramsUserBase,
 ):
 
     # upstream requirements
@@ -163,8 +162,8 @@ class HistogramsUserSingleShiftBase(
 
 
 class HistogramsUserMultiShiftBase(
-    HistogramsUserBase,
     ShiftSourcesMixin,
+    HistogramsUserBase,
 ):
     # upstream requirements
     reqs = Requirements(

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -206,7 +206,7 @@ class CalibratorMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after("config", "calibrator", f"calib__{self.calibrator_repr}")
+        parts.insert_after(self.store_part_anchor, "calibrator", f"calib__{self.calibrator_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -419,7 +419,7 @@ class CalibratorsMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after("config", "calibrators", f"calib__{self.calibrators_repr}")
+        parts.insert_after(self.store_part_anchor, "calibrators", f"calib__{self.calibrators_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -614,7 +614,7 @@ class SelectorMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after("config", "selector", f"sel__{self.selector_repr}")
+        parts.insert_after(self.store_part_anchor, "selector", f"sel__{self.selector_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -911,7 +911,7 @@ class ProducerMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after("config", "producer", f"prod__{self.producer_repr}")
+        parts.insert_after(self.store_part_anchor, "producer", f"prod__{self.producer_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -1120,7 +1120,7 @@ class ProducersMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after("config", "producers", f"prod__{self.producers_repr}")
+        parts.insert_after(self.store_part_anchor, "producers", f"prod__{self.producers_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -1576,10 +1576,10 @@ class MLModelTrainingMixin(MLModelMixinBase):
             if len(fct_names) > 2:
                 part += f"_{n_fct_per_config}_{law.util.create_hash(fct_names[2:])}"
 
-            parts.insert_after("config", label, f"{label}__{part}")
+            parts.insert_after(self.store_part_anchor, label, f"{label}__{part}")
 
         if self.ml_model_inst:
-            parts.insert_after("config", "ml_model", f"ml__{self.ml_model_repr}")
+            parts.insert_after(self.store_part_anchor, "ml_model", f"ml__{self.ml_model_repr}")
 
         return parts
 
@@ -1647,7 +1647,7 @@ class MLModelMixin(ConfigTask, MLModelMixinBase):
         parts = super().store_parts()
 
         if self.ml_model_inst:
-            parts.insert_after("config", "ml_model", f"ml__{self.ml_model_repr}")
+            parts.insert_after(self.store_part_anchor, "ml_model", f"ml__{self.ml_model_repr}")
 
         return parts
 
@@ -1672,7 +1672,7 @@ class MLModelDataMixin(MLModelMixin):
 
         # replace the ml_model entry
         store_name = self.ml_model_inst.store_name or self.ml_model_repr
-        parts.insert_after("config", "ml_data", f"ml__{store_name}")
+        parts.insert_after(self.store_part_anchor, "ml_data", f"ml__{store_name}")
         parts.pop("ml_model")
 
         return parts
@@ -1756,7 +1756,7 @@ class MLModelsMixin(ConfigTask):
         parts = super().store_parts()
 
         if self.ml_model_insts:
-            parts.insert_after("config", "ml_models", f"ml__{self.ml_models_repr}")
+            parts.insert_after(self.store_part_anchor, "ml_models", f"ml__{self.ml_models_repr}")
 
         return parts
 
@@ -1825,7 +1825,7 @@ class InferenceModelMixin(ConfigTask):
         parts = super().store_parts()
 
         if self.inference_model != law.NO_STR:
-            parts.insert_after("config", "inf_model", f"inf__{self.inference_model_repr}")
+            parts.insert_after(self.store_part_anchor, "inf_model", f"inf__{self.inference_model_repr}")
 
         return parts
 
@@ -2273,7 +2273,7 @@ class WeightProducerMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after("config", "weightprod", f"weight__{self.weight_producer_repr}")
+        parts.insert_after(self.store_part_anchor, "weightprod", f"weight__{self.weight_producer_repr}")
         return parts
 
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -201,19 +201,12 @@ class CalibratorMixin(ConfigTask):
         """
         return str(self.calibrator_inst)
 
-    def store_parts(self) -> law.util.InsertableDict[str, str]:
+    def store_parts(self) -> law.util.InsertableDict:
         """
-        Create parts to create the output path to store intermediary results
-        for the current :py:class:`~law.task.base.Task`.
-
-        This method calls :py:meth:`store_parts` of the ``super`` class and inserts
-        `{"calibrator": "calib__{self.calibrator}"}` before keyword ``version``.
-        For more information, see e.g. :py:meth:`~columnflow.tasks.framework.base.ConfigTask.store_parts`.
-
-        :return: Updated parts to create output path to store intermediary results.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_before("version", "calibrator", f"calib__{self.calibrator_repr}")
+        parts.insert_after("config", "calibrator", f"calib__{self.calibrator_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -421,22 +414,12 @@ class CalibratorsMixin(ConfigTask):
                 calibs_repr += f"__{law.util.create_hash([str(calib) for calib in self.calibrator_insts[5:]])}"
         return calibs_repr
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         """
-        Create parts to create the output path to store intermediary results
-        for the current :py:class:`~law.task.base.Task`.
-
-        Calls :py:meth:`store_parts` of the ``super`` class and inserts
-        `{"calibrator": "calib__{HASH}"}` before keyword ``version``.
-        Here, ``HASH`` is the joint string of the first five calibrator names
-        + a hash created with :py:meth:`law.util.create_hash` based on
-        the list of calibrators, starting at its 5th element (i.e. ``self.calibrators[5:]``)
-        For more information, see e.g. :py:meth:`~columnflow.tasks.framework.base.ConfigTask.store_parts`.
-
-        :return: Updated parts to create output path to store intermediary results.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_before("version", "calibrators", f"calib__{self.calibrators_repr}")
+        parts.insert_after("config", "calibrators", f"calib__{self.calibrators_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -626,19 +609,12 @@ class SelectorMixin(ConfigTask):
         """
         return str(self.selector_inst)
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         """
-        Create parts to create the output path to store intermediary results
-        for the current :py:class:`~law.task.base.Task`.
-
-        Calls :py:meth:`store_parts` of the ``super`` class and inserts
-        `{"selector": "sel__{SELECTOR_NAME}"}` before keyword ``version``.
-        Here, ``SELECTOR_NAME`` is the name of the current ``selector_inst``.
-
-        :return: Updated parts to create output path to store intermediary results.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_before("version", "selector", f"sel__{self.selector_repr}")
+        parts.insert_after("config", "selector", f"sel__{self.selector_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -746,16 +722,7 @@ class SelectorStepsMixin(SelectorMixin):
 
     def store_parts(self) -> law.util.InsertableDict:
         """
-        Create parts to create the output path to store intermediary results
-        for the current :py:class:`~law.task.base.Task`.
-
-        Calls :py:meth:`store_parts` of the ``super`` class and inserts
-        `{"selector": "__steps__LIST_OF_STEPS"}`, where ``LIST_OF_STEPS`` is the
-        sorted list of selector steps.
-        For more information, see e.g.
-        :py:meth:`~columnflow.tasks.framework.base.ConfigTask.store_parts`.
-
-        :return: Updated parts to create output path to store intermediary results.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
 
@@ -939,20 +906,12 @@ class ProducerMixin(ConfigTask):
         """
         return str(self.producer_inst) if self.producer != law.NO_STR else "none"
 
-    def store_parts(self) -> law.util.InsertableDict[str, str]:
+    def store_parts(self) -> law.util.InsertableDict:
         """
-        Create parts to create the output path to store intermediary results
-        for the current :py:class:`~law.task.base.Task`.
-
-        Calls :py:meth:`store_parts` of the ``super`` class and inserts
-        `{"producer": "prod__{self.producer}"}` before keyword ``version``.
-        For more information, see e.g. :py:meth:`~columnflow.tasks.framework.base.ConfigTask.store_parts`.
-
-        :return: Updated parts to create output path to store intermediary results.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        producer = f"prod__{self.producer_repr}"
-        parts.insert_before("version", "producer", producer)
+        parts.insert_after("config", "producer", f"prod__{self.producer_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -1156,23 +1115,12 @@ class ProducersMixin(ConfigTask):
                 prods_repr += f"__{law.util.create_hash([str(prod) for prod in self.producer_insts[5:]])}"
         return prods_repr
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         """
-        Create parts to create the output path to store intermediary results
-        for the current :py:class:`~law.task.base.Task`.
-
-        Calls :py:meth:`store_parts` of the ``super`` class and inserts
-        `{"producers": "prod__{HASH}"}` before keyword ``version``.
-        Here, ``HASH`` is the joint string of the first five producer names
-        + a hash created with :py:meth:`law.util.create_hash` based on
-        the list of producers, starting at its 5th element (i.e. ``self.producers[5:]``)
-        For more information, see e.g. :py:meth:`~columnflow.tasks.framework.base.ConfigTask.store_parts`.
-
-        :return: Updated parts to create output path to store intermediary results.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_before("version", "producers", f"prod__{self.producers_repr}")
-
+        parts.insert_after("config", "producers", f"prod__{self.producers_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -1591,21 +1539,9 @@ class MLModelTrainingMixin(MLModelMixinBase):
             parameters=self.ml_model_settings,
         )
 
-    def store_parts(self) -> law.util.InsertableDict[str, str]:
+    def store_parts(self) -> law.util.InsertableDict:
         """
-        Generate a dictionary of store parts for the current instance.
-
-        This method extends the base method to include additional parts related to machine learning
-        model configurations, calibrators, selectors, producers (CSP), and the ML model instance itself.
-        If the list of either of the CSPs is empty, the corresponding part is set to ``"none"``,
-        otherwise, the first two elements of the list are joined with ``"__"``.
-        If the list of either of the CSPs contains more than two elements, the part is extended
-        with the number of elements and a hash of the remaining elements, which is
-        created with :py:meth:`law.util.create_hash`.
-        The parts are represented as strings and are used to create unique identifiers for the
-        instance's output.
-
-        :return: An InsertableDict containing the store parts.
+        :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
 
@@ -1640,10 +1576,10 @@ class MLModelTrainingMixin(MLModelMixinBase):
             if len(fct_names) > 2:
                 part += f"_{n_fct_per_config}_{law.util.create_hash(fct_names[2:])}"
 
-            parts.insert_before("version", label, f"{label}__{part}")
+            parts.insert_after("config", label, f"{label}__{part}")
 
         if self.ml_model_inst:
-            parts.insert_before("version", "ml_model", f"ml__{self.ml_model_repr}")
+            parts.insert_after("config", "ml_model", f"ml__{self.ml_model_repr}")
 
         return parts
 
@@ -1705,10 +1641,13 @@ class MLModelMixin(ConfigTask, MLModelMixinBase):
             )
 
     def store_parts(self) -> law.util.InsertableDict:
+        """
+        :return: Dictionary with parts that will be translated into an output directory path.
+        """
         parts = super().store_parts()
 
         if self.ml_model_inst:
-            parts.insert_before("version", "ml_model", f"ml__{self.ml_model_repr}")
+            parts.insert_after("config", "ml_model", f"ml__{self.ml_model_repr}")
 
         return parts
 
@@ -1726,11 +1665,14 @@ class MLModelDataMixin(MLModelMixin):
     allow_empty_ml_model = False
 
     def store_parts(self) -> law.util.InsertableDict:
+        """
+        :return: Dictionary with parts that will be translated into an output directory path.
+        """
         parts = super().store_parts()
 
         # replace the ml_model entry
         store_name = self.ml_model_inst.store_name or self.ml_model_repr
-        parts.insert_before("ml_model", "ml_data", f"ml__{store_name}")
+        parts.insert_after("config", "ml_data", f"ml__{store_name}")
         parts.pop("ml_model")
 
         return parts
@@ -1808,10 +1750,13 @@ class MLModelsMixin(ConfigTask):
         ]
 
     def store_parts(self) -> law.util.InsertableDict:
+        """
+        :return: Dictionary with parts that will be translated into an output directory path.
+        """
         parts = super().store_parts()
 
         if self.ml_model_insts:
-            parts.insert_before("version", "ml_models", f"ml__{self.ml_models_repr}")
+            parts.insert_after("config", "ml_models", f"ml__{self.ml_models_repr}")
 
         return parts
 
@@ -1874,9 +1819,14 @@ class InferenceModelMixin(ConfigTask):
         return str(self.inference_model)
 
     def store_parts(self) -> law.util.InsertableDict:
+        """
+        :return: Dictionary with parts that will be translated into an output directory path.
+        """
         parts = super().store_parts()
+
         if self.inference_model != law.NO_STR:
-            parts.insert_before("version", "inf_model", f"inf__{self.inference_model_repr}")
+            parts.insert_after("config", "inf_model", f"inf__{self.inference_model_repr}")
+
         return parts
 
 
@@ -2318,9 +2268,12 @@ class WeightProducerMixin(ConfigTask):
     def weight_producer_repr(self) -> str:
         return str(self.weight_producer_inst)
 
-    def store_parts(self: WeightProducerMixin) -> law.util.InsertableDict[str, str]:
+    def store_parts(self) -> law.util.InsertableDict:
+        """
+        :return: Dictionary with parts that will be translated into an output directory path.
+        """
         parts = super().store_parts()
-        parts.insert_before("version", "weightprod", f"weight__{self.weight_producer_repr}")
+        parts.insert_after("config", "weightprod", f"weight__{self.weight_producer_repr}")
         return parts
 
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -206,7 +206,7 @@ class CalibratorMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "calibrator", f"calib__{self.calibrator_repr}")
+        parts.insert_after(self.config_store_anchor, "calibrator", f"calib__{self.calibrator_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -419,7 +419,7 @@ class CalibratorsMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "calibrators", f"calib__{self.calibrators_repr}")
+        parts.insert_after(self.config_store_anchor, "calibrators", f"calib__{self.calibrators_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -614,7 +614,7 @@ class SelectorMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "selector", f"sel__{self.selector_repr}")
+        parts.insert_after(self.config_store_anchor, "selector", f"sel__{self.selector_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -911,7 +911,7 @@ class ProducerMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "producer", f"prod__{self.producer_repr}")
+        parts.insert_after(self.config_store_anchor, "producer", f"prod__{self.producer_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -1120,7 +1120,7 @@ class ProducersMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "producers", f"prod__{self.producers_repr}")
+        parts.insert_after(self.config_store_anchor, "producers", f"prod__{self.producers_repr}")
         return parts
 
     def find_keep_columns(self, collection: ColumnCollection) -> set[Route]:
@@ -1576,10 +1576,10 @@ class MLModelTrainingMixin(MLModelMixinBase):
             if len(fct_names) > 2:
                 part += f"_{n_fct_per_config}_{law.util.create_hash(fct_names[2:])}"
 
-            parts.insert_after(self.store_part_anchor, label, f"{label}__{part}")
+            parts.insert_after(self.config_store_anchor, label, f"{label}__{part}")
 
         if self.ml_model_inst:
-            parts.insert_after(self.store_part_anchor, "ml_model", f"ml__{self.ml_model_repr}")
+            parts.insert_after(self.config_store_anchor, "ml_model", f"ml__{self.ml_model_repr}")
 
         return parts
 
@@ -1647,7 +1647,7 @@ class MLModelMixin(ConfigTask, MLModelMixinBase):
         parts = super().store_parts()
 
         if self.ml_model_inst:
-            parts.insert_after(self.store_part_anchor, "ml_model", f"ml__{self.ml_model_repr}")
+            parts.insert_after(self.config_store_anchor, "ml_model", f"ml__{self.ml_model_repr}")
 
         return parts
 
@@ -1672,7 +1672,7 @@ class MLModelDataMixin(MLModelMixin):
 
         # replace the ml_model entry
         store_name = self.ml_model_inst.store_name or self.ml_model_repr
-        parts.insert_after(self.store_part_anchor, "ml_data", f"ml__{store_name}")
+        parts.insert_after(self.config_store_anchor, "ml_data", f"ml__{store_name}")
         parts.pop("ml_model")
 
         return parts
@@ -1756,7 +1756,7 @@ class MLModelsMixin(ConfigTask):
         parts = super().store_parts()
 
         if self.ml_model_insts:
-            parts.insert_after(self.store_part_anchor, "ml_models", f"ml__{self.ml_models_repr}")
+            parts.insert_after(self.config_store_anchor, "ml_models", f"ml__{self.ml_models_repr}")
 
         return parts
 
@@ -1825,7 +1825,7 @@ class InferenceModelMixin(ConfigTask):
         parts = super().store_parts()
 
         if self.inference_model != law.NO_STR:
-            parts.insert_after(self.store_part_anchor, "inf_model", f"inf__{self.inference_model_repr}")
+            parts.insert_after(self.config_store_anchor, "inf_model", f"inf__{self.inference_model_repr}")
 
         return parts
 
@@ -2273,7 +2273,7 @@ class WeightProducerMixin(ConfigTask):
         :return: Dictionary with parts that will be translated into an output directory path.
         """
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "weightprod", f"weight__{self.weight_producer_repr}")
+        parts.insert_after(self.config_store_anchor, "weightprod", f"weight__{self.weight_producer_repr}")
         return parts
 
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -415,7 +415,6 @@ class PlotBase2D(PlotBase):
 class ProcessPlotSettingMixin(
     PlotBase,
     DatasetsProcessesMixin,
-    PlotBase,
 ):
     """
     Mixin class for tasks creating plots where contributions of different processes are shown.

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -315,10 +315,11 @@ class PlotBase1D(PlotBase):
         description="when True, each process is normalized on it's integral in the upper panel; "
         "default: None",
     )
-    hide_errors = law.OptionalBoolParameter(
+    hide_stat_errors = law.OptionalBoolParameter(
         default=None,
         significant=False,
-        description="when True, no error bars/bands on histograms are drawn; default: None",
+        description="when True, no error bands for statistical uncertainty histograms are drawn; "
+        "default: None",
     )
 
     def get_plot_parameters(self) -> DotDict:
@@ -328,7 +329,7 @@ class PlotBase1D(PlotBase):
         dict_add_strict(params, "density", self.density)
         dict_add_strict(params, "yscale", None if self.yscale == law.NO_STR else self.yscale)
         dict_add_strict(params, "shape_norm", self.shape_norm)
-        dict_add_strict(params, "hide_errors", self.hide_errors)
+        dict_add_strict(params, "hide_stat_errors", self.hide_stat_errors)
         return params
 
 

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -413,6 +413,7 @@ class PlotBase2D(PlotBase):
 
 
 class ProcessPlotSettingMixin(
+    PlotBase,
     DatasetsProcessesMixin,
     PlotBase,
 ):
@@ -467,8 +468,8 @@ class ProcessPlotSettingMixin(
 
 
 class VariablePlotSettingMixin(
-        VariablesMixin,
-        PlotBase,
+    PlotBase,
+    VariablesMixin,
 ):
     """
     Mixin class for tasks creating plots for multiple variables.

--- a/columnflow/tasks/framework/remote_bootstrap.sh
+++ b/columnflow/tasks/framework/remote_bootstrap.sh
@@ -35,10 +35,12 @@ bootstrap_htcondor_standalone() {
 
     # fix for missing voms/x509 variables in the lcg setup of the naf
     if [[ "${CF_HTCONDOR_FLAVOR}" = naf* ]]; then
+        echo "setting up X509 variables for ${CF_HTCONDOR_FLAVOR}"
         export X509_CERT_DIR="/cvmfs/grid.cern.ch/etc/grid-security/certificates"
         export X509_VOMS_DIR="/cvmfs/grid.cern.ch/etc/grid-security/vomsdir"
         export X509_VOMSES="/cvmfs/grid.cern.ch/etc/grid-security/vomses"
         export VOMS_USERCONF="/cvmfs/grid.cern.ch/etc/grid-security/vomses"
+        export CAPATH="/cvmfs/grid.cern.ch/etc/grid-security/certificates"
     fi
 
     # fallback to a default path when the externally given software base is empty or inaccessible

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -24,12 +24,12 @@ from columnflow.hist_util import create_hist_from_variables
 
 
 class CreateHistograms(
-    VariablesMixin,
-    WeightProducerMixin,
-    MLModelsMixin,
-    ProducersMixin,
     ReducedEventsUser,
     ChunkedIOMixin,
+    ProducersMixin,
+    MLModelsMixin,
+    WeightProducerMixin,
+    VariablesMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -287,13 +287,13 @@ CreateHistogramsWrapper = wrapper_factory(
 
 
 class MergeHistograms(
-    VariablesMixin,
-    WeightProducerMixin,
-    MLModelsMixin,
-    ProducersMixin,
-    SelectorStepsMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorStepsMixin,
+    ProducersMixin,
+    MLModelsMixin,
+    WeightProducerMixin,
+    VariablesMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -406,14 +406,14 @@ MergeHistogramsWrapper = wrapper_factory(
 
 
 class MergeShiftedHistograms(
-    VariablesMixin,
-    ShiftSourcesMixin,
-    WeightProducerMixin,
-    MLModelsMixin,
-    ProducersMixin,
-    SelectorStepsMixin,
-    CalibratorsMixin,
     DatasetTask,
+    ShiftSourcesMixin,
+    CalibratorsMixin,
+    SelectorStepsMixin,
+    ProducersMixin,
+    MLModelsMixin,
+    WeightProducerMixin,
+    VariablesMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -433,9 +433,6 @@ class MergeShiftedHistograms(
         MergeHistograms=MergeHistograms,
     )
 
-    # the field in the store parts behind which the new part is inserted
-    store_part_anchor = "dataset"
-
     def create_branch_map(self):
         # create a dummy branch map so that this task could as a job
         return {0: None}
@@ -457,7 +454,7 @@ class MergeShiftedHistograms(
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
-        parts.insert_after(self.store_part_anchor, "shift_sources", f"shifts_{self.shift_sources_repr}")
+        parts.insert_after("dataset", "shift_sources", f"shifts_{self.shift_sources_repr}")
         return parts
 
     def output(self):

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -305,7 +305,7 @@ class MergeHistograms(
     remove_previous = luigi.BoolParameter(
         default=False,
         significant=False,
-        description="when True, remove particlar input histograms after merging; default: False",
+        description="when True, remove particular input histograms after merging; default: False",
     )
 
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
@@ -334,7 +334,7 @@ class MergeHistograms(
 
         # optional dynamic behavior: determine not yet created variables and require only those
         if self.only_missing:
-            missing = self.output().count(existing=False, keys=True)[1]
+            missing = self.output()["hists"].count(existing=False, keys=True)[1]
             variables = sorted(missing, key=variables.index)
 
         return variables

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -433,6 +433,9 @@ class MergeShiftedHistograms(
         MergeHistograms=MergeHistograms,
     )
 
+    # the field in the store parts behind which the new part is inserted
+    store_part_anchor = "dataset"
+
     def create_branch_map(self):
         # create a dummy branch map so that this task could as a job
         return {0: None}
@@ -454,7 +457,7 @@ class MergeShiftedHistograms(
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
-        parts.insert_after("dataset", "shift_sources", f"shifts_{self.shift_sources_repr}")
+        parts.insert_after(self.store_part_anchor, "shift_sources", f"shifts_{self.shift_sources_repr}")
         return parts
 
     def output(self):

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -35,10 +35,10 @@ ak = maybe_import("awkward")
 
 
 class PrepareMLEvents(
-    MLModelDataMixin,
-    ProducersMixin,
-    ChunkedIOMixin,
     ReducedEventsUser,
+    ChunkedIOMixin,
+    ProducersMixin,
+    MLModelDataMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -296,13 +296,12 @@ PrepareMLEventsWrapper = wrapper_factory(
 
 
 class MergeMLStats(
-    MLModelDataMixin,
-    ProducersMixin,
-    SelectorMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorMixin,
+    ProducersMixin,
+    MLModelDataMixin,
     law.LocalWorkflow,
-    RemoteWorkflow,
 ):
 
     # upstream requirements
@@ -365,11 +364,11 @@ MergeMLStatsWrapper = wrapper_factory(
 
 
 class MergeMLEvents(
-    MLModelDataMixin,
-    ProducersMixin,
-    SelectorMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorMixin,
+    ProducersMixin,
+    MLModelDataMixin,
     law.tasks.ForestMerge,
     RemoteWorkflow,
 ):
@@ -589,10 +588,10 @@ class MLTraining(
 
 
 class MLEvaluation(
-    MLModelMixin,
-    ProducersMixin,
-    ChunkedIOMixin,
     ReducedEventsUser,
+    ChunkedIOMixin,
+    ProducersMixin,
+    MLModelMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -854,11 +853,11 @@ MLEvaluationWrapper = wrapper_factory(
 
 
 class MergeMLEvaluation(
-    MLModelMixin,
-    ProducersMixin,
-    SelectorMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorMixin,
+    ProducersMixin,
+    MLModelMixin,
     law.tasks.ForestMerge,
     RemoteWorkflow,
 ):
@@ -914,11 +913,11 @@ MergeMLEvaluationWrapper = wrapper_factory(
 
 class PlotMLResultsBase(
     ProcessPlotSettingMixin,
-    CategoriesMixin,
-    MLModelMixin,
-    ProducersMixin,
-    SelectorStepsMixin,
     CalibratorsMixin,
+    SelectorStepsMixin,
+    ProducersMixin,
+    MLModelMixin,
+    CategoriesMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -26,15 +26,15 @@ from columnflow.util import DotDict, dev_sandbox, dict_add_strict
 
 
 class PlotVariablesBase(
-    HistHookMixin,
-    VariablePlotSettingMixin,
-    ProcessPlotSettingMixin,
-    CategoriesMixin,
+    CalibratorsMixin,
+    SelectorStepsMixin,
+    ProducersMixin,
     MLModelsMixin,
     WeightProducerMixin,
-    ProducersMixin,
-    SelectorStepsMixin,
-    CalibratorsMixin,
+    CategoriesMixin,
+    ProcessPlotSettingMixin,
+    VariablePlotSettingMixin,
+    HistHookMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -62,9 +62,7 @@ class PlotVariablesBase(
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
-
         reqs["merged_hists"] = self.requires_from_branch()
-
         return reqs
 
     @abstractmethod
@@ -193,8 +191,8 @@ class PlotVariablesBase(
 
 
 class PlotVariablesBaseSingleShift(
-    PlotVariablesBase,
     ShiftTask,
+    PlotVariablesBase,
 ):
     exclude_index = True
 
@@ -276,8 +274,8 @@ class PlotVariables2D(
 
 
 class PlotVariablesPerProcess2D(
-    law.WrapperTask,
     PlotVariables2D,
+    law.WrapperTask,
 ):
     # force this one to be a local workflow
     workflow = "local"

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -48,7 +48,7 @@ class PlotVariablesBase(
         MergeHistograms=MergeHistograms,
     )
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
         parts.insert_before("version", "datasets", f"datasets_{self.datasets_repr}")
         return parts
@@ -243,7 +243,7 @@ class PlotVariablesBaseSingleShift(
             "plots": [self.target(name) for name in self.get_plot_names("plot")],
         }
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
         if "shift" in parts:
             parts.insert_before("datasets", "shift", parts.pop("shift"))
@@ -346,7 +346,7 @@ class PlotVariablesBaseMultiShifts(
             "plots": [self.target(name) for name in self.get_plot_names("plot")],
         }
 
-    def store_parts(self):
+    def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
         parts.insert_before("datasets", "shifts", f"shifts_{self.shift_sources_repr}")
         return parts

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -17,9 +17,9 @@ from columnflow.util import dev_sandbox
 
 
 class ProduceColumns(
-    ProducerMixin,
-    ChunkedIOMixin,
     ReducedEventsUser,
+    ChunkedIOMixin,
+    ProducerMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -30,10 +30,10 @@ default_keep_reduced_events = law.config.get_expanded("analysis", "default_keep_
 
 
 class ReduceEvents(
-    SelectorStepsMixin,
-    CalibratorsMixin,
-    ChunkedIOMixin,
     DatasetTask,
+    ChunkedIOMixin,
+    CalibratorsMixin,
+    SelectorStepsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -259,9 +259,9 @@ ReduceEventsWrapper = wrapper_factory(
 
 
 class MergeReductionStats(
-    SelectorStepsMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorStepsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -413,9 +413,9 @@ MergeReductionStatsWrapper = wrapper_factory(
 
 
 class MergeReducedEvents(
-    SelectorStepsMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorStepsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -500,9 +500,9 @@ MergeReducedEventsWrapper = wrapper_factory(
 
 
 class ProvideReducedEvents(
-    SelectorStepsMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorStepsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -638,9 +638,9 @@ ProvideReducedEventsWrapper = wrapper_factory(
 
 
 class ReducedEventsUser(
-    SelectorStepsMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorStepsMixin,
     law.BaseWorkflow,
 ):
     # upstream requirements

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -32,10 +32,10 @@ default_create_selection_hists = law.config.get_expanded_bool(
 
 
 class SelectEvents(
-    SelectorMixin,
-    CalibratorsMixin,
-    ChunkedIOMixin,
     DatasetTask,
+    ChunkedIOMixin,
+    CalibratorsMixin,
+    SelectorMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -287,9 +287,9 @@ SelectEventsWrapper = wrapper_factory(
 
 
 class MergeSelectionStats(
-    SelectorMixin,
-    CalibratorsMixin,
     DatasetTask,
+    CalibratorsMixin,
+    SelectorMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
@@ -366,10 +366,10 @@ MergeSelectionStatsWrapper = wrapper_factory(
 
 
 class MergeSelectionMasks(
-    SelectorMixin,
-    CalibratorsMixin,
     DatasetTask,
-    law.tasks.ForestMerge,
+    CalibratorsMixin,
+    SelectorMixin,
+    law.LocalWorkflow,
     RemoteWorkflow,
 ):
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -17,10 +17,10 @@ from columnflow.util import dev_sandbox
 
 
 class UniteColumns(
-    MLModelsMixin,
-    ProducersMixin,
-    ChunkedIOMixin,
     ReducedEventsUser,
+    ChunkedIOMixin,
+    ProducersMixin,
+    MLModelsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):

--- a/columnflow/tasks/yields.py
+++ b/columnflow/tasks/yields.py
@@ -22,12 +22,12 @@ from columnflow.util import dev_sandbox, try_int
 
 
 class CreateYieldTable(
+    CalibratorsMixin,
+    SelectorStepsMixin,
+    ProducersMixin,
+    WeightProducerMixin,
     DatasetsProcessesMixin,
     CategoriesMixin,
-    WeightProducerMixin,
-    ProducersMixin,
-    SelectorStepsMixin,
-    CalibratorsMixin,
     law.LocalWorkflow,
     RemoteWorkflow,
 ):


### PR DESCRIPTION
MergeHistograms fails as of now when using the only_missing argument due to an error in the lookup in the dictionary structure. This PR fixes that.