### PR TITLE
correct path only_missing looks for in MergeHistograms

### DIFF
--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -305,7 +305,7 @@ class MergeHistograms(
     remove_previous = luigi.BoolParameter(
         default=False,
         significant=False,
-        description="when True, remove particlar input histograms after merging; default: False",
+        description="when True, remove particular input histograms after merging; default: False",
     )
 
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
@@ -334,7 +334,7 @@ class MergeHistograms(
 
         # optional dynamic behavior: determine not yet created variables and require only those
         if self.only_missing:
-            missing = self.output().count(existing=False, keys=True)[1]
+            missing = self.output()["hists"].count(existing=False, keys=True)[1]
             variables = sorted(missing, key=variables.index)
 
         return variables


### PR DESCRIPTION
MergeHistograms fails as of now when using the only_missing argument due to an error in the lookup in the dictionary structure. This PR fixes that.