### PR TITLE
Fix TAF post init order

### DIFF
--- a/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
+++ b/analysis_templates/cms_minimal/__cf_module_name__/config/analysis___cf_short_name_lc__.py
@@ -111,13 +111,14 @@ for dataset_name in dataset_names:
 # verify that the root process of all datasets is part of any of the registered processes
 verify_config_processes(cfg, warn=True)
 
-# default objects, such as calibrator, selector, producer, ml model, inference model, etc
-ana.x.default_calibrator = "example"
-ana.x.default_selector = "example"
-ana.x.default_producer = "example"
-ana.x.default_weight_producer = "example"
-ana.x.default_ml_model = None
-ana.x.default_inference_model = "example"
+# default objects, such as calibrator, selector, reducer, producer, ml model, inference model, etc
+cfg.x.default_calibrator = "example"
+cfg.x.default_selector = "example"
+cfg.x.default_selector_steps = []
+cfg.x.default_producer = "example"
+cfg.x.default_weight_producer = "example"
+cfg.x.default_ml_model = None
+cfg.x.default_inference_model = "example"
 cfg.x.default_categories = ("incl",)
 cfg.x.default_variables = ("n_jet", "jet1_pt")
 

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -1081,7 +1081,7 @@ class ConfigTask(AnalysisTask):
     )
     configs = law.CSVParameter(
         default=(default_config,),
-        description=f"names of analysis configs to use; default: '{default_config}'",
+        description=f"comma-separated names of analysis configs to use; default: '{default_config}'",
         brace_expand=True,
     )
     known_shifts = luigi.Parameter(

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -93,7 +93,7 @@ class CalibratorClassMixin(ArrayFunctionClassMixin):
         """
         Return a string representation of the calibrator class.
         """
-        return self.array_function_cls_repr(self.calibrator, Calibrator)
+        return self.array_function_cls_repr(self.calibrator)
 
     def store_parts(self) -> law.util.InsertableDict:
         """

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -411,7 +411,7 @@ class SelectorClassMixin(ArrayFunctionClassMixin):
         "'default_selector' analysis aux",
     )
     selector_steps = law.CSVParameter(
-        default=(),
+        default=(RESOLVE_DEFAULT,),
         description="a subset of steps of the selector to apply; uses all steps when empty; "
         "default: empty",
         brace_expand=True,

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -33,7 +33,7 @@ logger_dev = law.logger.get_logger(f"{__name__}-dev")
 
 class ArrayFunctionClassMixin(ConfigTask):
 
-    def array_function_cls_repr(self, array_function) -> None:
+    def array_function_cls_repr(self, array_function) -> str:
         """
         Central definition of how to obtain representation of array function from the name
 
@@ -203,8 +203,8 @@ class CalibratorMixin(ArrayFunctionInstanceMixin, CalibratorClassMixin):
             self.reset_sandbox(sandbox)
 
     def _array_function_post_init(self, **kwargs) -> None:
-        super()._array_function_post_init(**kwargs)
         self.calibrator_inst.run_post_init(task=self, **kwargs)
+        super()._array_function_post_init(**kwargs)
 
     @property
     def calibrator_repr(self) -> str:
@@ -365,9 +365,9 @@ class CalibratorsMixin(ArrayFunctionInstanceMixin, CalibratorClassesMixin):
         super().get_known_shifts(params, shifts)
 
     def _array_function_post_init(self, **kwargs) -> None:
-        super()._array_function_post_init(**kwargs)
         for calibrator_inst in self.calibrator_insts or []:
             calibrator_inst.run_post_init(task=self, **kwargs)
+        super()._array_function_post_init(**kwargs)
 
     @property
     def calibrators_repr(self) -> str:
@@ -411,7 +411,7 @@ class SelectorClassMixin(ArrayFunctionClassMixin):
         "'default_selector' analysis aux",
     )
     selector_steps = law.CSVParameter(
-        default=(RESOLVE_DEFAULT,),
+        default=(),
         description="a subset of steps of the selector to apply; uses all steps when empty; "
         "default: empty",
         brace_expand=True,
@@ -578,8 +578,8 @@ class SelectorMixin(ArrayFunctionInstanceMixin, SelectorClassMixin):
             self.reset_sandbox(sandbox)
 
     def _array_function_post_init(self, **kwargs) -> None:
-        super()._array_function_post_init(**kwargs)
         self.selector_inst.run_post_init(task=self, **kwargs)
+        super()._array_function_post_init(**kwargs)
 
     @property
     def selector_repr(self) -> str:
@@ -759,8 +759,8 @@ class ProducerMixin(ArrayFunctionInstanceMixin, ProducerClassMixin):
             self.reset_sandbox(sandbox)
 
     def _array_function_post_init(self, **kwargs) -> None:
-        super()._array_function_post_init(**kwargs)
         self.producer_inst.run_post_init(task=self, **kwargs)
+        super()._array_function_post_init(**kwargs)
 
     @property
     def producer_repr(self) -> str:
@@ -921,9 +921,9 @@ class ProducersMixin(ArrayFunctionInstanceMixin, ProducerClassesMixin):
         super().get_known_shifts(params, shifts)
 
     def _array_function_post_init(self, **kwargs) -> None:
-        super()._array_function_post_init(**kwargs)
         for producer_inst in self.producer_insts or []:
             producer_inst.run_post_init(task=self, **kwargs)
+        super()._array_function_post_init(**kwargs)
 
     @property
     def producers_repr(self) -> str:
@@ -1535,8 +1535,8 @@ class WeightProducerMixin(ArrayFunctionInstanceMixin, WeightProducerClassMixin):
             self.reset_sandbox(sandbox)
 
     def _array_function_post_init(self, **kwargs) -> None:
-        super()._array_function_post_init(**kwargs)
         self.weight_producer_inst.run_post_init(task=self, **kwargs)
+        super()._array_function_post_init(**kwargs)
 
     @property
     def weight_producer_repr(self) -> str:


### PR DESCRIPTION
With this change, the order of post_init calls is

- calibrator(s)
- selector
- producer(s)
- weight_producer

as intended and also as used by e.g. `resolve_instances`.