### PR TITLE
Fixes for docs (pdf figures not displayed)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 *.root filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_st__cat_incl__var_cf_jet1_pt.svg
+++ b/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_st__cat_incl__var_cf_jet1_pt.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73fb556f8ad709dac829b80129f91dc5dd51119549d0d632a6e4fd7a8432cd25
+size 210242

--- a/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_tt__cat_incl__var_cf_jet1_pt.svg
+++ b/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_tt__cat_incl__var_cf_jet1_pt.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86c5c00f4a094ed50fdd31d58b90b3d896058a1f4419014f3993131bbff00cfb
+size 202776

--- a/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step0_Initial__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.svg
+++ b/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step0_Initial__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a7e2fcff6a0613c161648c8c6516cf0795d03d81a91f73c5cd7ca254abc421b
+size 248365

--- a/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step1_jet__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.svg
+++ b/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step1_jet__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d382de76aec4c8a67a4461e40fed9e9539c0563f2a0a1a9a3643adfeb9d6387
+size 242995

--- a/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step2_muon__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.svg
+++ b/docs/plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step2_muon__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbd6d7cf3f4fa21c9966c6ea50ee177c9701ff2e912cbd7af63a5f2f7434ffaa
+size 250007

--- a/docs/plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_2j.svg
+++ b/docs/plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_2j.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34dafc8075593ff87f6c6bf0405f2ad61cbbd3c803e10794aaed6c8a9189b471
+size 81445

--- a/docs/plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_incl.svg
+++ b/docs/plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_incl.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b5bc97efe206a5cb701c47084fd2516c85ec3ad0300f920793e64da1b448e5f
+size 82094

--- a/docs/plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_jet1_pt.svg
+++ b/docs/plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_jet1_pt.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:633307589b4d591bcc61187b5151681a6dcbd61bfc69c9e8882e423ebbda391c
+size 214961

--- a/docs/plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_n_jet.svg
+++ b/docs/plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_n_jet.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdcf0f2fce69c55b40fad8043e900ff55fbec5a078da8be4dcebe54515a8b920
+size 135064

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c1.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c1.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a08862597f9cbc4b5d2d856a22dc446c5af087d1624a4455d40ac2c7a433562
+size 109288

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c1.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c1.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe5e738db8a28cd5b5bf7bef6d3ccac05d6969b5240c1b2c4feb192f3833c0d3
+size 81395

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_2j__var_n_jet.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_2j__var_n_jet.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18b913c59ed746a0fa44e4d757d1bafa70a15310505487f28aa039d9bed815b7
+size 155256

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b001d593c28235d89235c34377ab6ec7bf321db66a0b29d70459df22c4de30d2
+size 157627

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__4601e8554b__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__4601e8554b__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b001d593c28235d89235c34377ab6ec7bf321db66a0b29d70459df22c4de30d2
+size 157627

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c3.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c3.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9ead543626fa2f47a7d61d9db2fae878c911d4dd89ba8dbc79d57dfdcc8058f
+size 105864

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c3.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c3.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1032fa21375905110bb671ed5be9c1c7c544bc494a859a5a71ced93b1c0f6a52
+size 94052

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c2.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c2.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b434012dade58ee791ce641dbeda592e66344021ba1d43748d34fae9d2538607
+size 108692

--- a/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c2.svg
+++ b/docs/plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c2.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b10b921b172e8bd05b970bb41a53bac452ea0b68324e4367cd7c2a063dd0a694
+size 103256

--- a/docs/plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt-n_jet.svg
+++ b/docs/plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt-n_jet.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cadccf88f3e91950ed180d3b40dd5b2893a10086e054a4eb22c87ae895dcbcb6
+size 178280

--- a/docs/plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_n_jet-jet1_pt.svg
+++ b/docs/plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_n_jet-jet1_pt.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:418d0c0f667ee18d2cf1f1ebd67b0ecab2c926c9edffe886121274f9dce301bd
+size 178610

--- a/docs/user_guide/plotting.md
+++ b/docs/user_guide/plotting.md
@@ -19,11 +19,11 @@ law run cf.PlotVariables1D --version v1 \
 This will run the full analysis chain for the given processes (data, tt, st) and should create plots looking like this:
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_incl__var_n_jet.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_2j__var_n_jet.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__12dfac316a__plot__proc_3_7727a49dc2__cat_2j__var_n_jet.*
 :width: 100%
 :::
 ::::
@@ -90,11 +90,11 @@ law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1
 to produce the following plot:
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c1.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c1.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c1.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__0191de868f__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c1.*
 :width: 100%
 :::
 ::::
@@ -130,11 +130,11 @@ law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1
 ```
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c2.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c2.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c2.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__c80529af83__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c2.*
 :width: 100%
 :::
 ::::
@@ -186,11 +186,11 @@ law run cf.PlotVariables1D --version v1 --processes tt,st --variables n_jet,jet1
 ```
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c3.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt__c3.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c3.pdf
+:::{figure} ../plots/cf.PlotVariables1D_tpl_config_analy__1__be60d3bca7__plot__proc_2_a2211e799f__cat_incl__var_n_jet__c3.*
 :width: 100%
 :::
 ::::
@@ -206,11 +206,11 @@ law run cf.PlotVariables2D --version v1 \
 ```
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt-n_jet.pdf
+:::{figure} ../plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_jet1_pt-n_jet.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_n_jet-jet1_pt.pdf
+:::{figure} ../plots/cf.PlotVariables2D_tpl_config_analy__1__b27b994979__plot__proc_2_a2211e799f__cat_incl__var_n_jet-jet1_pt.*
 :width: 100%
 :::
 ::::
@@ -233,11 +233,11 @@ law run cf.PlotCutflow --version v1 \
 ```
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_incl.pdf
+:::{figure} ../plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_incl.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_2j.pdf
+:::{figure} ../plots/cf.PlotCutflow_tpl_config_analy__1__12a17bf79c__cutflow__cat_2j.*
 :width: 100%
 :::
 ::::
@@ -269,15 +269,15 @@ law run cf.PlotCutflowVariables1D --version v1 \
 ```
 
 ::::{grid} 1 1 3 3
-:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step0_Initial__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.pdf
+:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step0_Initial__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step1_jet__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.pdf
+:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step1_jet__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step2_muon__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.pdf
+:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__d8a37d3da9__plot__step2_muon__proc_2_a2211e799f__cat_incl__var_cf_jet1_pt.*
 :width: 100%
 :::
 ::::
@@ -293,11 +293,11 @@ law run cf.PlotCutflowVariables1D --version v1 \
 ```
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_st__cat_incl__var_cf_jet1_pt.pdf
+:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_st__cat_incl__var_cf_jet1_pt.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_tt__cat_incl__var_cf_jet1_pt.pdf
+:::{figure} ../plots/cf.PlotCutflowVariables1D_tpl_config_analy__1__c3947accbb__plot__proc_tt__cat_incl__var_cf_jet1_pt.*
 :width: 100%
 :::
 ::::
@@ -328,11 +328,11 @@ law run cf.PlotShiftedVariables1D --version v1 \
 and produces the following plot:
 
 ::::{grid} 1 1 2 2
-:::{figure} ../plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_jet1_pt.pdf
+:::{figure} ../plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_jet1_pt.*
 :width: 100%
 :::
 
-:::{figure} ../plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_n_jet.pdf
+:::{figure} ../plots/cf.PlotShiftedVariables1D_tpl_config_analy__1__42b45aba89__plot__proc_2_a2211e799f__unc_mu__cat_incl__var_n_jet.*
 :width: 100%
 :::
 ::::

--- a/docs/user_guide/plotting.md
+++ b/docs/user_guide/plotting.md
@@ -31,7 +31,7 @@ This will run the full analysis chain for the given processes (data, tt, st) and
 :::{dropdown} Where do I find that plot?
 You can add ```--print-output 0``` to every task call, which will print the full filename of all outputs of the requested task.
 Alternatively, you can add ```--fetch-output 0,a``` to directly copy all outputs of this task into the directory you are currently in.
-Finally, there is the ```--view-cmd``` parameter you can add to directly display the plot during the runtime of the task, e.g. via ```--view-cmd evince-previewer``` or ```--view-cmd imgcat```.
+Finally, there is the ```--view-cmd``` parameter you can add to directly display the plot during the runtime of the task, e.g. via ```--view-cmd evince``` or ```--view-cmd imgcat```.
 :::
 
 The ```PlotVariables1D``` task is located at the bottom of our [task graph](https://github.com/columnflow/columnflow/wiki#default-task-graph), which means that all tasks leading to ```PlotVariables1D``` will be run for all datasets corresponding to the ```--processes``` we requested using the {py:class}`~columnflow.calibration.Calibrator`s, {py:class}`~columnflow.selection.Selector`, and {py:class}`~columnflow.production.Producer`s (often referred to as CSPs) as requested.
@@ -346,7 +346,7 @@ All plotting tasks also include a ```--view-cmd``` parameter that allows directl
 
 ```shell
 law run cf.PlotVariables1D --version v1 \
-    --processes tt,st --variables n_jet --view-cmd evince-previewer
+    --processes tt,st --variables n_jet --view-cmd evince
 ```
 
 (custom_plot_function)=


### PR DESCRIPTION
Mainly a fix to display the plots in the figures. Currently, the docs on readthedocs do not show the plots, but only links to the PDFs (maybe the alt text):
![image](https://github.com/user-attachments/assets/0d1a08b9-3c51-4bb4-845d-3184529ef074)

Although I heard rumors that for some person/os/browser combinations the PDFs are shown, we should resort so something that works for the average viewer.

I converted all plot PDFs to additional SVGs. If readthedocs would use the Makefile, one could have made a rule for automatic conversion, but I think this is good enough, because these plots have not changed too often. 
For the figure directives, I changed the file endings to wildcards, so sphinx uses what is best for the export format (e.g. latex will still use pdf).
![image](https://github.com/user-attachments/assets/472fc0bb-d555-4316-a5fe-72d811ecf297)

(+I added an lfs filter for svg files. The file `plots/user_guide/cf_plot.svg` was on lfs, already, but I did not find any filter for that -- probably somebody uploaded it to lfs, but did not commit the corresponding `.gitattributes`.)