### PR TITLE
Category groups for automatic combinations

### DIFF
--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -464,7 +464,7 @@ def add_category(
 @dataclasses.dataclass
 class CategoryGroup:
     """
-    Container to store information about a group of categories, mostly used for creating of combinations in
+    Container to store information about a group of categories, mostly used for creating combinations in
     :py:func:`create_category_combinations`.
 
     :param categories: List of :py:class:`order.Category` objects or names that refer to the desired category.


### PR DESCRIPTION
This PR is the first part of a rather involved system to warn users about potential misconfiguration of category combinations.

Considering the following scenario,

```python
category_groups = {
    "lepton": ["e", "mu"],
    "n_jets": ["eq0j", "eq1j", "eq2j", "ge2j"],
    "n_tags": ["0t", "1t"],
}
```

There are several caveats:

- Group "n_jets" is complete (covers the full phase space) but **has overlaps** (eq2j and ge2j).
- Group "n_tags" has no overlaps but is likely not complete (there might be events with ≥ 2 tags).

In set theory, both groups would not be valid partitions of the full phase space.

If a user now uses these groups to create category combinations with `create_category_combinations()` from our config utils, the histogramming will make sure to only project into the resulting leaf categories. Then, in turn, our plotting will sum over all leaves of a requested (parent) category. This can lead to implicit double counting or missing events if a group was not configured correctly.

I introduced `CategoryGroups` which - besides the usual sequence of categories - allow for defining `is_complete` and `has_overlaps` flags, which should make people more aware of the situation described above. A deprecation warning is shown in case a simple list is used (as was valid before), which is then casted implicitly.

So far, these flags are not used anywhere as the required checks are still to be fleshed out. However, it would be good to already have this container object available in the upcoming release to raise awareness early on. I will create the second PR at a later stage.

@aalvesan 