### PR TITLE
alpha_s variation weights introduced in pdf_weights producer

### DIFF
--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -107,6 +107,11 @@ def pdf_weights(
             events = set_ak_column_f32(events, "pdf_weight", ones)
             events = set_ak_column_f32(events, "pdf_weight_up", ones)
             events = set_ak_column_f32(events, "pdf_weight_down", ones)
+
+        events = set_ak_column_f32(events, "alphas_weight", ones)
+        events = set_ak_column_f32(events, "alphas_weight_up", ones)
+        events = set_ak_column_f32(events, "alphas_weight_down", ones)
+
         return events
 
     # complain when the number of weights is unexpected
@@ -135,6 +140,24 @@ def pdf_weights(
     # (for datasets with 103 weights, the last two weights are related to alpha_s variations)
     pdf_weights = ak.where(invalid_mask, empty, ak.without_parameters(events.LHEPdfWeight[:, 1:101]))
     pdf_weights = pdf_weights / pdf_weight_nominal
+
+    # if all events have alpha_s variations included in LHEPdfWeight else add ones as weights
+
+    if ak.all(n_weights == 103):
+        alphas_weight = ak.where(invalid_mask, empty, ak.without_parameters(events.LHEPdfWeight[:, 101:]))
+        alphas_weight = alphas_weight / pdf_weight_nominal
+
+        # store columns
+        events = set_ak_column_f32(events, "alphas_weight", ones)
+        events = set_ak_column_f32(events, "alphas_weight_up", alphas_weight[:, 0])
+        events = set_ak_column_f32(events, "alphas_weight_down", alphas_weight[:, 1])
+    else:
+        events = set_ak_column_f32(events, "alphas_weight", ones)
+        events = set_ak_column_f32(events, "alphas_weight_up", ones)
+        events = set_ak_column_f32(events, "alphas_weight_down", ones)
+        logger.warning(
+            "the LHEPdfWeights do not include alpha_s variations and alphas_weight_up(down) are set to 1",
+        )
 
     # store the nominal weight which is always 1 after normalization
     events = set_ak_column_f32(events, "pdf_weight", ones)
@@ -203,6 +226,7 @@ def pdf_weights(
 def pdf_weight_init(self: Producer) -> None:
     # add produced columns: nominal+all, or nominal+up+down
     self.produces.add("pdf_weight{,s}" if self.store_all_weights else "pdf_weight{,_up,_down}")
+    self.produces.add("alphas_weight{,_up,_down}")
 
 
 def _raise_unknown_action(attr: str, action: str, known_actions: tuple[str]) -> None:

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -142,7 +142,6 @@ def pdf_weights(
     pdf_weights = pdf_weights / pdf_weight_nominal
 
     # if all events have alpha_s variations included in LHEPdfWeight else add ones as weights
-
     if ak.all(n_weights == 103):
         alphas_weight = ak.where(invalid_mask, empty, ak.without_parameters(events.LHEPdfWeight[:, 101:]))
         alphas_weight = alphas_weight / pdf_weight_nominal
@@ -152,12 +151,12 @@ def pdf_weights(
         events = set_ak_column_f32(events, "alphas_weight_up", alphas_weight[:, 0])
         events = set_ak_column_f32(events, "alphas_weight_down", alphas_weight[:, 1])
     else:
+        logger.debug(
+            "the LHEPdfWeights do not include alpha_s variations and alphas_weight_up(down) are set to 1",
+        )
         events = set_ak_column_f32(events, "alphas_weight", ones)
         events = set_ak_column_f32(events, "alphas_weight_up", ones)
         events = set_ak_column_f32(events, "alphas_weight_down", ones)
-        logger.warning(
-            "the LHEPdfWeights do not include alpha_s variations and alphas_weight_up(down) are set to 1",
-        )
 
     # store the nominal weight which is always 1 after normalization
     events = set_ak_column_f32(events, "pdf_weight", ones)
@@ -218,6 +217,10 @@ def pdf_weights(
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight", 0)
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_up", 0)
         events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_down", 0)
+
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight_up", 0)
+        events = fill_at_f32(events, invalid_pdf_weight, "alphas_weight_down", 0)
 
     return events
 


### PR DESCRIPTION
This merge request introduces $\alpha_s$ weights to the pdf weight producer. This producer takes the `101` and `102` indices in the `LHEPdfWeight` column in NanoAOD which correspond to the up and down variation of $\alpha_s$.