### PR TITLE
CMS jet id producer

### DIFF
--- a/columnflow/production/cms/jet.py
+++ b/columnflow/production/cms/jet.py
@@ -1,18 +1,176 @@
 # coding: utf-8
 
 """
-Jet-related quantities
+Jet-related producers.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+import law
+
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import
-from columnflow.columnar_util import set_ak_column
+from columnflow.util import maybe_import, load_correction_set
+from columnflow.columnar_util import set_ak_column, layout_ak_array, flat_np_view
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
-coffea = maybe_import("coffea")
+
+
+@dataclass
+class JetIdConfig:
+    """
+    Container object to describe a CMS jet id configuration, consisting of names of correction sets mapped to bit
+    positions, similar to how the ``jetId`` column is defined in nanoAOD. Example:
+
+    .. code-block:: python
+
+        # configurtion for AK4 puppi jets
+        # second bit for "tight" id, third bit for "tight + lepton veto" id
+        JetIdConfig(corrections={
+            "AK4PUPPI_Tight": 2,
+            "AK4PUPPI_TightLeptonVeto": 3,
+        })
+    """
+
+    corrections: dict[str, int]
+
+    def __post_init__(self) -> None:
+        # for each correction, check if the bit fits into a uint8
+        for cor_name, bit in self.corrections.items():
+            if not (0 <= bit <= 8):
+                raise ValueError(f"jet id bit must be between 0 and 8, got {bit} for {cor_name}")
+
+
+@producer(
+    # names of used and produced columns are added dynamically in init depending on jet_name
+    # only run on mc
+    mc_only=True,
+    # name of the jet collection
+    jet_name="Jet",
+    # function to determine the correction file
+    get_jet_id_file=(lambda self, external_files: external_files.jet_id),
+    # function to determine the jet id config
+    get_jet_id_config=(lambda self: self.config_inst.x.jet_id),
+)
+def jet_id(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
+    """
+    Recomputes the jet id flag. Requires an external file in the config under ``jet_id``. Example:
+
+    .. code-block:: python
+
+        cfg.x.external_files = DotDict.wrap({
+            "jet_id": "/afs/cern.ch/work/m/mrieger/public/mirrors/jsonpog-integration-120c4271/POG/JME/2022_Summer22/jetid.json.gz",  # noqa
+        })
+
+    *get_jet_id_file* can be adapted in a subclass in case it is stored differently in the external files.
+
+    The pairs of correction set names and jet id bits (!) should be configured using the :py:class:`JetIdConfig` as an
+    auxiliary entry in the config:
+
+    .. code-block:: python
+
+        from columnflow.production.cms.jet import JetIdConfig
+        cfg.x.jet_id = JetIdConfig(
+            corrections={
+                "AK4PUPPI_Tight": 2,
+                "AK4PUPPI_TightLeptonVeto": 3,
+            },
+        )
+
+    *get_jet_id_config* can be adapted in a subclass in case it is stored differently in the config.
+
+    Resources:
+
+        - https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV?rev=22#nanoAOD_Flags
+        - https://cms-talk.web.cern.ch/t/bug-in-the-jetid-flag-in-nanov12-and-nanov13/108135
+        - https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/120c4271917f30d67fb64c789eb91f7b52be4845/examples/jetidExample.py
+    """ # noqa
+    # compute flat inputs
+    variable_map = {
+        col: flat_np_view(events[self.jet_name][col], axis=1)
+        for col in self.jet_columns
+    }
+    # sum of multiplicies might be required
+    if "multiplicity" not in variable_map and "chMultiplicity" in variable_map and "neMultiplicity" in variable_map:
+        variable_map["multiplicity"] = variable_map["chMultiplicity"] + variable_map["neMultiplicity"]
+
+    # identify jets for which the evaluation can succeed
+    valid_mask = self.get_valid_mask(variable_map)
+    variable_map = {col: value[valid_mask] for col, value in variable_map.items()}
+
+    # prepare the flat jet id array into which evaluated values will be inserted
+    jet_id_flat = np.zeros(len(valid_mask), dtype=np.uint8)
+
+    # iterate over all correctors
+    for cor_name, pass_bit in self.cfg.corrections.items():
+        inputs = [variable_map[inp.name] for inp in self.jet_id_correctors[cor_name].inputs]
+        id_flag = self.jet_id_correctors[cor_name].evaluate(*inputs).astype(np.uint8)
+        # the flag is either 0 or 1, so shift the bit to the correct position
+        jet_id_flat[valid_mask] |= id_flag << (pass_bit - 1)
+
+    # apply correct layout
+    jet_id = layout_ak_array(jet_id_flat, events[self.jet_name].eta)
+
+    # store them
+    events = set_ak_column(events, f"{self.jet_name}.jetId", jet_id, value_type=np.uint8)
+
+    return events
+
+
+@jet_id.init
+def jet_id_init(self: Producer, **kwargs) -> None:
+    """
+    Dynamically add the names of the used and produced columns depending on the jet name.
+    """
+    self.jet_columns = ["eta", "chHEF", "neHEF", "chEmEF", "neEmEF", "muEF", "chMultiplicity", "neMultiplicity"]
+    self.uses.update(f"{self.jet_name}.{col}" for col in self.jet_columns)
+    self.produces.add(f"{self.jet_name}.jetId")
+
+    # store a lambda to identify good jets (a value of zero will be stored for others)
+    self.get_valid_mask = lambda variable_map: variable_map["chMultiplicity"] >= 0
+
+
+@jet_id.requires
+def jet_id_requires(self: Producer, task: law.Task, reqs: dict, **kwargs) -> None:
+    """
+    Adds the requirements needed the underlying task to recompute the jet id into *reqs*.
+    """
+    if "external_files" in reqs:
+        return
+
+    from columnflow.tasks.external import BundleExternalFiles
+    reqs["external_files"] = BundleExternalFiles.req(task)
+
+
+@jet_id.setup
+def jet_id_setup(
+    self: Producer,
+    task: law.Task,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: law.util.InsertableDict,
+    **kwargs,
+) -> None:
+    """
+    Sets up the correction sets needed for the jet id using the external files.
+    """
+    bundle = reqs["external_files"]
+
+    # get the jet id config
+    self.cfg: JetIdConfig = self.get_jet_id_config()
+
+    # create the correctors
+    correction_set = load_correction_set(self.get_jet_id_file(bundle.files))
+    self.jet_id_correctors = {cor_name: correction_set[cor_name] for cor_name in self.cfg.corrections}
+
+
+# derive with defaults for fatjets
+fatjet_id = jet_id.derive("fatjet_id", cls_dict={
+    "jet_name": "FatJet",
+    "get_jet_id_config": (lambda self: self.config_inst.x.fatjet_id),
+})
 
 
 @producer(
@@ -55,7 +213,7 @@ def msoftdrop(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
     valid_subjets = ak.with_name(
         valid_subjets,
         "PtEtaPhiMLorentzVector",
-        behavior=coffea.nanoevents.NanoAODSchema.behavior(),
+        behavior=self.nano_behavior,
     )
 
     # recompute softdrop mass from LV sum
@@ -98,3 +256,10 @@ def msoftdrop_init(self: Producer, **kwargs) -> None:
 
     # outputs
     self.produces = {f"{self.jet_name}.{self.output_column}"}
+
+
+@msoftdrop.setup
+def msoftdrop_setup(self: Producer, task: law.Task, reqs: dict, **kwargs) -> None:
+    import coffea
+
+    self.nano_behavior = coffea.nanoevents.NanoAODSchema.behavior()

--- a/columnflow/production/cms/jet.py
+++ b/columnflow/production/cms/jet.py
@@ -37,10 +37,10 @@ class JetIdConfig:
     corrections: dict[str, int]
 
     def __post_init__(self) -> None:
-        # for each correction, check if the bit fits into a uint8
+        # for each correction, check if the bit is set and fits into a uint8
         for cor_name, bit in self.corrections.items():
-            if not (0 <= bit <= 8):
-                raise ValueError(f"jet id bit must be between 0 and 8, got {bit} for {cor_name}")
+            if not (1 <= bit <= 8):
+                raise ValueError(f"jet id bit must be between 1 and 8, got {bit} for {cor_name}")
 
 
 @producer(
@@ -128,9 +128,6 @@ def jet_id_init(self: Producer, **kwargs) -> None:
     self.uses.update(f"{self.jet_name}.{col}" for col in self.jet_columns)
     self.produces.add(f"{self.jet_name}.jetId")
 
-    # store a lambda to identify good jets (a value of zero will be stored for others)
-    self.get_valid_mask = lambda variable_map: variable_map["chMultiplicity"] >= 0
-
 
 @jet_id.requires
 def jet_id_requires(self: Producer, task: law.Task, reqs: dict, **kwargs) -> None:
@@ -164,6 +161,9 @@ def jet_id_setup(
     # create the correctors
     correction_set = load_correction_set(self.get_jet_id_file(bundle.files))
     self.jet_id_correctors = {cor_name: correction_set[cor_name] for cor_name in self.cfg.corrections}
+
+    # store a lambda to identify good jets (a value of zero will be stored for others)
+    self.get_valid_mask = lambda variable_map: variable_map["chMultiplicity"] >= 0
 
 
 # derive with defaults for fatjets


### PR DESCRIPTION
This PR adds a producer that recalculates the CMS jet id, which is [required in all recent nano versions](https://cms-talk.web.cern.ch/t/bug-in-the-jetid-flag-in-nanov12-and-nanov13/108135).

The same producer can be used to create the id for every jet type. The centrally provided correctionlib file contains corrections for all jet types and all selection flags. For parity with the original `jetId` column, the `JetIdConfig` could be set to

```python
JetIdConfig(corrections={
    "AK4PUPPI_Tight": 2,
    "AK4PUPPI_TightLeptonVeto": 3,
})
```

for standard AK4 jets.