### PR TITLE
Fix config lookup for taf classes mixins.

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -280,7 +280,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             items = [
                 parse(key, value)
                 for key, value in law.config.items("resources")
-                if value
+                if value and not key.startswith("_")
             ]
             cls._cfg_resources_dict = cls._structure_cfg_items(items)
 
@@ -361,7 +361,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
     @classmethod
     def _dfs_key_lookup(
         cls,
-        keys: law.util.InsertableDict[str, str] | Sequence[str],
+        keys: law.util.InsertableDict[str, str | Sequence[str]] | Sequence[str | Sequence[str]],
         nested_dict: dict[str, Any],
         empty_value: Any = None,
     ) -> str | Callable | None:
@@ -371,12 +371,12 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         if not nested_dict:
             return empty_value
 
-        # the keys to use for the lookup are the values of the keys dict
-        keys = collections.deque(keys.values() if isinstance(keys, dict) else keys)
+        # the keys to use for the lookup are the flattened values of the keys dict
+        flat_keys = collections.deque(law.util.flatten(keys.values() if isinstance(keys, dict) else keys))
 
         # start tree traversal using a queue lookup consisting of names and values of tree nodes,
         # as well as the remaining keys (as a deferred function) to compare for that particular path
-        lookup = collections.deque([tpl + ((lambda: keys.copy()),) for tpl in nested_dict.items()])
+        lookup = collections.deque([tpl + ((lambda: flat_keys.copy()),) for tpl in nested_dict.items()])
         while lookup:
             pattern, obj, keys_func = lookup.popleft()
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -289,6 +289,24 @@ class CalibratorClassesMixin(ArrayFunctionClassMixin):
         parts.insert_after(self.config_store_anchor, "calibrators", f"calib__{self.calibrators_repr}")
         return parts
 
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: CalibratorClassesMixin | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        # add the calibrator names
+        calibrators = (
+            inst_or_params.get("calibrators")
+            if isinstance(inst_or_params, dict)
+            else getattr(inst_or_params, "calibrators", None)
+        )
+        if calibrators not in {law.NO_STR, None, "", ()}:
+            keys["calibrators"] = [f"calib_{calibrator}" for calibrator in calibrators]
+
+        return keys
+
 
 class CalibratorsMixin(ArrayFunctionInstanceMixin, CalibratorClassesMixin):
     """
@@ -1023,6 +1041,24 @@ class ProducerClassesMixin(ArrayFunctionClassMixin):
         parts = super().store_parts()
         parts.insert_after(self.config_store_anchor, "producers", f"prod__{self.producers_repr}")
         return parts
+
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: ProducerClassesMixin | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        # add the producer names
+        producers = (
+            inst_or_params.get("producers")
+            if isinstance(inst_or_params, dict)
+            else getattr(inst_or_params, "producers", None)
+        )
+        if producers not in {law.NO_STR, None, "", ()}:
+            keys["producers"] = [f"prod_{producer}" for producer in producers]
+
+        return keys
 
 
 class ProducersMixin(ArrayFunctionInstanceMixin, ProducerClassesMixin):

--- a/columnflow/tasks/framework/remote.py
+++ b/columnflow/tasks/framework/remote.py
@@ -18,6 +18,7 @@ from columnflow import flavor as cf_flavor
 from columnflow.tasks.framework.base import Requirements, AnalysisTask
 from columnflow.tasks.framework.parameters import user_parameter_inst
 from columnflow.util import UNSET, real_path
+from columnflow.types import Any
 
 
 class BundleRepo(AnalysisTask, law.git.BundleGitRepository, law.tasks.TransferLocalFile):
@@ -363,6 +364,24 @@ class RemoteWorkflowMixin(AnalysisTask):
 
         # container to store scheduler message handlers
         self._scheduler_message_handlers: dict[str, SchedulerMessageHandler] = {}
+
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: RemoteWorkflowMixin | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        # add the pilot flag
+        pilot = (
+            inst_or_params.get("pilot")
+            if isinstance(inst_or_params, dict)
+            else getattr(inst_or_params, "pilot", None)
+        )
+        if pilot not in (law.NO_STR, None, ""):
+            keys["pilot"] = f"pilot_{pilot}"
+
+        return keys
 
     def add_bundle_requirements(
         self,


### PR DESCRIPTION
The mechanism that matches specific config settings to task parameter defaults, such as

```ini
cf.{SelectEvents,ReduceEvents}__sel_default: htcondor_memory=6.25GB
```

currently does not resolve keys for parameters that are present multiple times like `producers` and `calibrators`.

I added the responsible `get_config_lookup_keys` methods to the two relevant mixins and enabled sequences in the `_dfs_key_lookup`.

In addition, the `pilot` flag is now part of the lookup keys for tasks that support it, i.e., key fragments like `...__pilot_True__...` can be used now to trigger specific default conditions in case the task is in pilot mode (or not).