### PR TITLE
Use process names in hist axes.

### DIFF
--- a/columnflow/histograming/default.py
+++ b/columnflow/histograming/default.py
@@ -70,10 +70,13 @@ def cf_default_post_process_hist(self: HistProducer, h: hist.Histogram, task: la
     """
     axis_names = {ax.name for ax in h.axes}
 
-    # translate category and shift integers to strings
+    # translate axes
     if "category" in axis_names:
         category_map = {cat.id: cat.name for cat in self.config_inst.get_leaf_categories()}
         h = translate_hist_intcat_to_strcat(h, "category", category_map)
+    if "process" in axis_names:
+        process_map = {proc_id: self.config_inst.get_process(proc_id).name for proc_id in h.axes["process"]}
+        h = translate_hist_intcat_to_strcat(h, "process", process_map)
     if "shift" in axis_names:
         shift_map = {task.global_shift_inst.id: task.global_shift_inst.name}
         h = translate_hist_intcat_to_strcat(h, "shift", shift_map)

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -67,7 +67,7 @@ class CreateHistograms(_CreateHistograms):
         expected = {
             "category": hist.axis.StrCategory,
             "shift": hist.axis.StrCategory,
-            "process": hist.axis.IntCategory,
+            "process": hist.axis.StrCategory,
         }
         axes = {ax.name: ax for ax in h.axes}
         for axis_name, axis_type in expected.items():

--- a/docs/user_guide/02_03_transition.md
+++ b/docs/user_guide/02_03_transition.md
@@ -157,7 +157,7 @@ In short, histogram producers [continue to be task array functions](./task_array
 - `post_process_hist(self, h: hist.Histogram, task: law.Task) -> hist.Histogram`: After all data was filled in `cf.CreateHistogram`, allows to change the histogram before it is saved to disk.
 - `post_process_merged_hist(self, h: hist.Histogram, task: law.Task) -> hist.Histogram`: Invoked by `cf.MergeHistograms`, allows to change the merged histogram before it is saved for subsequent processing.
 
-The only requirement that columnflow imposes on histograms for plotting and export as part of statistical models is the existence of axes `"category"` (str), `"process"` (int) and `"shift"` (str) **after** merging.
+The only requirement that columnflow imposes on histograms for plotting and export as part of statistical models is the existence of categorical (string) axes `"category"`, `"process"` and `"shift"` **after** merging.
 
 The main callable of a histogram producer continues to be responsible for returning (and potentially preprocessing) the event chunk to histogram, as well as a float array representing event weights in a 2-tuple, consistent with the previous behavior of weight producers.
 


### PR DESCRIPTION
This PR applies the same id-to-name conversion to the "process" axis if histograms that is already in place for "category" and "shift".

I updated the docs accordingly, and also adapted the `get_config_process_map` lookup method.