### PR TITLE
allow skipping preparation_producer in MLEvaluation

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1458,7 +1458,9 @@ class PreparationProducerMixin(ArrayFunctionInstanceMixin, MLModelMixin):
     exclude_params_sandbox = {"preparation_producer_inst"}
     exclude_params_remote_workflow = {"preparation_producer_inst"}
 
-    invokes_preparation_producer = False
+    @classmethod
+    def invokes_preparation_producer(cls, params) -> bool:
+        return False
 
     @classmethod
     def get_producer_dict(cls, params: dict[str, Any]) -> dict[str, Any]:
@@ -1478,10 +1480,12 @@ class PreparationProducerMixin(ArrayFunctionInstanceMixin, MLModelMixin):
     @classmethod
     def resolve_instances(cls, params: dict[str, Any], shifts: TaskShifts) -> dict[str, Any]:
         ml_model_inst = params["ml_model_inst"]
-        preparation_producer = ml_model_inst.preparation_producer(params["analysis_inst"])
-        # add the producer instance
-        if preparation_producer and not params.get("preparation_producer_inst"):
-            params["preparation_producer_inst"] = cls.build_producer_inst(preparation_producer, params)
+
+        if cls.invokes_preparation_producer(params):
+            preparation_producer = ml_model_inst.preparation_producer(params["analysis_inst"])
+            # add the producer instance
+            if preparation_producer and not params.get("preparation_producer_inst"):
+                params["preparation_producer_inst"] = cls.build_producer_inst(preparation_producer, params)
 
         params = super().resolve_instances(params, shifts)
 

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -50,7 +50,10 @@ class PrepareMLEvents(
     sandbox = dev_sandbox(law.config.get("analysis", "default_columnar_sandbox"))
 
     allow_empty_ml_model = False
-    invokes_preparation_producer = True
+
+    @classmethod
+    def invokes_preparation_producer(cls, params) -> bool:
+        return True
 
     # upstream requirements
     reqs = Requirements(
@@ -570,8 +573,6 @@ class MLEvaluation(
     law.LocalWorkflow,
     RemoteWorkflow,
 ):
-    # TODO: Needs to be chosen based on ml_model_cls.preparation_producer_in_ml_evaluation
-    invokes_preparation_producer = True
 
     sandbox = None
 
@@ -594,6 +595,11 @@ class MLEvaluation(
         # set the sandbox
         self.sandbox = self.ml_model_inst.sandbox(self)
         # TODO: potentially reset
+
+    @classmethod
+    def invokes_preparation_producer(cls, params) -> bool:
+        # check if the preparation producer is used in the ML model
+        return bool(params["ml_model_inst"].preparation_producer_in_ml_evaluation)
 
     @classmethod
     def resolve_param_values_pre_init(


### PR DESCRIPTION
At the moment, the `preparation_producer` will always be invoked during `MLEvaluation`. This PR allows disabling the `preparation_producer` via the `ml_model.preparation_producer_in_ml_evaluation` attribute.