### PR TITLE
Fix task pinning

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -98,8 +98,8 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 # output locations per task family
 # the key can consist of multple underscore-separated parts, that can each be patterns or regexes
 # these parts are used for the lookup from within tasks and can contain (e.g.) the analysis name,
-# the config name, the task family, the dataset name, or the shift name
-# (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
+# the config name, the task family, the dataset name, or the shift name, for more info, see
+# https://columnflow.readthedocs.io/en/latest/user_guide/best_practices.html#selecting-output-locations
 # values can have the following format:
 # for local targets   : "local[, LOCAL_FS_NAME or STORE_PATH][, store_parts_modifier]"
 # for remote targets  : "wlcg[, WLCG_FS_NAME][, store_parts_modifier]"
@@ -108,8 +108,8 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 # the "store_parts_modifiers" can be the name of a function in the "store_parts_modifiers" aux dict
 # of the analysis instance, which is called with an output's store parts of an output to modify them
 # example:
-; run3_2023__cf.CalibrateEvents__nomin*: local
-; cf.CalibrateEvents: wlcg
+; cfg_run3_2023__task_cf.CalibrateEvents__shift_nomin*: local
+; task_cf.CalibrateEvents: wlcg
 
 
 [versions]
@@ -117,13 +117,13 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 # default versions of specific tasks to pin
 # the key can consist of multple underscore-separated parts, that can each be patterns or regexes
 # these parts are used for the lookup from within tasks and can contain (e.g.) the analysis name,
-# the config name, the task family, the dataset name, or the shift name
-# (see AnalysisTask.get_config_lookup_keys() - and subclasses - for the exact order)
+# the config name, the task family, the dataset name, or the shift name, for more info, see
+# https://columnflow.readthedocs.io/en/latest/user_guide/best_practices.html#pinned-versions-in-the-analysis-config-or-law-cfg-file
 # note:
 # this lookup is skipped if the lookup based on the config instance's auxiliary data succeeded
 # example:
-; run3_2023__cf.CalibrateEvents__nomin*: prod1
-; cf.CalibrateEvents: prod2
+; cfg_run3_2023__task_cf.CalibrateEvents__shift_nomin*: prod1
+; task_cf.CalibrateEvents: prod2
 
 
 [resources]
@@ -135,8 +135,8 @@ lfn_sources: wlcg_fs_infn_redirector, wlcg_fs_global_redirector
 # by the respective parameter instance at runtime
 # same as for [versions], the order of options is important as it defines the resolution order
 # example:
-; run3_2023__cf.CalibrateEvents__nomin*: htcondor_memory=5GB
-; run3_2023__cf.CalibrateEvents: htcondor_memory=2GB
+; cfg_run3_2023__task_cf.CalibrateEvents__shift_nomin*: htcondor_memory=5GB
+; cfg_run3_2023__task_cf.CalibrateEvents: htcondor_memory=2GB
 
 
 [job]

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -23,7 +23,7 @@ import law
 import order as od
 
 from columnflow.columnar_util import mandatory_coffea_columns, Route, ColumnCollection
-from columnflow.util import is_regex, prettify, DotDict
+from columnflow.util import get_docs_url, is_regex, prettify, DotDict
 from columnflow.types import Sequence, Callable, Any, T
 
 
@@ -354,10 +354,16 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             else getattr(inst_or_params, "analysis", None)
         )
         if analysis not in {law.NO_STR, None, ""}:
-            keys["analysis"] = analysis
+            prefix = "ana"
+            keys[prefix] = f"{prefix}_{analysis}"
 
         # add the task family
-        keys["task_family"] = cls.task_family
+        prefix = "task"
+        keys[prefix] = f"{prefix}_{cls.task_family}"
+
+        # for backwards compatibility, add the task family again without the prefix
+        # (TODO: this should be removed in the future)
+        keys[f"{prefix}_compat"] = cls.task_family
 
         return keys
 
@@ -375,7 +381,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
             return empty_value
 
         # the keys to use for the lookup are the flattened values of the keys dict
-        flat_keys = collections.deque(law.util.flatten(keys.values() if isinstance(keys, dict) else keys))
+        flat_keys = law.util.flatten(keys.values() if isinstance(keys, dict) else keys)
 
         # start tree traversal using a queue lookup consisting of names and values of tree nodes,
         # as well as the remaining keys (as a deferred function) to compare for that particular path
@@ -383,20 +389,33 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         while lookup:
             pattern, obj, keys_func = lookup.popleft()
 
-            # when pattern starts with a "!", it is a negation
-            negate = pattern.startswith("!")
-            if negate:
-                pattern = pattern[1:]
-
             # create the copy of comparison keys on demand
             # (the original sequence is living once on the previous stack until now)
             _keys = keys_func()
 
             # check if the pattern matches any key
             regex = is_regex(pattern)
-            while _keys:
-                key = _keys.popleft()
-                if law.util.multi_match(key, pattern, regex=regex) != negate:
+            for i, key in enumerate(_keys):
+                if law.util.multi_match(key, pattern, regex=regex):
+                    # for a limited time, show a deprecation warning when the old task family key was matched
+                    # (old = no "task_" prefix)
+                    # TODO: remove once deprecated
+                    if "task_compat" in keys and key == keys["task_compat"]:
+                        docs_url = get_docs_url(
+                            "user_guide",
+                            "best_practices.html",
+                            anchor="selecting-output-locations",
+                        )
+                        logger.warning_once(
+                            "dfs_lookup_old_task_key",
+                            f"during the lookup of a pinned location, version or resource value of a '{cls.__name__}' "
+                            f"task, an entry matched based on the task family '{key}' that misses the new 'task_' "
+                            "prefix; please update the pinned entries in your law.cfg file by adding the 'task_' "
+                            f"prefix to entries that contain the task family, e.g. 'task_{key}: VALUE'; support for "
+                            f"missing prefixes will be removed in a future version; see {docs_url} for more info",
+                        )
+                    # remove the matched key from remaining lookup keys
+                    _keys.pop(i)
                     # when obj is not a dict, we found the value
                     if not isinstance(obj, dict):
                         return obj
@@ -1454,7 +1473,8 @@ class ConfigTask(AnalysisTask):
             else getattr(inst_or_params, "config", None)
         )
         if config not in {law.NO_STR, None, ""}:
-            keys.insert_before("task_family", "config", config)
+            prefix = "cfg"
+            keys.insert_before("task", prefix, f"{prefix}_{config}")
 
         return keys
 
@@ -1634,7 +1654,8 @@ class ShiftTask(ConfigTask):
             else getattr(inst_or_params, "shift", None)
         )
         if shift not in (law.NO_STR, None, ""):
-            keys["shift"] = shift
+            prefix = "shift"
+            keys[prefix] = f"{prefix}_{shift}"
 
         return keys
 
@@ -1725,7 +1746,8 @@ class DatasetTask(ShiftTask):
             else getattr(inst_or_params, "dataset", None)
         )
         if dataset not in {law.NO_STR, None, ""}:
-            keys.insert_before("shift", "dataset", dataset)
+            prefix = "dataset"
+            keys.insert_before("shift", prefix, f"{prefix}_{dataset}")
 
         return keys
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -120,7 +120,8 @@ class CalibratorClassMixin(ArrayFunctionClassMixin):
             else getattr(inst_or_params, "calibrator", None)
         )
         if calibrator not in (law.NO_STR, None, ""):
-            keys["calibrator"] = f"calib_{calibrator}"
+            prefix = "calib"
+            keys[prefix] = f"{prefix}_{calibrator}"
 
         return keys
 
@@ -304,7 +305,8 @@ class CalibratorClassesMixin(ArrayFunctionClassMixin):
             else getattr(inst_or_params, "calibrators", None)
         )
         if calibrators not in {law.NO_STR, None, "", ()}:
-            keys["calibrators"] = [f"calib_{calibrator}" for calibrator in calibrators]
+            prefix = "calib"
+            keys[prefix] = [f"{prefix}_{calibrator}" for calibrator in calibrators]
 
         return keys
 
@@ -510,7 +512,8 @@ class SelectorClassMixin(ArrayFunctionClassMixin):
             else getattr(inst_or_params, "selector", None)
         )
         if selector not in (law.NO_STR, None, ""):
-            keys["selector"] = f"sel_{selector}"
+            prefix = "sel"
+            keys[prefix] = f"{prefix}_{selector}"
 
         return keys
 
@@ -702,7 +705,8 @@ class ReducerClassMixin(ArrayFunctionClassMixin):
             else getattr(inst_or_params, "reducer", None)
         )
         if reducer not in (law.NO_STR, None, ""):
-            keys["reducer"] = f"red_{reducer}"
+            prefix = "red"
+            keys[prefix] = f"{prefix}_{reducer}"
 
         return keys
 
@@ -877,7 +881,8 @@ class ProducerClassMixin(ArrayFunctionClassMixin):
             else getattr(inst_or_params, "producer", None)
         )
         if producer not in (law.NO_STR, None, ""):
-            keys["producer"] = f"prod_{producer}"
+            prefix = "prod"
+            keys[prefix] = f"{prefix}_{producer}"
 
         return keys
 
@@ -1061,7 +1066,8 @@ class ProducerClassesMixin(ArrayFunctionClassMixin):
             else getattr(inst_or_params, "producers", None)
         )
         if producers not in {law.NO_STR, None, "", ()}:
-            keys["producers"] = [f"prod_{producer}" for producer in producers]
+            prefix = "prod"
+            keys[prefix] = [f"{prefix}_{producer}" for producer in producers]
 
         return keys
 
@@ -1679,7 +1685,8 @@ class HistProducerClassMixin(ArrayFunctionClassMixin):
             else getattr(inst_or_params, "hist_producer", None)
         )
         if producer not in (law.NO_STR, None, ""):
-            keys["hist_producer"] = f"hist_{producer}"
+            prefix = "hist"
+            keys[prefix] = f"{prefix}_{producer}"
 
         return keys
 

--- a/docs/user_guide/best_practices.md
+++ b/docs/user_guide/best_practices.md
@@ -22,38 +22,40 @@ For convenience, if no file system with that name was defined, `LOCAL_FS_NAME` i
 - `wlcg, WLCG_FS_NAME` refers to a specific remote storage system named `WLCG_FS_NAME` that should be defined in the `law.cfg` file.
 
 `TASK_IDENTIFIER` identifies the task the location should apply to.
-It can be a simple task family such as `cf.CalibrateEvents`, but for larger analyses a more fine grained selection is required.
+It can be a simple task family such as `task_cf.CalibrateEvents` (see the format below), but for larger analyses a more fine grained selection is required.
 For this purpose, `TASK_IDENTIFIER` can be a `__`-separated sequence of so-called lookup keys, e.g.
 
 ```ini
 [outputs]
 
-run3_23__cf.CalibrateEvents__nominal: wlcg, wlcg_fs_run3_23
+cfg_run3_23__task_cf.CalibrateEvents__shift_nominal: wlcg, wlcg_fs_run3_23
 ```
 
 Here, three keys are defined, making use of the config name, the task family, and the name of a systematic shift.
 The exact selection of possible keys and their resolution order is defined by the task itself in {py:meth}:`~columnflow.tasks.framework.base.AnalysisTask.get_config_lookup_keys` (and subclasses).
 Most tasks, however, define their lookup keys as:
 
-1. analysis name
-2. config name
-3. task family
-4. dataset name
-5. shift name
+1. analysis name, prefixed by `ana_`
+2. config name, prefixed by `cfg_`
+3. task family, prefixed by `task_`
+4. dataset name, prefixed by `dataset_`
+5. shift name, prefixed by `shift_`
 6. calibrator name, prefixed by `calib_`
 7. selector name, prefixed by `sel_`
-8. producer name, prefixed by `prod_`
+8. reducer name, prefixed by `red_`
+9. producer name, prefixed by `prod_`
+10. hist producer name, prefixed by `hist_`
 
 When defining `TASK_IDENTIFIER`'s, not all keys need to be specified, and patterns or regular expressions (`^EXPR$`) can be used.
-The definition order is **important** as the first matching definition is used.
+The definition order in the config file is **important** as the first matching definition is used.
 This way, output locations are highly customizable.
 
 ```ini
 [outputs]
 
 # store all run3 outputs on a specific fs, and all other outputs locally
-run3_*__cf.CalibrateEvents: wlcg, wlcg_fs_run3
-cf.CalibrateEvents: local
+cfg_run3_*__task_cf.CalibrateEvents: wlcg, wlcg_fs_run3
+task_cf.CalibrateEvents: local
 ```
 
 ## Controlling versions of upstream tasks
@@ -90,18 +92,18 @@ Consider the following two examples for defining versions, one via auxiliary con
 
 ```python
 cfg.x.versions = {
-    "run3_*": {
-        "cf.CalibrateEvents": "v2",
+    "cfg_run3_*": {
+        "task_cf.CalibrateEvents": "v2",
     },
-    "cf.CalibrateEvents": "v1",
+    "task_cf.CalibrateEvents": "v1",
 }
 ```
 
 ```ini
 [versions]
 
-run3_*__cf.CalibrateEvents: v2
-cf.CalibrateEvents: v1
+cfg_run3_*__task_cf.CalibrateEvents: v2
+task_cf.CalibrateEvents: v1
 ```
 
 They are **equivalent** since the `__`-separated `TASK_IDENTIFIER`'s in the `law.cfg` are internallly converted to the same nested dictionary structure.

--- a/docs/user_guide/examples.md
+++ b/docs/user_guide/examples.md
@@ -267,11 +267,10 @@ lfn_sources: local_dcache
 # output locations per task family
 # for local targets : "local[, STORE_PATH]"
 # for remote targets: "wlcg[, WLCG_FS_NAME]"
-cf.Task1: local
-cf.Task2: local, /shared/path/to/store/output
-cf.Task3: /shared/path/to/store/output
+task_cf.Task1: local
+task_cf.Task2: local, /shared/path/to/store/output
+task_cf.Task3: /shared/path/to/store/output
 ...
-
 ```
 
 It is important to redirect the setup to the custom config file by setting the ```LAW_CONFIG_FILE``` environment variable in the `setup.sh` file to the path of the custom config file as follows:

--- a/setup.sh
+++ b/setup.sh
@@ -756,13 +756,19 @@ cf_setup_post_install() {
     #       Should be true or false, indicating if the setup is run in a local environment.
     #   CF_REPO_BASE
     #       The base directory of the analysis repository, which is used to determine the law home and config file.
+    #
+    # Optional environment variables:
+    #   CF_SKIP_SETUP_GIT_HOOKS
+    #       When set to true, the setup of git hooks is skipped.
+    #   CF_SKIP_CHECK_TMP_DIR
+    #       When set to true, the check of the size of the target tmp directory is skipped.
 
     #
     # git hooks
     #
 
     # only in local env
-    if ${CF_LOCAL_ENV}; then
+    if ! ${CF_SKIP_SETUP_GIT_HOOKS} && ${CF_LOCAL_ENV}; then
         cf_setup_git_hooks || return "$?"
     fi
 
@@ -790,7 +796,7 @@ cf_setup_post_install() {
     # check the tmp directory size
     #
 
-    if ${CF_LOCAL_ENV} && which law &> /dev/null; then
+    if ! ${CF_SKIP_CHECK_TMP_DIR} && ${CF_LOCAL_ENV} && which law &> /dev/null; then
         cf_check_tmp_dir
     fi
 
@@ -1106,6 +1112,8 @@ for flag_name in \
         CF_REINSTALL_SOFTWARE \
         CF_REINSTALL_HOOKS \
         CF_SKIP_BANNER \
+        CF_SKIP_SETUP_GIT_HOOKS \
+        CF_SKIP_CHECK_TMP_DIR \
         CF_ON_HTCONDOR \
         CF_ON_SLURM \
         CF_ON_GRID \


### PR DESCRIPTION
This PR fixes the pinning of output locations, versions and resources of tasks through the law config file.

## Current state

So far, we are able to pin-point the exact task through a "__"-separated key in the respective config section, such as

```ini
[versions]
22pre_v14__cf.ProduceColumns__prod_default: prod9
22pre_v14__cf.ProduceColumns: prod10
```

which leads to all cf.ProduceColumns tasks that run with the `22pre_v14` config to use a default version `prod10` unless the producer is `default` in which case it uses `prod9`. The keys also allow for using patterns and regular expressions for more complex matching.

There is a slight inconsistency in the way the key is constructed (which is the crucial point later on): The producer is prefixed by `prod_` whereas config, task, and also the analysis name (if provided) are not prefixed by anything (**A**). This was usually okay, since we imposed an order for the matching of key fragments (**B**) such that config has to be placed after the analysis but before the task, which itself can be followed by dataset, shift, calibrator, selector, reducer, producer and histogram producer names. The former 5 fragments are **not** prefixed by anything, but the 5 latter ones are (e.g. `calib_`, `sel_`, etc.).

## Issue

However, it turns out that this inconsistency (**A**) **AND** the order of key fragments (**B**) becomes a huge problem when e.g. negating expressions. For example, when the versions for all tasks for **all configs except** for a specific one, say `22post_v14`, should be pinned, one would do

```ini
[versions]
^(?!22post_v14)$__cf.*: prod9
```

(using regex markers `^$` and a negative lookahead `(?!...)`). This first fragment actually **matches the analysis name first** rather than the config because it comes first in the matching order (**B**) and there is no prefix like `cfg_` to further help referring to the config name (**A**). For producers, this would be simpler, since the `prod_` prefix could be used for explicitly refer to the producer fragment like `^prod_(?!...)$`.

As a result, negation and likely other non-exclusive patterns are just not possible. However, this would be a powerful feature as it would avoid extreme verbosity in the configuration (think of pinning the version for tasks with datasets **other than** DY... you would have to list all of them, since `__^(?!dy_.+)$__` would not work; it would match the analysis name fragment already, same as above).

## Fix

This PR fixes both **A** and **B**:
- **A**: All key fragments have prefixes now. From the updated docs:
  1. analysis name, prefixed by `ana_`
  2. config name, prefixed by `cfg_`
  3. task family, prefixed by `task_`
  4. dataset name, prefixed by `dataset_`
  5. shift name, prefixed by `shift_`
  6. calibrator name, prefixed by `calib_`
  7. selector name, prefixed by `sel_`
  8. reducer name, prefixed by `red_`
  9. producer name, prefixed by `prod_`
  10. hist producer name, prefixed by `hist_`
- **B**: The matching order is no longer important, so defining matching keys no longer requires looking up and memorizing the order given in the docs. This was anyway not very intuitive and quite error-prone.
- All docs are updated accordingly.

With that, the example above would become

```ini
[versions]
^cfg_(?!22post_v14)$__task_cf.*: prod9
```

(note the `cfg_` and `task_` prefixes) and is perfectly working.

## Backwards compatibility

The most frequent usecase is likely something as simple as

```ini
[outputs]
cf.CalibrateEvents: wlcg
```

Now, this would need to be changed to

```ini
[outputs]
task_cf.CalibrateEvents: wlcg
```

However, to be backwards compatible, for a limited time the task fragment *can* but *does not have to* start with the `task_` prefix. There is a deprecation warning in case it is found to be missing though. With that, this change is hopefully not breaking user code.
