### PR TITLE
allow passing mask to apply JER smearing only to a subset of jets

### DIFF
--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -958,7 +958,8 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
 
 
 jer_horn_handling = jer.derive("jer_horn_handling", cls_dict={
-    "stochastic_smearing_mask": lambda self, jets: (abs(jets.eta) < 2.6) | (abs(jets.eta) > 3.1),
+    # source: https://cms-jerc.web.cern.ch/Recommendations/#note-25eta30
+    "stochastic_smearing_mask": lambda self, jets: (abs(jets.eta) < 2.5) | (abs(jets.eta) > 3.0),
 })
 
 

--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -708,6 +708,8 @@ def get_jer_config_default(self: Calibrator) -> DotDict:
     jec_uncertainty_sources=None,
     # whether gen jet matching should be performed relative to the nominal jet pt, or the jec varied values
     gen_jet_matching_nominal=False,
+    # regions where stochastic smearing is applied
+    stochastic_smearing_mask=lambda self, jets: ak.ones_like(jets.pt, dtype=np.bool),
 )
 def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     """
@@ -847,7 +849,11 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
     add_smear = np.sqrt(ak.where(jersf2_m1 < 0, 0, jersf2_m1))
 
     # compute smearing factors (stochastic method)
-    smear_factors_stochastic = 1.0 + random_normal * jer * add_smear
+    smear_factors_stochastic = ak.where(
+        self.stochastic_smearing_mask(events[jet_name]),
+        1.0 + random_normal * jer * add_smear,
+        1.0,
+    )
 
     # -- scaling method (using gen match)
 
@@ -949,6 +955,11 @@ def jer(self: Calibrator, events: ak.Array, **kwargs) -> ak.Array:
             events = set_ak_column_f32(events, f"{met_name}.phi{postfix}", met_phi)
 
     return events
+
+
+jer_horn_handling = jer.derive("jer_horn_handling", cls_dict={
+    "stochastic_smearing_mask": lambda self, jets: (abs(jets.eta) < 2.6) | (abs(jets.eta) > 3.1),
+})
 
 
 @jer.init

--- a/columnflow/production/cms/jet.py
+++ b/columnflow/production/cms/jet.py
@@ -198,7 +198,11 @@ def msoftdrop(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         valid_subjet_idxs = ak.mask(subjet_idx, subjet_idx >= 0)
 
         # pad list of subjets to prevent index error on lookup
-        padded_subjet = ak.pad_none(subjet, ak.max(valid_subjet_idxs) + 1)
+        max_valid_subjets = ak.max(valid_subjet_idxs)
+        padded_subjet = ak.pad_none(
+            subjet,
+            0 if max_valid_subjets is None else (max_valid_subjets + 1),
+        )
 
         # retrieve subjets for each jet
         valid_subjet = padded_subjet[valid_subjet_idxs]


### PR DESCRIPTION
This mini PR allows passing a mask to the `jer` Calibrator to disable the stochastic smearing for a subset of jets.

I also added the `jer_horn_handling` that disables the stochastic smearing in `2.5 < |eta| < 3.0`, following the latest CMS recommendations: https://cms-jerc.web.cern.ch/Recommendations/#note-25eta30


Additionally, I also fixed an issue with the `msoftdrop` Producer similar to #603 (padding to 0 when `ak.max` returns None)