### PR TITLE
Ensure some tasks are only run locally

### DIFF
--- a/columnflow/tasks/framework/decorators.py
+++ b/columnflow/tasks/framework/decorators.py
@@ -3,7 +3,42 @@ Custom law task method decorators.
 """
 
 import law
-from typing import Any, Callable
+
+from columnflow import env_is_local
+from columnflow.types import Any, Callable
+
+
+@law.decorator.factory(accept_generator=True)
+def only_local_env(
+    fn: Callable,
+    opts: Any,
+    task: law.Task,
+    *args: Any,
+    **kwargs: Any,
+) -> tuple[Callable, Callable, Callable]:
+    """ only_local_env()
+    A decorator that ensures that the task's decorated method is only executed in the local environment, and not by
+    (e.g.) remote jobs.
+
+    :param fn: The decorated function.
+    :param opts: Options for the decorator.
+    :param task: The task instance.
+    :param args: Arguments to be passed to the function call.
+    :param kwargs: Keyword arguments to be passed to the function call.
+    :return: A tuple containing the before_call, call, and after_call functions.
+    """
+    def before_call() -> None:
+        return None
+
+    def call(state: Any) -> Any:
+        if not env_is_local:
+            raise RuntimeError(f"{task.task_family}.{fn.__name__}() can only be executed locally")
+        return fn(task, *args, **kwargs)
+
+    def after_call(state: Any) -> None:
+        return None
+
+    return before_call, call, after_call
 
 
 @law.decorator.factory(accept_generator=True)

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -17,6 +17,7 @@ import law
 from columnflow import flavor as cf_flavor
 from columnflow.tasks.framework.base import Requirements, AnalysisTask
 from columnflow.tasks.framework.parameters import user_parameter_inst
+from columnflow.tasks.framework.decorators import only_local_env
 from columnflow.util import UNSET, real_path
 
 
@@ -61,6 +62,7 @@ class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLo
     def output(self):
         return law.tasks.TransferLocalFile.output(self)
 
+    @only_local_env
     @law.decorator.notify
     @law.decorator.log
     @law.decorator.safe_output
@@ -92,6 +94,7 @@ class BundleSoftware(AnalysisTask, law.tasks.TransferLocalFile):
         path = os.path.expandvars(os.path.expanduser(self.single_output().path))
         return self.get_replicated_path(path, i=None if self.replicas <= 0 else r"[^\.]+")
 
+    @only_local_env
     @law.decorator.notify
     @law.decorator.log
     @law.decorator.safe_output
@@ -171,6 +174,7 @@ class BuildBashSandbox(SandboxFileTask):
         # note: invoking self.env will already trigger installing the sandbox
         return law.LocalFileTarget(self.env["CF_SANDBOX_FLAG_FILE"])
 
+    @only_local_env
     def run(self):
         # no need to run anything as the sandboxing mechanism handles the installation
         return
@@ -232,6 +236,7 @@ class BundleBashSandbox(AnalysisTask, law.tasks.TransferLocalFile):
         path = os.path.expandvars(os.path.expanduser(self.single_output().path))
         return self.get_replicated_path(path, i=None if self.replicas <= 0 else r"[^\.]+")
 
+    @only_local_env
     @law.decorator.notify
     @law.decorator.log
     @law.decorator.safe_output
@@ -308,6 +313,7 @@ class BundleCMSSWSandbox(SandboxFileTask, law.cms.BundleCMSSW, law.tasks.Transfe
         path = os.path.expandvars(os.path.expanduser(self.single_output().path))
         return self.get_replicated_path(path, i=None if self.replicas <= 0 else r"[^\.]+")
 
+    @only_local_env
     @law.decorator.notify
     @law.decorator.log
     def run(self):


### PR DESCRIPTION
This PR adds a decorator that fails the task execution in case the environment is not local, i.e., it will fail in remote jobs.

We need to have this as a protection to make sure that our jobs are not requesting remote resources with extreme parallelism (DoS attacks). Even though this shouldn't happen in the first place since external bundles should always be created before job submission, glitches of the job infrastructure may cause this bundles to be inaccessible, which then triggers re-bundling. This should not happen remotely.