### PR TITLE
minor fixes and streamlining

### DIFF
--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -75,7 +75,7 @@ def plot_variable_stack(
         for proc_inst, h in hists.items()
         if proc_inst.is_mc and getattr(proc_inst, "unstack", False)
     }
-    hists |= remove_residual_axis(unstacked_hists, "shift", select_value=0)
+    hists |= remove_residual_axis(unstacked_hists, "shift", select_value="nominal")
 
     # prepare the plot config
     plot_config = prepare_stack_plot_config(

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1243,9 +1243,10 @@ class MLModelMixinBase(ConfigTask):
 
 class MLModelTrainingMixin(
     MLModelMixinBase,
-    ProducerClassesMixin,
-    SelectorClassMixin,
     CalibratorClassesMixin,
+    SelectorClassMixin,
+    ReducerClassMixin,
+    ProducerClassesMixin,
 ):
     """
     A mixin class for training machine learning models.

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -191,13 +191,10 @@ class CreateHistograms(_CreateHistograms):
             for inp in ((
                 {variable_inst.expression}
                 if isinstance(variable_inst.expression, str)
-                # for variable_inst with custom expressions, read columns declared via aux key
-                else set(variable_inst.x("inputs", []))
-            ) | (
-                set()
-                if variable_inst.selection == "1"
-                # for variable_inst with selection, read columns declared via aux key
-                else set(variable_inst.x("inputs", []))
+                else set()
+            ) | set(
+                # read requested input columns if defined
+                variable_inst.x("inputs", []),
             ))
         }
 


### PR DESCRIPTION
This PR fixes two minor issues:

- during Plotting, there was an issue with picking the "nominal" shift bin
- missing ReducerClassMixin for the MLModelTrainingMixin + fixing order of mixins

Additionally, I also streamlined the reading of inputs from variables. Right now, the "inputs" aux is ignored when passing an expression via string, however, there are usecases, where one still wants to read custom inputs, e.g. when a collection is updated/defined as part of the HistProducer:

```python
config.add_variable(
    name=f"lepton0_pt",
    expression="Lepton[:, 0].pt",
    aux=dict(
        inputs={"{Electron,Muon}.{pt,eta,phi,mass}"},
    ),
    binning=(40, 0., 400.),
    unit="GeV",
    null_value=EMPTY_FLOAT,
    x_title=f"Lepton 0 $p_{{T}}$",
)
 ```