### PR TITLE
Fix bugs in the cms_minimal analysis template

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/calibration/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/calibration/example.py
@@ -16,7 +16,7 @@ ak = maybe_import("awkward")
 @calibrator(
     uses={
         deterministic_seeds,
-        "Jet.pt", "Jet.mass",
+        "Jet.{pt,eta,phi,mass}",
     },
     produces={
         deterministic_seeds,

--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -95,7 +95,7 @@ dataset_names = [
     # backgrounds
     "tt_sl_powheg",
     # signals
-    "st_tchannel_t_powheg",
+    "st_tchannel_t_4f_powheg",
 ]
 for dataset_name in dataset_names:
     # add the dataset
@@ -230,7 +230,7 @@ cfg.add_shift(name="mu_down", id=11, type="shape")
 add_shift_aliases(cfg, "mu", {"muon_weight": "muon_weight_{direction}"})
 
 # external files
-json_mirror = "/afs/cern.ch/work/m/mrieger/public/mirrors/jsonpog-integration-9ea86c4c"
+json_mirror = "/afs/cern.ch/work/m/mrieger/public/mirrors/jsonpog-integration-377439e8"
 cfg.x.external_files = DotDict.wrap({
     # lumi files
     "lumi": {

--- a/analysis_templates/cms_minimal/__cf_module_name__/inference/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/inference/example.py
@@ -38,7 +38,7 @@ def example(self):
         "ST",
         is_signal=True,
         config_process="st",
-        config_mc_datasets=["st_tchannel_t_powheg"],
+        config_mc_datasets=["st_tchannel_t_4f_powheg"],
     )
     self.add_process(
         "TT",

--- a/analysis_templates/cms_minimal/__cf_module_name__/ml/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/ml/example.py
@@ -40,7 +40,7 @@ class ExampleModel(MLModel):
 
     def datasets(self, config_inst: od.Config) -> set[od.Dataset]:
         return {
-            config_inst.get_dataset("st_tchannel_t_powheg"),
+            config_inst.get_dataset("st_tchannel_t_4f_powheg"),
             config_inst.get_dataset("tt_sl_powheg"),
         }
 

--- a/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
@@ -26,7 +26,7 @@ ak = maybe_import("awkward")
 
 
 @selector(
-    uses={"Muon.pt", "Muon.eta"},
+    uses={"Muon.{pt,eta,phi,mass}"},
 )
 def muon_selection(
     self: Selector,
@@ -53,7 +53,7 @@ def muon_selection(
 
 
 @selector(
-    uses={"Jet.pt", "Jet.eta"},
+    uses={"Muon.{pt,eta,phi,mass}"},
 )
 def jet_selection(
     self: Selector,

--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -25,7 +25,7 @@ columnflow.columnar_util-perf: INFO
 
 default_analysis: __cf_module_name__.config.analysis___cf_short_name_lc__.analysis___cf_short_name_lc__
 default_config: run2_2017_nano_v9
-default_dataset: st_tchannel_t_powheg
+default_dataset: st_tchannel_t_4f_powheg
 
 calibration_modules: columnflow.calibration.cms.{jets,met,tau}, __cf_module_name__.calibration.example
 selection_modules: columnflow.selection.{empty}, columnflow.selection.cms.{json_filter,met_filters}, __cf_module_name__.selection.example


### PR DESCRIPTION
* The st_tchannel_t_powheg dataset was renamed to st_tchannel_t_4f_powheg in cmsdb
* Add missing requirements for {Jet,Muon}.{eta,phi} ("coffea issue")
* Update the JSONPOG mirror tag to a working version