### PR TITLE
Eager taf teardown when call function fails.

### DIFF
--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -152,7 +152,11 @@ class CalibrateEvents(_CalibrateEvents):
                 events = update_ak_array(events, *cols)
 
                 # just invoke the calibration function
-                events = self.calibrator_inst(events, task=self)
+                try:
+                    events = self.calibrator_inst(events, task=self)
+                except:
+                    self.calibrator_inst.run_teardown(task=self)
+                    raise
 
                 # remove columns
                 events = route_filter(events)

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -10,6 +10,7 @@ import law
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorMixin, ChunkedIOMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.tasks.framework.decorators import on_failure
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox
 
@@ -95,6 +96,7 @@ class CalibrateEvents(_CalibrateEvents):
     @ensure_proxy
     @law.decorator.localize(input=False)
     @law.decorator.safe_output
+    @on_failure(callback=lambda task: task.teardown_calibrator_inst())
     def run(self):
         """
         Run method of this task.
@@ -152,11 +154,7 @@ class CalibrateEvents(_CalibrateEvents):
                 events = update_ak_array(events, *cols)
 
                 # just invoke the calibration function
-                try:
-                    events = self.calibrator_inst(events, task=self)
-                except:
-                    self.calibrator_inst.run_teardown(task=self)
-                    raise
+                events = self.calibrator_inst(events, task=self)
 
                 # remove columns
                 events = route_filter(events)
@@ -171,7 +169,7 @@ class CalibrateEvents(_CalibrateEvents):
                 self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # teardown the calibrator
-        self.calibrator_inst.run_teardown(task=self)
+        self.teardown_calibrator_inst()
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -207,6 +207,10 @@ class CalibratorMixin(ArrayFunctionInstanceMixin, CalibratorClassMixin):
         self.calibrator_inst.run_post_init(task=self, **kwargs)
         super()._array_function_post_init(**kwargs)
 
+    def teardown_calibrator_inst(self) -> None:
+        if self.calibrator_inst:
+            self.calibrator_inst.run_teardown(task=self)
+
     @property
     def calibrator_repr(self) -> str:
         """
@@ -578,6 +582,10 @@ class SelectorMixin(ArrayFunctionInstanceMixin, SelectorClassMixin):
         self.selector_inst.run_post_init(task=self, **kwargs)
         super()._array_function_post_init(**kwargs)
 
+    def teardown_selector_inst(self) -> None:
+        if self.selector_inst:
+            self.selector_inst.run_teardown(task=self)
+
     @property
     def selector_repr(self) -> str:
         """
@@ -771,6 +779,10 @@ class ReducerMixin(ArrayFunctionInstanceMixin, ReducerClassMixin):
         self.reducer_inst.run_post_init(task=self, **kwargs)
         super()._array_function_post_init(**kwargs)
 
+    def teardown_reducer_inst(self) -> None:
+        if self.reducer_inst:
+            self.reducer_inst.run_teardown(task=self)
+
     @property
     def reducer_repr(self) -> str:
         """
@@ -941,6 +953,10 @@ class ProducerMixin(ArrayFunctionInstanceMixin, ProducerClassMixin):
     def _array_function_post_init(self, **kwargs) -> None:
         self.producer_inst.run_post_init(task=self, **kwargs)
         super()._array_function_post_init(**kwargs)
+
+    def teardown_producer_inst(self) -> None:
+        if self.producer_inst:
+            self.producer_inst.run_teardown(task=self)
 
     @property
     def producer_repr(self) -> str:
@@ -1428,6 +1444,10 @@ class PreparationProducerMixin(ArrayFunctionInstanceMixin, MLModelMixin):
 
     build_producer_inst = ProducerMixin.build_producer_inst
 
+    def teardown_preparation_producer_inst(self) -> None:
+        if self.preparation_producer_inst:
+            self.preparation_producer_inst.run_teardown(task=self)
+
     @classmethod
     def resolve_instances(cls, params: dict[str, Any], shifts: TaskShifts) -> dict[str, Any]:
         ml_model_inst = params["ml_model_inst"]
@@ -1718,6 +1738,10 @@ class HistProducerMixin(ArrayFunctionInstanceMixin, HistProducerClassMixin):
     def _array_function_post_init(self, **kwargs) -> None:
         self.hist_producer_inst.run_post_init(task=self, **kwargs)
         super()._array_function_post_init(**kwargs)
+
+    def teardown_hist_producer_inst(self) -> None:
+        if self.hist_producer_inst:
+            self.hist_producer_inst.run_teardown(task=self)
 
     @property
     def hist_producer_repr(self) -> str:

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -237,7 +237,11 @@ class CreateHistograms(_CreateHistograms):
 
                 # invoke the hist producer, potentially updating columns and creating the event weight
                 events = attach_coffea_behavior(events)
-                events, weight = self.hist_producer_inst(events, task=self)
+                try:
+                    events, weight = self.hist_producer_inst(events, task=self)
+                except:
+                    self.hist_producer_inst.run_teardown(task=self)
+                    raise
 
                 # merge category ids and check that they are defined as leaf categories
                 category_ids = ak.concatenate(

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -216,13 +216,17 @@ class PrepareMLEvents(
                 events = set_ak_column(events, "fold_indices", events.deterministic_seed % self.ml_model_inst.folds)
                 # invoke the optional producer
                 if len(events) and self.preparation_producer_inst:
-                    events = self.preparation_producer_inst(
-                        events,
-                        task=self,
-                        stats=stats,
-                        fold_indices=events.fold_indices,
-                        ml_model_inst=self.ml_model_inst,
-                    )
+                    try:
+                        events = self.preparation_producer_inst(
+                            events,
+                            task=self,
+                            stats=stats,
+                            fold_indices=events.fold_indices,
+                            ml_model_inst=self.ml_model_inst,
+                        )
+                    except:
+                        self.preparation_producer_inst.run_teardown(task=self)
+                        raise
 
                 # read fold_indices from events array to allow masking training events
                 fold_indices = events.fold_indices
@@ -745,13 +749,17 @@ class MLEvaluation(
 
                 # invoke the optional producer
                 if len(events) and self.preparation_producer_inst:
-                    events = self.preparation_producer_inst(
-                        events,
-                        task=self,
-                        stats=stats,
-                        fold_indices=events.fold_indices,
-                        ml_model_inst=self.ml_model_inst,
-                    )
+                    try:
+                        events = self.preparation_producer_inst(
+                            events,
+                            task=self,
+                            stats=stats,
+                            fold_indices=events.fold_indices,
+                            ml_model_inst=self.ml_model_inst,
+                        )
+                    except:
+                        self.preparation_producer_inst.run_teardown(task=self)
+                        raise
 
                 # evaluate the model
                 events = self.ml_model_inst.evaluate(

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -146,7 +146,11 @@ class ProduceColumns(_ProduceColumns):
                 # invoke the producer
                 if len(events):
                     events = attach_coffea_behavior(events)
-                    events = self.producer_inst(events, task=self)
+                    try:
+                        events = self.producer_inst(events, task=self)
+                    except:
+                        self.producer_inst.run_teardown(task=self)
+                        raise
 
                 # remove columns
                 events = route_filter(events)

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -12,6 +12,7 @@ import law
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import ProducerMixin, ChunkedIOMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.tasks.framework.decorators import on_failure
 from columnflow.tasks.reduction import ReducedEventsUser
 from columnflow.util import dev_sandbox
 
@@ -79,6 +80,7 @@ class ProduceColumns(_ProduceColumns):
     @law.decorator.log
     @law.decorator.localize(input=False)
     @law.decorator.safe_output
+    @on_failure(callback=lambda task: task.teardown_producer_inst())
     def run(self):
         from columnflow.columnar_util import (
             Route, RouteFilter, mandatory_coffea_columns, update_ak_array, add_ak_aliases,
@@ -146,11 +148,7 @@ class ProduceColumns(_ProduceColumns):
                 # invoke the producer
                 if len(events):
                     events = attach_coffea_behavior(events)
-                    try:
-                        events = self.producer_inst(events, task=self)
-                    except:
-                        self.producer_inst.run_teardown(task=self)
-                        raise
+                    events = self.producer_inst(events, task=self)
 
                 # remove columns
                 events = route_filter(events)
@@ -165,7 +163,7 @@ class ProduceColumns(_ProduceColumns):
                 self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # teardown the producer
-        self.producer_inst.run_teardown(task=self)
+        self.teardown_producer_inst()
 
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -213,7 +213,11 @@ class ReduceEvents(_ReduceEvents):
                 if len(events):
                     n_all += len(events)
                     events = attach_coffea_behavior(events)
-                    events = self.reducer_inst(events, selection=sel, task=self)
+                    try:
+                        events = self.reducer_inst(events, selection=sel, task=self)
+                    except:
+                        self.reducer_inst.run_teardown(task=self)
+                        raise
                     n_reduced += len(events)
 
                 # remove columns

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -219,7 +219,11 @@ class SelectEvents(_SelectEvents):
                 )
 
                 # invoke the selection function
-                events, results = self.selector_inst(events, task=self, stats=stats, hists=hists)
+                try:
+                    events, results = self.selector_inst(events, task=self, stats=stats, hists=hists)
+                except:
+                    self.selector_inst.run_teardown(task=self)
+                    raise
 
                 # complain when there is no event mask
                 if results.event is None:

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -13,6 +13,7 @@ import law
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorsMixin, SelectorMixin, ChunkedIOMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.tasks.framework.decorators import on_failure
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.tasks.calibration import CalibrateEvents
 from columnflow.production import Producer
@@ -131,6 +132,7 @@ class SelectEvents(_SelectEvents):
     @ensure_proxy
     @law.decorator.localize(input=False)
     @law.decorator.safe_output
+    @on_failure(callback=lambda task: task.teardown_selector_inst())
     def run(self):
         from columnflow.tasks.histograms import CreateHistograms
         from columnflow.columnar_util import (
@@ -219,11 +221,7 @@ class SelectEvents(_SelectEvents):
                 )
 
                 # invoke the selection function
-                try:
-                    events, results = self.selector_inst(events, task=self, stats=stats, hists=hists)
-                except:
-                    self.selector_inst.run_teardown(task=self)
-                    raise
+                events, results = self.selector_inst(events, task=self, stats=stats, hists=hists)
 
                 # complain when there is no event mask
                 if results.event is None:
@@ -258,7 +256,7 @@ class SelectEvents(_SelectEvents):
                     self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # teardown the selector
-        self.selector_inst.run_teardown(task=self)
+        self.teardown_selector_inst()
 
         # merge the result files
         sorted_chunks = [result_chunks[key] for key in sorted(result_chunks)]


### PR DESCRIPTION
This PR is straight forward and updates all tasks with task array function involvement to run the teardown method eagerly as soon as the run method fails. This is implemented through a `on_failure` decorator and a new method in all relevant mixins to trigger the teardown with correct parameters.

This allows resources to be freed up in case of issues of any kind.

---

Background: our ML evaluation of externally trained models is encapsulated into subprocesses for better resource control. However, in case a different producer fails, we need to trigger the subprocess termination, since it would otherwise block the main process as it never receives a stop signal. This already lead to remote jobs that are left in pending state.