### PR TITLE
Make merging chunk size configurable.

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -70,6 +70,9 @@ chunked_io_chunk_size: 100000
 chunked_io_pool_size: 2
 chunked_io_debug: False
 
+# settings for merging parquet files in several locations
+merging_row_group_size: 50000
+
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
 # checked (raising an exception) for non-finite values before saving them to disk
 check_finite_output: cf.CalibrateEvents, cf.SelectEvents, cf.ReduceEvents, cf.ProduceColumns

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -3032,7 +3032,11 @@ class DaskArrayReader(object):
         # case nested nodes separated by "*.list.element.*" (rather than "*.list.item.*") are found
         # (to be removed in the future)
         if open_options.get("split_row_groups"):
-            nodes = ak.ak_from_parquet.metadata(path)[0]
+            try:
+                nodes = ak.ak_from_parquet.metadata(path)[0]
+            except:
+                logger.error(f"unable to read {path}")
+                raise
             cre = re.compile(r"^.+\.list\.element(|\..+)$")
             if any(map(cre.match, nodes)):
                 logger.warning(

--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -174,7 +174,12 @@ class CalibrateEvents(_CalibrateEvents):
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
         law.pyarrow.merge_parquet_task(
-            self, sorted_chunks, output["columns"], local=True, writer_opts=self.get_parquet_writer_opts(),
+            task=self,
+            inputs=sorted_chunks,
+            output=output["columns"],
+            local=True,
+            writer_opts=self.get_parquet_writer_opts(),
+            target_row_group_size=self.merging_row_group_size,
         )
 
 

--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -2402,6 +2402,9 @@ class ChunkedIOMixin(ConfigTask):
         description="when True, checks whether columns if input arrays overlap in at least one field",
     )
 
+    # number of events per row group in the merged file
+    merging_row_group_size = law.config.get_expanded_int("analysis", "merging_row_group_size", 50_000)
+
     exclude_params_req = {"check_finite_output", "check_overlapping_inputs"}
 
     # define default chunk and pool sizes that can be adjusted per inheriting task

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -806,7 +806,12 @@ class MLEvaluation(
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
         law.pyarrow.merge_parquet_task(
-            self, sorted_chunks, output["mlcolumns"], local=True, writer_opts=self.get_parquet_writer_opts(),
+            task=self,
+            inputs=sorted_chunks,
+            output=output["mlcolumns"],
+            local=True,
+            writer_opts=self.get_parquet_writer_opts(),
+            target_row_group_size=self.merging_row_group_size,
         )
 
 

--- a/columnflow/tasks/production.py
+++ b/columnflow/tasks/production.py
@@ -168,7 +168,12 @@ class ProduceColumns(_ProduceColumns):
         # merge output files
         sorted_chunks = [output_chunks[key] for key in sorted(output_chunks)]
         law.pyarrow.merge_parquet_task(
-            self, sorted_chunks, output["columns"], local=True, writer_opts=self.get_parquet_writer_opts(),
+            task=self,
+            inputs=sorted_chunks,
+            output=output["columns"],
+            local=True,
+            writer_opts=self.get_parquet_writer_opts(),
+            target_row_group_size=self.merging_row_group_size,
         )
 
 

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -265,14 +265,24 @@ class SelectEvents(_SelectEvents):
         sorted_chunks = [result_chunks[key] for key in sorted(result_chunks)]
         writer_opts_masks = self.get_parquet_writer_opts(repeating_values=True)
         law.pyarrow.merge_parquet_task(
-            self, sorted_chunks, outputs["results"], local=True, writer_opts=writer_opts_masks,
+            task=self,
+            inputs=sorted_chunks,
+            output=outputs["results"],
+            local=True,
+            writer_opts=writer_opts_masks,
+            target_row_group_size=self.merging_row_group_size,
         )
 
         # merge the column files
         if write_columns:
             sorted_chunks = [column_chunks[key] for key in sorted(column_chunks)]
             law.pyarrow.merge_parquet_task(
-                self, sorted_chunks, outputs["columns"], local=True, writer_opts=self.get_parquet_writer_opts(),
+                task=self,
+                inputs=sorted_chunks,
+                output=outputs["columns"],
+                local=True,
+                writer_opts=self.get_parquet_writer_opts(),
+                target_row_group_size=self.merging_row_group_size,
             )
 
         # save stats

--- a/law.cfg
+++ b/law.cfg
@@ -64,6 +64,9 @@ chunked_io_chunk_size: 100000
 chunked_io_pool_size: 2
 chunked_io_debug: False
 
+# settings for merging parquet files in several locations
+merging_row_group_size: 50000
+
 # csv list of task families that inherit from ChunkedReaderMixin and whose output arrays should be
 # checked (raising an exception) for non-finite values before saving them to disk
 # supported tasks are: cf.CalibrateEvents, cf.SelectEvents, cf.ReduceEvents, cf.ProduceColumns,


### PR DESCRIPTION
This PR extends the previously added possibility to control the chunk size of events when merging parquet files.

Before, this was only the case in `MergeReducedEvents` and only with a fixed row group size. This PR introduces the same concept to all tasks that perform a post-run merging (calibration, selection, ...) and makes the chunk size configurable through the law.cfg via `[analysis] merging_row_group_size`.