### PR TITLE
prioritise custom style config via command line

### DIFF
--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -271,7 +271,7 @@ class PlotBase(ConfigTask):
         # update style_config
         style_config = kwargs.get("style_config", {})
         if isinstance(custom_style_config, dict) and isinstance(style_config, dict):
-            style_config = law.util.merge_dicts(custom_style_config, style_config)
+            style_config = law.util.merge_dicts(style_config, custom_style_config)
             kwargs["style_config"] = style_config
 
         # update other defaults


### PR DESCRIPTION
Style configs hard coded in the tasks were given priority over command line specified style configs (defined via the custom style config groups). Reversed this situation to give more control via command line.

see also issue #616 