### PR TITLE
Add ml model task pinning.

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -1283,6 +1283,25 @@ class MLModelMixinBase(ConfigTask):
             not shift_inst.has_tag("disjoint_from_nominal")
         )
 
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: MLModelMixinBase | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        # add the ml model name
+        ml_model = (
+            inst_or_params.get("ml_model")
+            if isinstance(inst_or_params, dict)
+            else getattr(inst_or_params, "ml_model", None)
+        )
+        if ml_model not in (law.NO_STR, None, ""):
+            prefix = "ml"
+            keys[prefix] = f"{prefix}_{ml_model}"
+
+        return keys
+
 
 class MLModelTrainingMixin(
     MLModelMixinBase,
@@ -1609,6 +1628,25 @@ class MLModelsMixin(ConfigTask):
             ))
 
         return columns
+
+    @classmethod
+    def get_config_lookup_keys(
+        cls,
+        inst_or_params: MLModelsMixin | dict[str, Any],
+    ) -> law.util.InsertiableDict:
+        keys = super().get_config_lookup_keys(inst_or_params)
+
+        # add the ml model names
+        ml_models = (
+            inst_or_params.get("ml_models")
+            if isinstance(inst_or_params, dict)
+            else getattr(inst_or_params, "ml_models", None)
+        )
+        if ml_models not in {law.NO_STR, None, "", ()}:
+            prefix = "ml"
+            keys[prefix] = [f"{prefix}_{ml_model}" for ml_model in ml_models]
+
+        return keys
 
 
 class HistProducerClassMixin(ArrayFunctionClassMixin):

--- a/docs/user_guide/best_practices.md
+++ b/docs/user_guide/best_practices.md
@@ -44,7 +44,8 @@ Most tasks, however, define their lookup keys as:
 7. selector name, prefixed by `sel_`
 8. reducer name, prefixed by `red_`
 9. producer name, prefixed by `prod_`
-10. hist producer name, prefixed by `hist_`
+10. ml model name, prefixed by `ml_`
+11. hist producer name, prefixed by `hist_`
 
 When defining `TASK_IDENTIFIER`'s, not all keys need to be specified, and patterns or regular expressions (`^EXPR$`) can be used.
 The definition order in the config file is **important** as the first matching definition is used.


### PR DESCRIPTION
This PR adds the choice of the `--ml-model` or `--ml-models` to the list of available keys for pinning task output locations, resources and versions.

The fragment should be prefixed by `ml_` as also added to the documentation. With that, a respective entry in the config file could look like

```ini
[versions]

task_cf.CreateHistograms__ml_RegNet: prod10
```