### PR TITLE
Cleanup top pt weight producer.

### DIFF
--- a/columnflow/production/cms/top_pt_weight.py
+++ b/columnflow/production/cms/top_pt_weight.py
@@ -171,6 +171,6 @@ def top_pt_weight_skip(self: Producer, **kwargs) -> bool:
     Skip if running on anything except ttbar MC simulation, evaluated via the :py:attr:`require_dataset_tag` attribute.
     """
     if self.require_dataset_tag is None:
-        return False
+        return self.dataset_inst.is_data
 
     return self.dataset_inst.is_data or not self.dataset_inst.has_tag("is_ttbar")


### PR DESCRIPTION
This PR cleans up the CMS-specific top-pt weight producer.

- Minor code refactoring
- Remove skip functions since the required tags such as "has_top" or "is_ttbar" are analysis-specific and whether the producers are called or not should be decided elsewhere.
- Added TopPtWeightConfig with configurable params and pt cutoff for consistency with other producers (fully backwards compatible).
- Added reference to Twiki.