### PR TITLE
Apply new recommendation for egamma calibration

### DIFF
--- a/columnflow/calibration/cms/egamma.py
+++ b/columnflow/calibration/cms/egamma.py
@@ -62,13 +62,30 @@ class egamma_scale_corrector(Calibrator):
 
     def call_func(self, events: ak.Array, **kwargs) -> ak.Array:
         """
-        Apply energy corrections to EGamma objects in the events array.
-
-        There are two types of implementations: standard and Et dependent. For Run2 the standard
-        implementation is used, while for Run3 the Et dependent is recommended by the EGammaPog:
-        https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammSFandSSRun3?rev=41 The Et dependendent
-        recipe follows the example given in:
+        Apply energy corrections to EGamma objects in the events array. There are two types of implementations: standard
+        and Et dependent.
+        For Run2 the standard implementation is used, while for Run3 the Et dependent is recommended by the EGammaPog:
+        https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammSFandSSRun3?rev=41
+        The Et dependendent recipe follows the example given in:
         https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/66f581d0549e8d67fc55420d8bba15c9369fff7c/examples/egmScaleAndSmearingExample.py
+
+        Requires an external file in the config under ``electron_ss``. Example:
+        .. code-block:: python
+            cfg.x.external_files = DotDict.wrap({
+                "electron_ss": "/afs/cern.ch/work/m/mrieger/public/mirrors/jsonpog-integration-120c4271/POG/EGM/2022_Summer22//electronSS_EtDependent.json.gz",  # noqa
+            })
+
+        The pairs of correction set, value and uncertainty type names,  and if a compound method is used should be configured using the :py:class:`EGammaCorrectionConfig` as an
+        auxiliary entry in the config:
+
+        .. code-block:: python
+
+            cfg.x.eec = EGammaCorrectionConfig(
+                correction_set="EGMScale_Compound_Ele_2022preEE",
+                compound=True,
+                value_type="scale",
+                uncertainty_type="escale",
+            )
 
         Derivatives of this base class require additional member variables and functions:
 
@@ -276,6 +293,24 @@ class egamma_resolution_corrector(Calibrator):
         https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammSFandSSRun3?rev=41 The Et dependendent
         recipe follows the example given in:
         https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/66f581d0549e8d67fc55420d8bba15c9369fff7c/examples/egmScaleAndSmearingExample.py
+
+        Requires an external file in the config under ``electron_ss``. Example:
+        .. code-block:: python
+            cfg.x.external_files = DotDict.wrap({
+                "electron_ss": "/afs/cern.ch/work/m/mrieger/public/mirrors/jsonpog-integration-120c4271/POG/EGM/2022_Summer22/electronSS_EtDependent.json.gz",  # noqa
+            })
+
+        The pairs of correction set, value and uncertainty type names, and if a compound method is used should be configured using the :py:class:`EGammaCorrectionConfig` as an
+        auxiliary entry in the config:
+
+        .. code-block:: python
+
+            cfg.x.eec = EGammaCorrectionConfig(
+                correction_set="EGMSmearAndSyst_ElePTsplit_2022preEE",
+                compound=False,
+                value_type="smear",
+                uncertainty_type="esmear",
+            )
 
         Derivatives of this base class require additional member variables and functions:
 

--- a/columnflow/calibration/cms/egamma.py
+++ b/columnflow/calibration/cms/egamma.py
@@ -63,21 +63,26 @@ class egamma_scale_corrector(Calibrator):
         """
         Apply energy corrections to EGamma objects in the events array.
 
-        This implementation follows the recommendations from the EGamma POG:
-        https://twiki.cern.ch/twiki/bin/view/CMS/EgammSFandSSRun3#Scale_And_Smearings_Example
+        There are two types of implementations: standard and Et dependent. For Run2 the standard
+        implementation is used, while for Run3 the Et dependent is recommended by the EGammaPog:
+        https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammSFandSSRun3?rev=41 The Et dependendent
+        recipe follows the example given in:
+        https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/66f581d0549e8d67fc55420d8bba15c9369fff7c/examples/egmScaleAndSmearingExample.py
 
-        Derivatives of this base class require additional member variables and
-        functions:
+        Derivatives of this base class require additional member variables and functions:
 
-        - *source_field*: The field name of the EGamma objects in the events array (i.e. `Electron` or `Photon`).
-        - *get_correction_file*: Function to retrieve the correction file, e.g.from the list ,of external files in the current `config_inst`.
+        - *source_field*: The field name of the EGamma objects in the events array (i.e. `Electron`
+            or `Photon`).
+        - *get_correction_file*: Function to retrieve the correction file, e.g.from
+            the list, of external files in the current `config_inst`.
         - *get_scale_config*: Function to retrieve the configuration for the energy correction.
-            This config must be an instance of :py:class:`~columnflow.calibration.cms.egamma.EGammaCorrectionConfig`.
+            This config must be an instance of
+            :py:class:`~columnflow.calibration.cms.egamma.EGammaCorrectionConfig`.
 
-        If no raw pt (i.e., pt before any corrections) is available, use the nominal pt.
-        The correction tool only supports flat arrays, so inputs are converted to a flat numpy view first.
-        Corrections are always applied to the raw pt, which is important if more than one correction is applied in a
-        row. The final corrections must be applied to the current pt.
+        If no raw pt (i.e., pt before any corrections) is available, use the nominal pt. The
+        correction tool only supports flat arrays, so inputs are converted to a flat numpy view
+        first. Corrections are always applied to the raw pt, which is important if more than one
+        correction is applied in a row. The final corrections must be applied to the current pt.
 
         If :py:attr:`with_uncertainties` is set to `True`, the scale uncertainties are calculated.
         The scale uncertainties are only available for simulated data.
@@ -88,9 +93,9 @@ class egamma_scale_corrector(Calibrator):
         :notes:
             - Varied corrections are only applied to Monte Carlo (MC) data.
             - EGamma energy correction is only applied to real data.
-            - Changes are applied to the views and directly propagate to the original awkward arrays.
+            - Changes are applied to the views and directly propagate to the original awkward
+                arrays.
         """
-
         # if no raw pt (i.e. pt for any corrections) is available, use the nominal pt
         if "rawPt" not in events[self.source_field].fields:
             events = set_ak_column_f32(
@@ -265,11 +270,13 @@ class egamma_resolution_corrector(Calibrator):
         """
         Apply energy resolution corrections to EGamma objects in the events array.
 
-        This implementation follows the recommendations from the EGamma POG:
-        https://twiki.cern.ch/twiki/bin/view/CMS/EgammSFandSSRun3#Scale_And_Smearings_Example
+        There are two types of implementations: standard and Et dependent. For Run2 the standard
+        implementation is used, while for Run3 the Et dependent is recommended by the EGammaPog:
+        https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammSFandSSRun3?rev=41 The Et dependendent
+        recipe follows the example given in:
+        https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/66f581d0549e8d67fc55420d8bba15c9369fff7c/examples/egmScaleAndSmearingExample.py
 
-        Derivatives of this base class require additional member variables and
-        functions:
+        Derivatives of this base class require additional member variables and functions:
 
         - *source_field*: The field name of the EGamma objects in the events array (i.e. `Electron` or `Photon`).
         - *get_correction_file*: Function to retrieve the correction file, e.g.

--- a/columnflow/calibration/cms/egamma.py
+++ b/columnflow/calibration/cms/egamma.py
@@ -226,10 +226,6 @@ class egamma_scale_corrector(Calibrator):
             corr_set = corr_set.compound
         self.scale_corrector = corr_set[self.scale_config.correction_set]
 
-        if not self.scale_config.compound:
-            # check version, does not exist for compound
-            assert self.scale_corrector.version in [0, 1, 2]
-
 
 class egamma_resolution_corrector(Calibrator):
 
@@ -459,10 +455,6 @@ class egamma_resolution_corrector(Calibrator):
         if self.resolution_cfg.compound:
             corr_set = corr_set.compound
         self.resolution_corrector = corr_set[self.resolution_cfg.correction_set]
-
-        if not self.resolution_cfg.compound:
-            # check versions, does not exist for compound version
-            assert self.resolution_corrector.version in [0, 1, 2]
 
         # use deterministic seeds for random smearing if requested
         if self.deterministic_seed_index >= 0:

--- a/columnflow/calibration/cms/egamma.py
+++ b/columnflow/calibration/cms/egamma.py
@@ -70,8 +70,7 @@ class egamma_scale_corrector(Calibrator):
         functions:
 
         - *source_field*: The field name of the EGamma objects in the events array (i.e. `Electron` or `Photon`).
-        - *get_correction_file*: Function to retrieve the correction file, e.g.from the list ,
-        of external files in the current `config_inst`.
+        - *get_correction_file*: Function to retrieve the correction file, e.g.from the list ,of external files in the current `config_inst`.
         - *get_scale_config*: Function to retrieve the configuration for the energy correction.
             This config must be an instance of :py:class:`~columnflow.calibration.cms.egamma.EGammaCorrectionConfig`.
 
@@ -113,7 +112,6 @@ class egamma_scale_corrector(Calibrator):
         r9 = flat_np_view(events[self.source_field].r9, axis=1)
 
         # prepare arguments
-        # we use pt as et since there depends in linear (following the recoomendations)
         # (energy is part of the LorentzVector behavior)
         variable_map = {
             "et": pt_eval,
@@ -314,8 +312,6 @@ class egamma_resolution_corrector(Calibrator):
         r9 = flat_np_view(events[self.source_field].r9, axis=1)
         flat_seeds = flat_np_view(events[self.source_field].deterministic_seed, axis=1)
 
-        # we use pt as et since there depends in linear (following the recommendations)
-        # (energy is part of the LorentzVector behavior)
         pt = flat_np_view(events[self.source_field].rawPt, axis=1)
 
         # prepare arguments
@@ -334,10 +330,6 @@ class egamma_resolution_corrector(Calibrator):
         )
 
         # calculate the smearing scale
-        # available option are for Et: smear, esmear or escale, e = error
-
-        # TODO : ask Marcel/philip about this
-        # NOTE: the presence of the scale uncertainties ("escale") among the "EGMSmearAndSyst",
         # as mentioned in the example above, allows us to apply them directly to the MC simulation.
         rho = self.resolution_corrector.evaluate(self.resolution_cfg.corrector_strings["type"], *args)
 

--- a/columnflow/calibration/cms/egamma.py
+++ b/columnflow/calibration/cms/egamma.py
@@ -70,7 +70,9 @@ class egamma_scale_corrector(Calibrator):
         https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/66f581d0549e8d67fc55420d8bba15c9369fff7c/examples/egmScaleAndSmearingExample.py
 
         Requires an external file in the config under ``electron_ss``. Example:
+
         .. code-block:: python
+
             cfg.x.external_files = DotDict.wrap({
                 "electron_ss": "/afs/cern.ch/work/m/mrieger/public/mirrors/jsonpog-integration-120c4271/POG/EGM/2022_Summer22//electronSS_EtDependent.json.gz",  # noqa
             })
@@ -82,9 +84,9 @@ class egamma_scale_corrector(Calibrator):
 
             cfg.x.eec = EGammaCorrectionConfig(
                 correction_set="EGMScale_Compound_Ele_2022preEE",
-                compound=True,
                 value_type="scale",
                 uncertainty_type="escale",
+                compound=True,
             )
 
         Derivatives of this base class require additional member variables and functions:
@@ -295,7 +297,9 @@ class egamma_resolution_corrector(Calibrator):
         https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/66f581d0549e8d67fc55420d8bba15c9369fff7c/examples/egmScaleAndSmearingExample.py
 
         Requires an external file in the config under ``electron_ss``. Example:
+
         .. code-block:: python
+
             cfg.x.external_files = DotDict.wrap({
                 "electron_ss": "/afs/cern.ch/work/m/mrieger/public/mirrors/jsonpog-integration-120c4271/POG/EGM/2022_Summer22/electronSS_EtDependent.json.gz",  # noqa
             })
@@ -307,7 +311,6 @@ class egamma_resolution_corrector(Calibrator):
 
             cfg.x.eec = EGammaCorrectionConfig(
                 correction_set="EGMSmearAndSyst_ElePTsplit_2022preEE",
-                compound=False,
                 value_type="smear",
                 uncertainty_type="esmear",
             )
@@ -350,7 +353,6 @@ class egamma_resolution_corrector(Calibrator):
         sceta = flat_np_view(events[self.source_field].superclusterEta, axis=1)
         r9 = flat_np_view(events[self.source_field].r9, axis=1)
         flat_seeds = flat_np_view(events[self.source_field].deterministic_seed, axis=1)
-
         pt = flat_np_view(events[self.source_field].rawPt, axis=1)
 
         # prepare arguments

--- a/columnflow/calibration/cms/egamma.py
+++ b/columnflow/calibration/cms/egamma.py
@@ -340,7 +340,7 @@ class egamma_resolution_corrector(Calibrator):
 
             smearing_up = (
                 smearing_func(
-                    random_normal_number(flat_seeds, rand_func=self.deterministic_normal),
+                    random_normal_number(flat_seeds, rand_func=self.deterministic_normal_up),
                     rho + rho_unc,
                 )
                 if self.deterministic_seed_index >= 0
@@ -352,7 +352,7 @@ class egamma_resolution_corrector(Calibrator):
 
             smearing_down = (
                 smearing_func(
-                    random_normal_number(flat_seeds, rand_func=self.deterministic_normal),
+                    random_normal_number(flat_seeds, rand_func=self.deterministic_normal_down),
                     rho - rho_unc,
                 )
                 if self.deterministic_seed_index >= 0


### PR DESCRIPTION
This PR enables the application of egamma corrections for run2 and run3, as recommended in [Twiki of JSON Pog](https://twiki.cern.ch/twiki/bin/view/CMS/EgammSFandSSRun3#2022_and_2023_Scale_and_Smearing).

- Due to changes in the correctionlib json more information needed to be given to the config. For this reason multiple conditions are added
- The calculation of up and down smearing was generalized to a more robust version.