### PR TITLE
use nominal for processes that don't have a requested shift

### DIFF
--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -159,7 +159,7 @@ class PlotVariablesBase(_PlotVariablesBase):
         plot_shift_names = set(shift_inst.name for shift_inst in plot_shifts)
 
         # get assignment of processes to datasets and shifts
-        config_process_map, process_shift_map = self.get_config_process_map()
+        config_process_map, _ = self.get_config_process_map()
 
         # histogram data per process copy
         hists: dict[od.Config, dict[od.Process, hist.Hist]] = {}
@@ -192,8 +192,7 @@ class PlotVariablesBase(_PlotVariablesBase):
                         h = h[{"process": sum}]
 
                         # create expected shift bins and fill them with the nominal histogram
-                        expected_shifts = plot_shift_names & process_shift_map[process_inst.name]
-                        add_missing_shifts(h, expected_shifts, str_axis="shift", nominal_bin="nominal")
+                        add_missing_shifts(h, plot_shift_names, str_axis="shift", nominal_bin="nominal")
 
                         # add the histogram
                         if process_inst in hists_config:
@@ -243,14 +242,6 @@ class PlotVariablesBase(_PlotVariablesBase):
             for process_inst in hists.keys():
                 h = hists[process_inst]
                 # determine expected shifts from the intersection of requested shifts and those known for the process
-                process_shifts = (
-                    process_shift_map[process_inst.name]
-                    if process_inst.name in process_shift_map
-                    else {"nominal"}
-                )
-                expected_shifts = plot_shift_names & process_shifts
-                if not expected_shifts:
-                    raise Exception(f"no shifts to plot found for process {process_inst.name}")
                 # selections
                 h = h[{
                     "category": [
@@ -260,7 +251,7 @@ class PlotVariablesBase(_PlotVariablesBase):
                     ],
                     "shift": [
                         hist.loc(s_name)
-                        for s_name in expected_shifts
+                        for s_name in plot_shift_names
                         if s_name in h.axes["shift"]
                     ],
                 }]


### PR DESCRIPTION
The current code checks if the plot shifts are defined for a given process and only then the nominal is used if that shift is not found in the histogram. I'd suggest to do this always, whether the shift is defined for the process or not. Cause currently, the task `cf.PlotShiftedVariables1D` creates weird plots like the one below, which shows in the systematics band the renormalization and factorization scale variations. THese aren't defined for the QCD contribution, whcih means that the QCD constribution is not counted in the up and down variation. Both variations, therefore undershoot the nominal prediction.

I am wondering why this requirement of the shift being defined for the process is in there in the first place? I might be missing something?

*edit (Marcel)*: Removed the picture from public resource :)
