### PR TITLE
Fix/template issues

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/plotting/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/plotting/example.py
@@ -34,7 +34,7 @@ def my_plot1d_func(
     variable_settings: dict | None = None,
     example_param: str | float | bool | None = None,
     **kwargs,
-) -> tuple(plt.Figure, tuple(plt.Axis)):
+) -> tuple[plt.Figure, tuple[plt.Axis]]:
     """
     This is an exemplary custom plotting function.
 

--- a/analysis_templates/cms_minimal/__cf_module_name__/plotting/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/plotting/example.py
@@ -34,7 +34,7 @@ def my_plot1d_func(
     variable_settings: dict | None = None,
     example_param: str | float | bool | None = None,
     **kwargs,
-) -> tuple(plt.Figure, tuple(plt.Axis,)):
+) -> tuple(plt.Figure, tuple(plt.Axis)):
     """
     This is an exemplary custom plotting function.
 

--- a/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.selection.stats import increment_stats
-from columnflow.selection.util import sorted_indices_from_mask
+from columnflow.columnar_util import sorted_indices_from_mask
 from columnflow.production.processes import process_ids
 from columnflow.production.cms.mc_weight import mc_weight
 from columnflow.util import maybe_import
@@ -53,7 +53,7 @@ def muon_selection(
 
 
 @selector(
-    uses={"Muon.{pt,eta,phi,mass}"},
+    uses={"Jet.{pt,eta,phi,mass}"},
 )
 def jet_selection(
     self: Selector,

--- a/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/selection/example.py
@@ -81,6 +81,7 @@ def jet_selection(
         },
     )
 
+
 @jet_selection.init
 def jet_selection_init(self: Selector) -> None:
     # register shifts
@@ -94,6 +95,7 @@ def jet_selection_init(self: Selector) -> None:
 # exposed selectors
 # (those that can be invoked from the command line)
 #
+
 
 @selector(
     uses={

--- a/analysis_templates/cms_minimal/sandboxes/example.txt
+++ b/analysis_templates/cms_minimal/sandboxes/example.txt
@@ -1,8 +1,8 @@
 # version 1
 
-git+https://github.com/CoffeaTeam/coffea.git@b9356b9#egg=coffea
-awkward~=2.0
-dask-awkward~=2023.1
-uproot~=5.0
-tabulate~=0.9
-tensorflow~=2.11
+# use packages from columnar sandbox as baseline
+-r ../modules/columnflow/sandboxes/columnar.txt
+
+# add numpy and tensorflow with exact version requirement
+numpy==1.26.4
+tensorflow==2.11.0

--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -85,8 +85,8 @@ def muon_weights(
     subset of muons.
     """
     # flat absolute eta and pt views
-    abs_eta = flat_np_view(abs(events.Muon.eta[muon_mask]), axis=1)
-    pt = flat_np_view(events.Muon.pt[muon_mask], axis=1)
+    abs_eta = flat_np_view(abs(events.Muon["eta"][muon_mask]), axis=1)
+    pt = flat_np_view(events.Muon["pt"][muon_mask], axis=1)
 
     variable_map = {
         "year": self.muon_config.campaign,
@@ -111,7 +111,7 @@ def muon_weights(
         sf_flat = self.muon_sf_corrector(*inputs)
 
         # add the correct layout to it
-        sf = layout_ak_array(sf_flat, events.Muon.pt[muon_mask])
+        sf = layout_ak_array(sf_flat, events.Muon["pt"][muon_mask])
 
         # create the product over all muons in one event
         weight = ak.prod(sf, axis=1, mask_identity=False)

--- a/sandboxes/ml_tf.txt
+++ b/sandboxes/ml_tf.txt
@@ -1,5 +1,8 @@
-# version 9
+# version 10
 
+# use packages from columnar sandbox as baseline
 -r columnar.txt
 
-tensorflow~=2.11.0
+# add numpy and tensorflow with exact version requirement
+numpy==1.26.4
+tensorflow==2.11.0


### PR DESCRIPTION
- minor linter fixes
- The `example` sandbox did not work due to a coffea commit that does no longer exist. I changed the example sandbox to the same as `ml_tf`. Closes #633 
- The `ml_tf` sandbox installs tf 2.11 in combination with numpy 2.x, which does not compile. I therefore pinned exact versions of tf 2.11 and np 2.16.4, but we could also pin different tf versions (tf 2.12 correctly installs np < 2 and tf 2.18 would be compatible with np 2.x)
- I fixed the bug in `muon.py` that is raised when coffea behaviour is attached but not all muon columns are required by not using the behaviour at all (changing `muon.pt` to `muon["pt"]` etc.). Closes #626 
- I also added an example producer that uses coffea behaviour