### PR TITLE
allow evaluating multiple working points with single electron_weights Producer

### DIFF
--- a/columnflow/production/cms/electron.py
+++ b/columnflow/production/cms/electron.py
@@ -10,11 +10,10 @@ from dataclasses import dataclass
 
 import law
 
-from columnflow.types import Callable
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import, load_correction_set, DotDict
 from columnflow.columnar_util import set_ak_column, flat_np_view, layout_ak_array, EMPTY_FLOAT
-from columnflow.types import Any
+from columnflow.types import Any, Callable
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")


### PR DESCRIPTION
This PR targets the evaluation of electron reco SFs which are implemented as separate `WorkingPoint` inputs for different pt ranges. Exemplary configuration:
```python
        cfg.x.electron_sf_names = ElectronSFConfig(
            correction="Electron-ID-SF",
            campaign="2022Re-recoE+PromptFG",
            working_point={
                "RecoBelow20": lambda variable_map: variable_map["pt"] < 20.0,
                "Reco20to75": lambda variable_map: (variable_map["pt"] >= 20.0) & (variable_map["pt"] < 75.0),
                "RecoAbove75": lambda variable_map: variable_map["pt"] >= 75.0,
            },
        )
```

I would have preferred to implement this with a single Callable that produces the `WorkingPoint` column, assigning the correct string to each individual electron. Sadly, this did not work, because one cannot pass arrays of strings when evaluating a correctionlib json as one can see in this error message:

```
----> 1 self.electron_sf_corrector("2022Re-recoE+PromptFG", "sf", ["Reco20to75", "RecoBelow20"], [1.,1.2],[25., 15.])

File ~/Projects/hh2bbww/software/venvs/venv_columnar_dev_3cbb5aff/lib/python3.9/site-packages/correctionlib/highlevel.py:247, in Correction.evaluate(self, *args)
    245     oshape = bargs[0].shape
    246     fargs = (arg.flatten() for arg in bargs)
--> 247     out = self._base.evalv(
    248         *(
    249             next(fargs) if not isinstance(arg, (str, int, float)) else arg
    250             for arg in args
    251         )
    252     )
    253     return out.reshape(oshape)
    254 return self._base.evaluate(*args)  # type: ignore

ValueError: Array arguments only allowed for integer and real input types
```