### PR TITLE
typo on inference task

### DIFF
--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -305,10 +305,10 @@ class CreateDatacards(
                     if not self.inference_model_inst.require_shapes_for_parameter(param_obj):
                         continue
                     # store the varied hists
-                    datacard_hists[proc_obj_name][param_obj.name] = {}
+                    datacard_hists[proc_obj.name][param_obj.name] = {}
                     for d in ["up", "down"]:
                         shift_inst = self.config_inst.get_shift(f"{param_obj.config_shift_source}_{d}")
-                        datacard_hists[proc_obj_name][param_obj.name][d] = h_proc[
+                        datacard_hists[proc_obj.name][param_obj.name][d] = h_proc[
                             {"shift": hist.loc(shift_inst.id)}
                         ]
 


### PR DESCRIPTION
There is a typo in the `cf.CreateDatacards` task that causes the task not to work.

Fix:
- replace ´proc_obj_name´ with ´proc_obj.name´ in L307 & L310