### PR TITLE
B-tagging scale factors with fixed workingpoint (includes B-tagging efficiencies)

### DIFF
--- a/columnflow/plotting/cmsGhent/plot_util.py
+++ b/columnflow/plotting/cmsGhent/plot_util.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+import order as od
+from columnflow.util import maybe_import
+
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+
+
+def cumulate(h: np.ndarray | hist.Hist, direction="below", axis: str | int | od.Variable = 0):
+    idx_slice = np.s_[::-1] if direction == "above" else np.s_[:]
+    arr = h if isinstance(h, np.ndarray) else h.view(flow=False)
+    if isinstance(axis, od.Variable):
+        axis = axis.name
+    if isinstance(axis, str):
+        assert isinstance(h, hist.Hist), "str axis only allowed for hist.Hist"
+        ax_names = [ax.name for ax in h.axes]
+        assert axis in ax_names, f"requested axis not available in histrogram axes {', '.join(ax_names)}"
+        axis = ax_names.index(axis)
+    arr = np.swapaxes(arr, 0, axis)
+    arr = np.cumsum(arr[idx_slice], axis=0)[idx_slice]
+    arr = np.swapaxes(arr, 0, axis)
+    if isinstance(h, np.ndarray):
+        return arr
+    h_cum = h.copy()
+    h_cum.view(flow=False)[:] = arr
+    return h_cum

--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -229,7 +229,10 @@ def plot_all(
         # invoke the method
         method = cfg["method"]
         h = cfg["hist"]
-        plot_methods[method](ax, h, **cfg.get("kwargs", {}))
+        if callable(method):
+            method(ax, h, **cfg.get("kwargs", {}))
+        else:
+            plot_methods[method](ax, h, **cfg.get("kwargs", {}))
 
         # repeat for ratio axes if configured
         if not skip_ratio and "ratio_kwargs" in cfg:

--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -24,6 +24,7 @@ logger = law.logger.get_logger(__name__)
 @dataclass
 class BTagSFConfig:
     correction_set: str
+    sources: list[str]
     jec_sources: list[str]
     discriminator: str = ""  # when empty, set in post init based on correction set
     corrector_kwargs: dict[str, Any] = field(default_factory=dict)
@@ -35,6 +36,8 @@ class BTagSFConfig:
                 self.discriminator = "btagDeepFlavB"
             elif "particlenet" in cs:
                 self.discriminator = "btagPNetB"
+            elif "robustparticletransformer" in cs:
+                self.discriminator = "btagRobustParTAK4B"
             else:
                 raise NotImplementedError(
                     "cannot identify btag discriminator for correction set "

--- a/columnflow/production/cmsGhent/btag_weights.py
+++ b/columnflow/production/cmsGhent/btag_weights.py
@@ -1,0 +1,462 @@
+"""
+Producer that produces a column Jet.btag based on the default_btag Algorithm provided in the config
+"""
+
+from __future__ import annotations
+
+import law
+import order as od
+from typing import Iterable
+from collections import OrderedDict
+
+
+from columnflow.production import Producer, producer
+from columnflow.weight import WeightProducer, weight_producer
+from columnflow.selection import SelectionResult
+
+from columnflow.util import maybe_import, InsertableDict, DotDict
+from columnflow.columnar_util import set_ak_column, layout_ak_array, Route, has_ak_column, optional_column
+from columnflow.production.cms.btag import BTagSFConfig
+
+ak = maybe_import("awkward")
+np = maybe_import("numpy")
+hist = maybe_import("hist")
+correctionlib = maybe_import("correctionlib")
+
+logger = law.logger.get_logger(__name__)
+
+
+def init_btag(self: Producer | WeightProducer, add_eff_vars=True):
+    if not hasattr(self, "get_btag_config"):
+        self.btag_config = self.config_inst.x(
+            "btag_sf",
+            BTagSFConfig(
+                correction_set="DeepJet",
+                sources=["uncorrelated", "correlated"],
+                jec_sources=[],
+            ),
+        )
+        self.btag_config = BTagSFConfig.new(self.btag_config)
+    else:
+        self.btag_config = self.get_btag_config()
+
+    # update used columns
+    self.uses.add(f"Jet.{self.btag_config.discriminator}")
+
+    if add_eff_vars:
+        if "default_btag_variables" not in self.config_inst.aux:
+            logger.warning_once(
+                "no default btagging efficiency variables defined in config",
+                "Config does not have an attribute x.default_btag_variables that provides default \
+                    variables in which to bin b - tagging efficiency.\n \
+                    The variables 'btag_jet_pt' & 'btag_jet_eta' are used if defined in the config.",
+            )
+        self.variables = self.config_inst.x("default_btag_variables", ("btag_jet_pt", "btag_jet_eta"))
+        self.variable_insts = list(map(self.config_inst.get_variable, self.variables))
+        self.uses.update({
+            inp
+            for variable_inst in self.variable_insts
+            for inp in (
+                [variable_inst.expression] if isinstance(variable_inst.expression, str) else variable_inst.x("inputs",
+                                                                                                             [])
+            )
+        })
+
+
+def setup_btag(self: Producer | WeightProducer, reqs: dict):
+    bundle = reqs["external_files"]
+    correction_set_btag_wp_corr = correctionlib.CorrectionSet.from_string(
+        self.get_btag_sf(bundle.files).load(formatter="gzip").decode("utf-8"),
+    )
+
+    btag_wp_corrector = correction_set_btag_wp_corr[f"{self.btag_config.correction_set}_wp_values"]
+    self.btag_wp_value = OrderedDict([(wp, btag_wp_corrector.evaluate(wp)) for wp in "LMT"])
+    return correction_set_btag_wp_corr
+
+
+def req_btag(self: Producer | WeightProducer, reqs: dict):
+    from columnflow.tasks.external import BundleExternalFiles
+    reqs["external_files"] = BundleExternalFiles.req(self.task)
+
+
+@producer(
+    produces={optional_column("Jet.btag_{LMT}")},
+    get_btag_config=(lambda self: BTagSFConfig.new(self.config_inst.x.btag_sf)),
+    get_btag_sf=lambda self, external_files: external_files.btag_sf_corr,
+)
+def jet_btag(
+    self: Producer,
+    events: ak.Array,
+    working_points: Iterable[str] = None,
+    jet_mask: ak.Array[bool] = None,
+    **kwargs,
+) -> ak.Array:
+
+    for wp in working_points or self.btag_wp_value:
+        tag = events.Jet[self.btag_config.discriminator] >= self.btag_wp_value[wp]
+        if jet_mask is not None:
+            tag = tag & jet_mask
+        events = set_ak_column(events, f"Jet.btag_{wp}", tag)
+
+    return events
+
+
+@jet_btag.init
+def jet_btag_init(self: Producer):
+    init_btag(self, add_eff_vars=False)
+
+
+@jet_btag.setup
+def jet_btag_setup(self: Producer, reqs: dict, *args, **kwargs) -> None:
+    setup_btag(self, reqs)
+
+
+@jet_btag.requires
+def jet_btag_requires(self: Producer, reqs: dict) -> None:
+    req_btag(self, reqs)
+
+
+@weight_producer(
+    uses={"Jet.{pt,eta,hadronFlavour}", jet_btag},
+    get_btag_config=(lambda self: BTagSFConfig.new(self.config_inst.x.btag_sf)),
+    get_btag_sf=lambda self, external_files: external_files.btag_sf_corr,
+    get_btag_eff=lambda self, external_files: external_files.get("btag_sf_eff", {}),
+    # Return a dict mapping dataset groups to efficiencies.
+    # Missing dataset groups are calculated with the BTagEfficiency task
+    mc_only=True,
+    weight_name="btag_weight",
+    produce_plots=True,
+)
+def fixed_wp_btag_weights(
+    self: Producer,
+    events: ak.Array,
+    working_points: Iterable[str] | str,
+    jet_mask: ak.Array[bool] = None,
+    **kwargs,
+) -> ak.Array:
+
+    working_points = sorted(law.util.make_list(working_points), key=lambda x: "LMT".find(x))
+
+    # get the total number of jets in the chunk
+    jets = events.Jet[jet_mask] if jet_mask is not None else events.Jet
+    jets = set_ak_column(jets, "abseta", abs(jets.eta))
+
+    # helper to create and store the weight
+    def add_weight(flavour_group, systematic, variation=None):
+
+        # variation as in correctionlib TODO: make flexible if naming scheme changes
+        syst_variation = systematic if not variation else f"{variation}_{systematic}"
+
+        # define a mask that selects the correct flavor to assign to, depending on the systematic
+        jet_mask = ak.full_like(jets.hadronFlavour, True)
+        if flavour_group == "light":
+            # only apply to light flavor
+            jet_mask = jets.hadronFlavour == 0
+            btag_sf_corrector = self.btag_sf_incl_corrector
+        elif flavour_group == "heavy":
+            # only apply to heavy flavor
+            jet_mask = jets.hadronFlavour != 0
+            btag_sf_corrector = self.btag_sf_comb_corrector
+
+        weight = np.ones(len(jets.pt))
+        for i, wp in enumerate([None, *working_points]):
+            next_wp = working_points[i] if wp != working_points[-1] else None
+
+            if wp is None:
+                jet_mask_wp = jet_mask & (~jets[f"btag_{next_wp}"])
+            else:
+                jet_mask_wp = jet_mask & jets[f"btag_{wp}"]
+                if next_wp is not None:
+                    jet_mask_wp = jet_mask_wp & (~jets[f"btag_{next_wp}"])
+
+            selected_jets = jets[jet_mask_wp]
+            flat_input = ak.flatten(selected_jets, axis=1)
+
+            # get efficiencies and scale factors for this and next working point
+            def sf_eff_wp(working_point, none_value=0.):
+                if working_point is None:
+                    return (np.full_like(flat_input.pt, none_value),) * 2
+                sf = btag_sf_corrector(
+                    syst_variation,
+                    working_point,
+                    flat_input.hadronFlavour,
+                    flat_input.abseta,
+                    flat_input.pt,
+                )
+                eff = self.btag_eff_corrector(
+                    flat_input.hadronFlavour,
+                    # currently set hard max on pt since overflow could not be changed in correctionlib
+                    # (could also manually change the flow)
+                    ak.min([flat_input.pt, 999 * ak.ones_like(flat_input.pt)], axis=0),
+                    flat_input.abseta,
+                    working_point,
+                )
+                return sf, eff
+
+            sf_this_wp, eff_this_wp = sf_eff_wp(wp, none_value=1.)
+            sf_next_wp, eff_next_wp = sf_eff_wp(next_wp, none_value=0.)
+
+            # calculate the event weight following:
+            # https://btv-wiki.docs.cern.ch/PerformanceCalibration/fixedWPSFRecommendations/
+            weight_flat = (sf_this_wp * eff_this_wp - sf_next_wp * eff_next_wp) / (eff_this_wp - eff_next_wp)
+
+            # enforce the correct shape and create the product over all jets per event
+            weight = weight * ak.prod(layout_ak_array(weight_flat, selected_jets.pt), axis=1, mask_identity=False)
+
+        column_name = f"{self.weight_name}_{flavour_group}"
+        if systematic != "central":
+            column_name += f"_{systematic}_{variation}"  # .replace("uncorrelated", str(self.config_inst.x.year))
+
+        if ak.any((weight == np.inf) | ak.is_none(ak.nan_to_none(weight))):
+            weight = ak.nan_to_num(weight, nan=1.0, posinf=1.0, neginf=1.0)
+            logger.warning_once(
+                "weight column has an infinite or Nan value",
+                f"weight column events.{column_name} has \
+                {ak.sum((weight == np.inf) | ak.is_none(ak.nan_to_none(weight)))} infinite or Nan values \
+                and are set to 1. Make sure the b-tagging efficiency is defined and physical in all bins.",
+            )
+        elif ak.any(weight < 0):
+            weight = ak.nan_to_num(weight, nan=1.0, posinf=1.0, neginf=1.0)
+            logger.warning_once(
+                "weight column has a negative value",
+                f"weight column events.{column_name} has {ak.sum(weight < 0)} negative values and are set to 1.",
+            )
+
+        return set_ak_column(events, column_name, weight, value_type=np.float32)
+
+    # nominal weight and those of all method intrinsic uncertainties
+    for flavour_group in self.flavour_groups:
+        events = add_weight(flavour_group, "central")
+
+        # only calculate up and down variations for nominal shift
+        if self.local_shift_inst.is_nominal:
+            for direction in ["up", "down"]:
+                for corr in self.btag_config.sources:
+                    events = add_weight(
+                        flavour_group=flavour_group,
+                        systematic=corr,
+                        variation=direction,
+                    )
+
+    # nominal weights:
+    nominal = np.prod([events[f"{self.weight_name}_{fg}"] for fg in self.flavour_groups], axis=0)
+
+    return set_ak_column(events, self.weight_name, nominal)
+
+
+@fixed_wp_btag_weights.init
+def fixed_wp_btag_weights_init(
+    self: Producer,
+) -> None:
+    init_btag(self)
+
+    # depending on the requested shift_inst, there are three cases to handle:
+    #   1. when a JEC uncertainty is requested whose propagation to btag weights is known, the
+    #      producer should only produce that specific weight column
+    #   2. when the nominal shift is requested, the central weight and all variations related to the
+    #      method-intrinsic shifts are produced
+    #   3. when any other shift is requested, only create the central weight column
+
+    shift_inst = getattr(self, "local_shift_inst", None)
+    if not shift_inst:
+        return
+
+    if not getattr(self, "dataset_inst", None):
+        return
+
+    # to handle this efficiently in one spot, store jec information
+    self.jec_source = shift_inst.x.jec_source if shift_inst.has_tag("jec") else None
+    btag_sf_jec_source = "" if self.jec_source == "Total" else self.jec_source  # noqa
+
+    # save names of method-intrinsic uncertainties
+    self.flavour_groups = {
+        "light",
+        "heavy",
+    }
+
+    # add uncertainty sources of the method itself
+    self.produces = {self.weight_name}
+    for name in self.flavour_groups:
+        # nominal columns
+        self.produces.add(f"{self.weight_name}_{name}")
+        if shift_inst.is_nominal:
+            self.produces.update({
+                f"{self.weight_name}_{name}_" + (direction if not corr else f"{corr}_{direction}")
+                for direction in ["up", "down"]
+                for corr in self.btag_config.sources
+            })
+
+    # determine to which btag_dataset_group the dataset belongs.
+    # btag efficiency will be calculated for the btag_dataset_group
+    # default value of datasets to calculate the efficiency is the dataset of the produce task
+    self.datasets = [self.dataset_inst.name]
+    self.dataset_group = self.dataset_inst.processes.names()[0]
+
+    if hasattr(self.config_inst.x, "btag_dataset_groups"):
+        for btag_group in self.config_inst.x.btag_dataset_groups:
+            # check if dataset is in data group
+            if self.dataset_inst.name in self.config_inst.x.btag_dataset_groups[btag_group]:
+                self.datasets = self.config_inst.x.btag_dataset_groups[btag_group]
+                if btag_group in self.config_inst.processes.names():
+                    self.dataset_group = btag_group  # only for plotting text
+                break
+    else:
+        logger.warning_once(
+            "no default btagging efficiency dataset groups defined in config",
+            "Config does not have an attribute 'x.btag_dataset_groups' that provides  \
+            default groupings of datasets for b-tagging efficiency calculation.\n"
+            f"The dataset {self.dataset_inst.name} is used to calculate but defining one is recommended.\n"
+            "example: config.x.btag_dataset_groups = {'ttx': ['ttztollnunu_m10_amcatnlo','tt_sl_powheg']}",
+        )
+
+    self.has_external_efficiencies = self.dataset_group in self.get_btag_eff(self.config_inst.x.external_files)
+
+
+@fixed_wp_btag_weights.setup
+def fixed_wp_btag_weights_setup(
+    self: Producer,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: InsertableDict,
+) -> None:
+    correction_set_btag_wp_corr = setup_btag(self, reqs)
+
+    # fix for change in nomenclature of deepJet scale factors for light hadronFlavour jets
+    if self.config_inst.x.year <= 2018:
+        self.btag_sf_incl_corrector = correction_set_btag_wp_corr[f"{self.btag_config.correction_set}_incl"]
+    else:
+        self.btag_sf_incl_corrector = correction_set_btag_wp_corr[f"{self.btag_config.correction_set}_light"]
+    self.btag_sf_comb_corrector = correction_set_btag_wp_corr[f"{self.btag_config.correction_set}_comb"]
+
+    # unpack the b-tagging efficiency
+    if self.has_external_efficiencies:
+        file = self.get_btag_eff(reqs["external_files"].files)[self.dataset_group]
+    else:
+        file = reqs["btag_efficiency"].output()["json"]
+
+    if file.path.endswith(".json.gz"):
+        corr_set_btag_eff_corr = correctionlib.CorrectionSet.from_string(file.load(formatter="gzip").decode("utf-8"))
+    elif file.path.endswith(".json"):
+        corr_set_btag_eff_corr = correctionlib.CorrectionSet.from_file(file.path)
+    else:
+        raise AssertionError(f"{file} should be json or json.gz")
+
+    if len(corr_set_btag_eff_corr.keys()) != 1:
+        raise Exception(f"Expected exactly one type of btagging efficiencies. Found more in provided file {file}.")
+
+    corrector_name = list(corr_set_btag_eff_corr.keys())[0]
+    self.btag_eff_corrector = corr_set_btag_eff_corr[corrector_name]
+
+
+@fixed_wp_btag_weights.requires
+def fixed_wp_btag_weights_requires(self: Producer, reqs: dict) -> None:
+    req_btag(self, reqs)
+
+    if not self.has_external_efficiencies:
+        from columnflow.tasks.cmsGhent.btagefficiency import BTagEfficiency
+        reqs["btag_efficiency"] = BTagEfficiency.req(
+            self.task,
+            datasets=self.datasets,
+            variables=self.variables,
+        )
+
+        if self.produce_plots:
+            from columnflow.tasks.cmsGhent.btagefficiency import BTagEfficiencyPlot
+            reqs["btag_efficiency_plots"] = BTagEfficiencyPlot.req(
+                self.task,
+                branch=-1,
+                _exclude={"branches"},
+                datasets=self.datasets,
+                variables=self.variables,
+                dataset_group=self.dataset_group,
+            )
+
+
+@producer(
+    uses={"mc_weight", "Jet.{hadronFlavour,pt,eta}"},
+    get_btag_config=(lambda self: BTagSFConfig.new(self.config_inst.x.btag_sf)),
+    get_btag_sf=lambda self, external_files: external_files.btag_sf_corr,
+    # only run on mc
+    mc_only=True,
+)
+def btag_efficiency_hists(
+    self: Producer,
+    events: ak.Array,
+    results: SelectionResult,
+    hists: DotDict | dict = None,
+    **kwargs,
+) -> ak.Array:
+
+    if hists is None:
+        return events
+
+    assert "event_no_btag" in results.aux, "results.aux does not contain mask 'event_no_btag'"
+
+    # jet selection and event selection
+    jets = events.Jet[results.objects.Jet.Jet][results.x.event_no_btag]
+    selected_events = ak.Array({
+        "Jet": jets,
+        "mc_weight": events.mc_weight[results.x.event_no_btag],
+    })
+
+    histogram = hist.Hist.new.IntCat([0, 4, 5], name="hadronFlavour")  # Jet hadronFlavour 0, 4, or 5
+    # add variables for binning the efficiency
+    for var_inst in self.variable_insts:
+        histogram = histogram.Var(
+            var_inst.bin_edges,
+            name=var_inst.name,
+            label=var_inst.get_full_x_title(),
+        )
+    hists["btag_efficiencies"] = histogram.Weight()
+
+    fill_kwargs = {
+        # broadcast event weight and process-id to jet weight
+        "hadronFlavour": ak.flatten(jets.hadronFlavour),
+        "weight": ak.flatten(ak.broadcast_arrays(selected_events.mc_weight, jets.hadronFlavour)[0]),
+    }
+
+    # loop over Jet variables in which the efficiency is binned
+    for var_inst in self.variable_insts:
+        expr = var_inst.expression
+        if isinstance(expr, str):
+            route = Route(expr)
+
+            def expr(evs, *args, **kwargs):
+                if len(evs) == 0 and not has_ak_column(evs, route):
+                    return ak.Array(np.array([], dtype=np.float32))
+                return route.apply(evs, null_value=var_inst.null_value)
+
+        # apply the variable (flatten to fill histogram)
+        fill_kwargs[var_inst.name] = ak.flatten(expr(selected_events))
+
+    # fill inclusive histogram
+    hists["btag_efficiencies"].fill(**fill_kwargs)
+    hists["btag_efficiencies"].name = f"{self.btag_config.correction_set}({self.btag_config.discriminator})"
+
+    return events
+
+
+@btag_efficiency_hists.init
+def btag_efficiency_hists_init(self: Producer) -> None:
+    init_btag(self)
+
+
+@btag_efficiency_hists.setup
+def btag_efficiency_hists_setup(
+    self: Producer,
+    reqs: dict,
+    inputs: dict,
+    reader_targets: InsertableDict,
+) -> None:
+    setup_btag(self, reqs)
+    self.variable_insts.append(od.Variable(
+        name="btag_wp",
+        expression=f"Jet.{self.btag_config.discriminator}",
+        binning=[0, *self.btag_wp_value.values(), 1],
+        x_labels=["U", "L", "M", "T"],
+    ))
+
+
+@btag_efficiency_hists.requires
+def btag_efficiency_hists_requires(self: Producer, reqs: dict) -> None:
+    req_btag(self, reqs)

--- a/columnflow/tasks/cmsGhent/btagefficiency.py
+++ b/columnflow/tasks/cmsGhent/btagefficiency.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import law
+import luigi
+
+import order as od
+from collections import OrderedDict
+
+from columnflow.tasks.framework.base import Requirements
+from columnflow.tasks.framework.mixins import (
+    CalibratorsMixin, VariablesMixin, SelectorMixin, DatasetsMixin,
+)
+from columnflow.tasks.framework.plotting import (
+    PlotBase, PlotBase2D,
+)
+from columnflow.tasks.cmsGhent.selection_hists import SelectionEfficiencyHistMixin, CustomDefaultVariablesMixin
+
+from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.util import dev_sandbox, dict_add_strict, DotDict, maybe_import
+
+hist = maybe_import("hist")
+
+
+class BTagEfficiencyBase:
+    tag_name = "btag"
+    flav_name = "hadronFlavour"
+    flavours = {0: "light", 4: "charm", 5: "bottom"}
+    wps = ["L", "M", "T"]
+
+
+class BTagEfficiency(
+    BTagEfficiencyBase,
+    SelectionEfficiencyHistMixin,
+    CustomDefaultVariablesMixin,
+    VariablesMixin,
+    SelectorMixin,
+    CalibratorsMixin,
+    law.LocalWorkflow,
+    RemoteWorkflow,
+):
+    def output(self):
+        return {
+            "json": self.target(f"{self.tag_name}_efficiency.json"),
+            "hist": self.target(f"{self.tag_name}_efficiency.pickle"),
+        }
+
+    def get_plot_parameters(self):
+        # convert parameters to usable values during plotting
+        params = super().get_plot_parameters()
+        dict_add_strict(params, "legend_title", "Processes")
+        return params
+
+    @law.decorator.log
+    def run(self):
+        import hist
+        import correctionlib
+        import correctionlib.convert
+        from columnflow.plotting.cmsGhent.plot_util import cumulate
+
+        variable_insts = list(map(self.config_inst.get_variable, self.variables))
+        histograms = self.read_hist(variable_insts)
+        sum_histogram = sum(histograms.values())
+
+        # combine tagged and inclusive histograms to an efficiency histogram
+        cum_histogram = cumulate(sum_histogram, direction="above", axis=f"{self.tag_name}_wp")
+        incl = cum_histogram[{f"{self.tag_name}_wp": slice(0, 1)}]
+
+        axes = OrderedDict(zip(cum_histogram.axes.name, cum_histogram.axes))
+        axes[f"{self.tag_name}_wp"] = hist.axis.StrCategory(self.wps, name=f"{self.tag_name}_wp", label="working point")
+
+        selected_counts = hist.Hist(*axes.values(), name=sum_histogram.name, storage=hist.storage.Weight())
+        selected_counts.view()[:] = cum_histogram[{"btag_wp": slice(1, None)}].view()
+
+        efficiency_hist = self.efficiency(selected_counts, incl)
+
+        # save as pickle hist
+        self.output()["hist"].dump(efficiency_hist, formatter="pickle")
+
+        # save as correctionlib file
+        efficiency_hist.label = "out"
+        description = f"{self.tag_name} efficiencies of jets for {efficiency_hist.name} algorithm"
+        clibcorr = correctionlib.convert.from_histogram(efficiency_hist[{"systematic": "central"}])
+        clibcorr.description = description
+
+        cset = correctionlib.schemav2.CorrectionSet(schema_version=2, description=description, corrections=[clibcorr])
+        self.output()["json"].dump(cset.dict(exclude_unset=True), indent=4, formatter="json")
+
+
+class BTagEfficiencyPlot(
+    BTagEfficiencyBase,
+    DatasetsMixin,
+    CustomDefaultVariablesMixin,
+    VariablesMixin,
+    SelectorMixin,
+    CalibratorsMixin,
+    law.LocalWorkflow,
+    PlotBase2D,
+):
+    reqs = Requirements(BTagEfficiency=BTagEfficiency)
+
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.plot_functions_2d.plot_2d",
+        add_default_to_description=True,
+    )
+
+    dataset_group = luigi.Parameter(
+        default="",
+        description="the name of the label to print on the b-tagging efficiency plots to represent the dataset group.",
+    )
+
+    sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
+
+    def store_parts(self):
+        parts = super().store_parts()
+        parts.insert_before("version", "datasets", f"datasets_{self.datasets_repr}")
+        return parts
+
+    def create_branch_map(self):
+        return [
+            DotDict({"flav": flav, "wp": wp})
+            for flav in self.flavours
+            for wp in self.wps
+        ]
+
+    def requires(self):
+        return self.reqs.BTagEfficiency.req(
+            self,
+            branch=-1,
+            _exclude={"branches"},
+        )
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+        reqs["BTagEfficiency"] = self.requires_from_branch()
+
+        return reqs
+
+    def output(self):
+        return [
+            [
+                self.target(name)
+                for name in self.get_plot_names(
+                    f"{self.tag_name}_eff__{self.flavours[self.branch_data.flav]}_{self.flav_name}"
+                    f"__wp_{self.branch_data.wp}" +
+                    (f"__err_{dr}" if dr != "central" else ""),
+                )
+            ]
+            for dr in ["central", "down", "up"]
+        ]
+
+    def run(self):
+        import hist
+        import numpy as np
+
+        variable_insts = list(map(self.config_inst.get_variable, self.variables))
+
+        # plot efficiency for each hadronFlavour and wp
+        efficiency_hist = self.input()["collection"][0]["hist"].load(formatter="pickle")
+
+        for i, sys in enumerate(["central", "down", "up"]):
+            # create a dummy histogram dict for plotting with the first process
+            # TODO change process name to the relevant process group
+            h = efficiency_hist[{
+                self.flav_name: hist.loc(self.branch_data.flav),
+                f"{self.tag_name}_wp": self.branch_data.wp,
+            }]
+
+            h_sys = h[{"systematic": sys}]
+            if sys != "central":
+                h_sys -= h[{"systematic": "central"}].values()
+
+            # create dummy process for plotting
+            proc = od.Process(
+                name=f"{self.datasets_repr}_{self.dataset_group}",
+                id="+",
+                label=self.dataset_group,
+            )
+
+            # create a dummy category for plotting
+            cat = od.Category(
+                name=self.flav_name,
+                label=self.flavours[self.branch_data.flav],
+            )
+
+            # custom styling:
+            label_values = np.round(h_sys.values() * 100, decimals=1)
+            style_config = {"plot2d_cfg": {"cmap": "PiYG", "labels": label_values}}
+            # call the plot function
+            fig, _ = self.call_plot_func(
+                self.plot_function,
+                hists={proc: h_sys},
+                config_inst=self.config_inst,
+                category_inst=cat.copy_shallow(),
+                variable_insts=[var_inst.copy_shallow() for var_inst in variable_insts],
+                style_config=style_config,
+                **self.get_plot_parameters(),
+            )
+            for p in self.output()[i]:
+                p.dump(fig, formatter="mpl")

--- a/columnflow/tasks/cmsGhent/selection_hists.py
+++ b/columnflow/tasks/cmsGhent/selection_hists.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import luigi
+import law
+import order as od
+
+from columnflow.tasks.framework.base import Requirements
+from columnflow.tasks.framework.mixins import DatasetsMixin, VariablesMixin
+from columnflow.tasks.selection import MergeSelectionStats
+from columnflow.tasks.framework.remote import RemoteWorkflow
+from columnflow.util import dev_sandbox, maybe_import
+
+from columnflow.tasks.framework.plotting import (
+    PlotBase, PlotBase1D, VariablePlotSettingMixin, ProcessPlotSettingMixin,
+)
+
+from columnflow.types import Any
+
+
+hist = maybe_import("hist")
+
+
+class CustomDefaultVariablesMixin(
+    VariablesMixin,
+):
+    tag_name = ""
+    exclude_index = True
+
+    @classmethod
+    def get_default_variables(cls, params):
+        if not (config_inst := params.get("config_inst")):
+            return params
+        tag = ("_" if cls.tag_name else "") + cls.tag_name
+
+        return config_inst.x(f"default_{tag}_variables", tuple())
+
+    @classmethod
+    def resolve_param_values(
+            cls,
+            params: law.util.InsertableDict[str, Any],
+    ) -> law.util.InsertableDict[str, Any]:
+        f"""
+        Resolve values *params* and check against possible default values
+
+        Check the values in *params* against the default value in the current config inst.
+        See {cls.__class__}.get_default_variables for where the default value should be stored
+        For more information, see
+        :py:meth:`~columnflow.tasks.framework.base.ConfigTask.resolve_config_default_and_groups`.
+        """
+        redo_default_variables = False
+        # when empty, use the config default
+        if not params.get("variables", None):
+            redo_default_variables = True
+
+        params = super().resolve_param_values(params)
+
+        config_inst = params.get("config_inst")
+        if not config_inst:
+            return params
+
+        if redo_default_variables:
+            # when empty, use the config default
+            if default_variables := cls.get_default_variables(params):
+                params["variables"] = tuple(default_variables)
+            elif cls.default_variables:
+                params["variables"] = tuple(cls.default_variables)
+            else:
+                raise AssertionError(f"define default {cls.tag_name} variables "
+                                     f"in {cls.__class__} or config {config_inst.name}")
+
+        return params
+
+
+class SelectionEfficiencyHistMixin(
+    DatasetsMixin,
+):
+    exclude_index = True
+
+    # upstream requirements
+    reqs = Requirements(
+        RemoteWorkflow.reqs,
+        MergeSelectionStats=MergeSelectionStats,
+    )
+
+    sandbox = dev_sandbox("bash::$CF_BASE/sandboxes/venv_selection_eff.sh")
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+        for d in self.datasets:
+            reqs[d] = self.reqs.MergeSelectionStats.req(
+                self,
+                branch=-1,
+                dataset=d,
+            )
+        return reqs
+
+    def requires(self):
+        return {
+            d: self.reqs.MergeSelectionStats.req(
+                self,
+                branch=-1,
+                dataset=d,
+            )
+            for d in self.datasets
+        }
+
+    def create_branch_map(self):
+        # create a dummy branch map so that this task could be submitted as a job
+        return {0: None}
+
+    def store_parts(self):
+        parts = super().store_parts()
+        parts.insert_before("version", "datasets", f"datasets_{self.datasets_repr}")
+        return parts
+
+    @classmethod
+    def get_process_xsec(cls, dataset: od.Dataset | str, config_inst: od.Config) -> tuple[od.Process, float]:
+        """
+        link dataset to a process and a xsec. Implemented as class method so it can be easily adapted to the
+        the needs of a specific analysis using a patch.
+        """
+        dataset_inst = dataset if isinstance(dataset, od.Dataset) else config_inst.get_dataset(dataset)
+        process_inst = dataset_inst.processes.get_first()
+        if config_inst.has_process(process_inst):
+            process_inst = config_inst.get_process(process_inst)
+        xsec = 1 if process_inst.is_data else process_inst.get_xsec(config_inst.campaign.ecm).nominal
+        return process_inst, xsec
+
+    def read_hist(self, variable_insts=tuple(), name=None) -> dict[od.Dataset, hist.Hist]:
+        """
+        read the histograms calculated in MergeSelectionStats task, properly normalize,
+        and apply flow and merged bin settings from the given variables.
+        """
+        import numpy as np
+        from columnflow.plotting.plot_util import use_flow_bins
+
+        if name is None:
+            name = f"{self.tag_name}_efficiencies"
+        # histogram for the tagged and all jets (combine all datasets)
+
+        histograms = {}
+        for dataset, inp in self.input().items():
+            # map dataset to one of to requested processes
+            _, xsec = self.get_process_xsec(dataset, self.config_inst)
+            dataset_inst = self.config_inst.get_dataset(dataset)
+
+            h_in = inp["collection"][0]["hists"].load(formatter="pickle")[name]
+            for variable_inst in variable_insts:
+                v_idx = h_in.axes.name.index(variable_inst.name)
+                for mi, mj in variable_inst.x("merge_bins", []):
+                    merged_bins = h_in[{variable_inst.name: slice(mi, mj + 1, sum)}]
+                    new_arr = np.moveaxis(h_in.view(), v_idx, 0)
+                    new_arr[mi:mj + 1] = merged_bins.view()[np.newaxis]
+                    h_in.view()[:] = np.moveaxis(new_arr, 0, v_idx)
+
+                if any(flows := [
+                    getattr(variable_inst, f + "flow", variable_inst.x(f + "flow", False))
+                    for f in ["under", "over"]
+                ]):
+                    h_in = use_flow_bins(h_in, variable_inst.name, *flows)
+
+            if dataset_inst.is_mc:
+                norm = inp["collection"][0]["stats"].load()["sum_mc_weight"]
+                h_in = h_in * xsec / norm * self.config_inst.x.luminosity.nominal
+
+            histograms[dataset_inst] = histograms.get(dataset_inst, 0) + h_in
+
+        if not histograms:
+            raise Exception(
+                "no histograms found to plot; possible reasons:\n" +
+                "  - requested variable requires columns that were missing during histogramming\n" +
+                "  - selected --datasets did not match any value on the process axis of the input histogram",
+            )
+
+        return histograms
+
+    @classmethod
+    def efficiency(cls, selected_counts: hist.Hist, incl: hist.Hist, **kwargs) -> hist.Hist:
+        """
+        calculate efficiencies with uncertainties given two histograms **selected_counts** and **incl**
+        containing  the counts before and after selecton. The uncertainties are calculated using the method
+        **proportion_confint**  from the **statsmodels.stats.proportion** modul. The default output are
+        two-sided 65% level confidence intervals according to the Clopper-Pearson (beta) method, but other settings
+        can be chosen through the keyword arguments. For more documentation see
+
+        https://www.statsmodels.org/dev/generated/statsmodels.stats.proportion.proportion_confint.html
+
+        @param selected_counts: histogram with event counts after selection
+        @param incl: histogram with event counts before selection
+        @param kwargs: keyword arguments passed to **proportion_confint**
+        """
+        from statsmodels.stats.proportion import proportion_confint
+        efficiency = selected_counts / incl.values()
+        eff_sample_size_corr = incl.values() / incl.variances()
+        eff_selected = selected_counts.values() * eff_sample_size_corr
+        eff_incl = incl.values() * eff_sample_size_corr
+        kwargs = dict(alpha=0.35, method="beta") | kwargs
+        error = proportion_confint(eff_selected, eff_incl, **kwargs)
+        eff_full = hist.Hist(
+            hist.axis.StrCategory(["central", "down", "up"], name="systematic"),
+            *selected_counts.axes,
+            storage=hist.storage.Weight(),
+            name=selected_counts.name,
+        )
+        eff_full.values()[:] = [efficiency.values(), *error]
+        eff_full.variances()[:] = 1
+        return eff_full
+
+
+class SelectionHistPlot(
+    SelectionEfficiencyHistMixin,
+    CustomDefaultVariablesMixin,
+    VariablePlotSettingMixin,
+    ProcessPlotSettingMixin,
+    PlotBase1D,
+):
+    exclude_index = False
+
+    hist_name = luigi.Parameter(
+        description="name of the selection histograms to plot",
+        significant=True,
+    )
+    cat_label = luigi.Parameter(
+        default="",
+        description="category label for the plot",
+        significant=False,
+    )
+
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.plot_functions_1d.plot_variable_per_process",
+        add_default_to_description=True,
+    )
+
+    @law.workflow_property(setter=True, cache=True, empty_value=0)
+    def hist_variables(self):
+        # check if the merging stats are present
+        all_hists = []
+        for d in self.datasets:
+            hists = self.reqs.MergeSelectionStats.req(self, dataset=d).output()["hists"]
+            if not hists.exists():
+                return []
+            all_hists.append(hists.load(formatter="pickle")[self.hist_name])
+        if not all([h.axes == all_hists[0].axes for h in all_hists]):
+            return []
+        return all_hists[0].axes.name
+
+    @law.dynamic_workflow_condition
+    def workflow_condition(self):
+        # the workflow shape can be constructed as soon as the histogram variables are know
+        return self.hist_variables
+
+    @workflow_condition.output
+    def output(self):
+        return {
+            vr: [self.target(name) for name in self.get_plot_names(vr)]
+            for vr in self.hist_variables
+        }
+
+    @law.decorator.log
+    def run(self):
+        variable_insts = list(map(self.config_inst.get_variable, self.variables))
+        histograms = self.read_hist(variable_insts)
+
+        for variable_name in self.hist_variables:
+            variable_inst = self.config_inst.get_variable(
+                variable_name,
+                default=od.Variable(variable_name),
+            )
+
+            fig, _ = self.call_plot_func(
+                self.control_plot_function,
+                hists={process_inst: h.project(variable_name) for process_inst, h in histograms.items()},
+                config_inst=self.config_inst,
+                category_inst=od.Category(name=self.cat_label),
+                variable_insts=[variable_inst.copy_shallow()],
+                **self.get_control_plot_parameter(),
+            )
+            for p in self.output()[variable_name]:
+                p.dump(fig, formatter="mpl")


### PR DESCRIPTION
### Introduction

This merge request introduces a `fixed_wp_btag_weights` producer that produces b-tagging scale factors with up and down uncertainties for fixed working point (wp) b-tagging. The implementation that is followed for fixed working point b-tagging scale factors  are the [BTV Recommendations](https://btv-wiki.docs.cern.ch/PerformanceCalibration/fixedWPSFRecommendations/) 

### Summary of Changes
#### Producers
- **BTagSFConfig update:** added `robustparticletransformer` to the possible desciminators and include uncertainty `sources`  as an attribute.
- **jet_btag producer:** This `producer` takes as input `events`, `working_points` (eg.: [L, M, T]) and `jet_mask`, produces a mask for each jet whether it passes the b-tagging wp requirement and `jet_mask` if provided and stores the mask in the column`Jet.btag_{wp}`. All b-tagging related producers use the **BTagSFConfig** accessed through `self.get_btag_config` to know the `discriminator` used for b-tagging. The working point values do not need to be defined in the config and are instead read out from a correctionlib file provided by BTV (accessed trough `self.get_btag_sf`).
- **fixed_wp_btag_weights producer:** This `producer` implements the fixed b-tagging scale factor implementation provided by BTV. The b-tagging weights are split into heavy flavor and light-flavor groups together with up/down uncertainties for each of the `sources` provided in the `BTagSFConfig`. B-tagging scale factors with fixed wp require the b-tagging efficiency in Monte Carlo to be measured in the analysis phase-space (without b-tagging requirements). For this in addition to the `BTagSFConfig` the production of b-tagging efficiencies requires two additional settings in the config:
  - binning variables: the variables in which to bin the measured b-tagging efficiency. These variables are added to the config and their names stored in `config.x.default_btag_variables`.
  - dataset groups: the Monte Carlo samples to combine for the b-tagging efficiency measurements. These dataset groups are of the type Dict[name,list(datasets)] and are stored in `config.x.btag_dataset_groups`. An example of dataset groups bundled by the number of top quarks in the process is shown here: 
  ```python
  config.x.btag_dataset_groups = {
      "ttx": [dataset.name for dataset in config.datasets if (
          dataset.name.startswith("tt") &
          (dataset.is_mc))],
      "tx": [dataset.name for dataset in config.datasets if (
          (dataset.name.startswith("t") |
          dataset.name.startswith("st")) &
          (not dataset.name.startswith("tt")) &
          (dataset.is_mc))],
      "ewk": [dataset.name for dataset in config.datasets if (
          ~(dataset.name.startswith("t") |
          dataset.name.startswith("st")) &
          (~dataset.name.startswith("tt")) &
          (dataset.is_mc))],
  }
  ```
- **btag_efficiency_hists producer:** This producer creates a histogram in the `cf.SelectEvents` task in order to calculate the b-tagging efficiency in Monte Carlo binned in the variables provided in  `config.x.default_btag_variables`. This histogram producer requires th input `results: SelectionResult`  the mask `results.x.event_no_btag` to exist and contain the full analysis selection without any b-tagging requirement.

#### Helpers

- **SelectionEfficiencyHistMixin:** This class is a helper for any columnflow task that requires efficiencies to be calculated from histograms produced in the selection task. This helper can then be used to derive efficiencies for b-tagging descriminators, triggers, object identification...
- **DatasetsMixin:** thiss Mixin class is taken directly from the `DatasetsProcessesMixin` class but is limited to only datasets. This is useful for plotting where the processes are not needed such as plotting b-tagging efficiencies
- [plot_util.py](https://github.com/columnflow/columnflow/pull/677/files#diff-bc61404c42ea481ccec90ee56b7104ccd7e9f189c1fdf4a5e6095ede6ade4720):
- [columnflow/plotting/plot_all.py](https://github.com/columnflow/columnflow/pull/677/files#diff-13835787137d07a881b78655ba80353cdbe2ff88dfcfc2e2666795de8240fbb0): allow a callable function of a custom plotting method to be given in the `plot_config` instead of a fixed set of plotting function names. If the custom plotting method is given the method is called instead of searching the method in `plot_methods`.

#### Columnflow Tasks
- **BTagEfficiency:** This task takes histograms provided by the `btag_efficiency_hists` producer in selection and calculates the b-tagging efficiency by using functions of the `SelectionEfficiencyHistMixin` helper class. The efficiency is derived for a each set of datasets defined in `config.x.btag_dataset_groups`. The efficiency histograms are stored in both pickle and correctionlib format. 
- **BTagEfficiencyPlot:** This task takes the efficiency histograms provided by the `BTagEfficiency` task and produces 2D plots for the b-tagging efficiency and uncertainty of each wp.


### Implementation

B-tagging scale factors are produces for fixed working points following [BTV recommendations](https://btv-wiki.docs.cern.ch/PerformanceCalibration/fixedWPSFRecommendations/). The configuration of the b-tagging scale factors is done with the class `BTagSFConfig` that has attributes:
- `correction_set`: b-tag algorithm name for which to produce scale factors (deepJet, particleNet, robustParticleTransformer)
- `sources`: uncertainty variations to include when producing the scale factors
- `jec_sources`: JEC uncertainty variations to propagate trough
B-tagging scale factors require the b-tagging efficiency in Monte Carlo to be measured in the analysis phase-space (without b-tagging requirements). For this in addition to the `BTagSFConfig` the production of b-tagging efficiencies requires two additional settings in the config:
- binning variables: the variables in which to bin the measured b-tagging efficiency. These variables are added to the config and their names stored in `config.x.default_btag_variables`.
- dataset groups: the Monte Carlo samples to combine for the b-tagging efficiency measurements. These dataset groups are of the type Dict[name,list(datasets)] and are stored in `config.x.btag_dataset_groups`. An example of dataset groups bundled by the number of top quarks in the process is shown here:

```python
config.x.btag_dataset_groups = {
    "ttx": [dataset.name for dataset in config.datasets if (
        dataset.name.startswith("tt") &
        (dataset.is_mc))],
    "tx": [dataset.name for dataset in config.datasets if (
        (dataset.name.startswith("t") |
        dataset.name.startswith("st")) &
        (not dataset.name.startswith("tt")) &
        (dataset.is_mc))],
    "ewk": [dataset.name for dataset in config.datasets if (
        ~(dataset.name.startswith("t") |
        dataset.name.startswith("st")) &
        (~dataset.name.startswith("tt")) &
        (dataset.is_mc))],
}
```

B-tagging scale factors require the b-tagging efficiency in Monte Carlo to be measured in the analysis phase-space (without b-tagging requirements). In columnflow this is achieved trough the custom `cf.BTagEfficiency` task in [columnflow/tasks/cmsGhent/btagefficiency.py](https://github.com/GhentAnalysis/columnflow/blob/scalefactor-development/columnflow/tasks/cmsGhent/btagefficiency.py). The `cf.BTagEfficiency` task requires histograms to be created in the `cf.SelectEvents` task using the `btag_efficiency_hists` helper function. This helper function can be included in the selection as shown in the [template selection](https://github.com/GhentAnalysis/columnflow/blob/9f4aa6629ef51bc568b02732c19cf55c5624d16b/analysis_templates/ghent_template/__cf_module_name__/selection/default.py#L238-L245). The `cf.BTagEfficiency` task is not required to be run in the command line as it is a requirement of the b-tagging weight producer in [columnflow/production/cmsGnet/btag_weights.py](https://github.com/GhentAnalysis/columnflow/blob/252a1c91a9a1b2238c6fcce219789e3733d1f432/columnflow/production/cmsGhent/btag_weights.py#L129) called `fixed_wp_btag_weights`. Here is an example of a `producer` to produce b-tagging scale factor weights and uncertainties for the `medium` working point:

```python
from columnflow.production.cmsGhent.btag_weights import jet_btag, fixed_wp_btag_weights

@producer(
    uses={fixed_wp_btag_weights, jet_btag},
    produces={fixed_wp_btag_weights, jet_btag},
)
def btag_weights(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
    is_ctjet = abs(events.Jet.eta) < 2.4
    events = self[jet_btag](events, working_points=["L", "M", "T"], jet_mask=is_ctjet)
    events = self[fixed_wp_btag_weights](events, working_points=["M",], jet_mask=is_ctjet)
    return events
```
### Merge Request Questions
- should any reference to Ghent be removed and the files be integrated into `cms` instead of  `cmsGhent`?

