### PR TITLE
Feature/histogram user multiconfig

### DIFF
--- a/columnflow/tasks/framework/histograms.py
+++ b/columnflow/tasks/framework/histograms.py
@@ -158,6 +158,7 @@ class HistogramsUserSingleShiftBase(
         return reqs
 
     def requires(self):
+        datasets = [self.datasets] if self.single_config else self.datasets
         return {
             config_inst.name: {
                 d: self.reqs.MergeHistograms.req_different_branching(
@@ -166,7 +167,7 @@ class HistogramsUserSingleShiftBase(
                     branch=-1,
                     _prefer_cli={"variables"},
                 )
-                for d in self.datasets[i]
+                for d in datasets[i]
                 if config_inst.has_dataset(d)
             }
             for i, config_inst in enumerate(self.config_insts)
@@ -191,6 +192,7 @@ class HistogramsUserMultiShiftBase(
         return reqs
 
     def requires(self):
+        datasets = [self.datasets] if self.single_config else self.datasets
         return {
             config: {
                 d: self.reqs.MergeShiftedHistograms.req_different_branching(
@@ -199,7 +201,7 @@ class HistogramsUserMultiShiftBase(
                     branch=-1,
                     _prefer_cli={"variables"},
                 )
-                for d in self.datasets[i]
+                for d in datasets[i]
             }
             for i, config in enumerate(self.configs)
         }

--- a/columnflow/tasks/inspection.py
+++ b/columnflow/tasks/inspection.py
@@ -26,17 +26,41 @@ class InspectHistograms(HistogramsUserSingleShiftBase):
         return {"always_incomplete_dummy": self.target("dummy.txt")}
 
     def run(self):
+        """
+        Loads histograms for all configs, variables, and datasets,
+        sums them up for each variable and
+        slices them according to the processes, categories, and shift,
+        The resulting histograms are stored in a dictionary with variable names as keys.
+        If `debugger` is set to True, an IPython debugger session is started for
+        interactive inspection of the histograms.
+        """
+        shifts = ["nominal", self.shift]
         hists = {}
 
-        for dataset in self.datasets:
-            for variable in self.variables:
-                h_in = self.load_histogram(dataset, variable)
-                h_in = self.slice_histogram(h_in, self.processes, self.categories, self.shift)
+        for variable in self.variables:
+            for i, config_inst in enumerate(self.config_insts):
+                hist_per_config = None
+                sub_processes = self.processes[i]
+                for dataset in self.datasets[i]:
+                    # sum over all histograms of the same variable and config
+                    if hist_per_config is None:
+                        hist_per_config = self.load_histogram(config_inst, dataset, variable)
+                    else:
+                        hist_per_config += self.load_histogram(config_inst, dataset, variable)
+
+                # slice histogram per config according to the sub_processes and categories
+                hist_per_config = self.slice_histogram(
+                    histogram=hist_per_config,
+                    config_inst=config_inst,
+                    processes=sub_processes,
+                    categories=self.categories,
+                    shifts=shifts,
+                )
 
                 if variable in hists.keys():
-                    hists[variable] += h_in
+                    hists[variable] += hist_per_config
                 else:
-                    hists[variable] = h_in
+                    hists[variable] = hist_per_config
 
         if self.debugger:
             from IPython import embed
@@ -57,18 +81,41 @@ class InspectShiftedHistograms(HistogramsUserMultiShiftBase):
         return {"always_incomplete_dummy": self.target("dummy.txt")}
 
     def run(self):
+        """
+        Loads histograms for all configs, variables, and datasets,
+        sums them up for each variable and
+        slices them according to the processes, categories, and shift,
+        The resulting histograms are stored in a dictionary with variable names as keys.
+        If `debugger` is set to True, an IPython debugger session is started for
+        interactive inspection of the histograms.
+        """
         shifts = ["nominal"] + self.shifts
         hists = {}
 
-        for dataset in self.datasets:
-            for variable in self.variables:
-                h_in = self.load_histogram(dataset, variable)
-                h_in = self.slice_histogram(h_in, self.processes, self.categories, shifts)
+        for variable in self.variables:
+            for i, config_inst in enumerate(self.config_insts):
+                hist_per_config = None
+                sub_processes = self.processes[i]
+                for dataset in self.datasets[i]:
+                    # sum over all histograms of the same variable and config
+                    if hist_per_config is None:
+                        hist_per_config = self.load_histogram(config_inst, dataset, variable)
+                    else:
+                        hist_per_config += self.load_histogram(config_inst, dataset, variable)
+
+                # slice histogram per config according to the sub_processes and categories
+                hist_per_config = self.slice_histogram(
+                    histogram=hist_per_config,
+                    config_inst=config_inst,
+                    processes=sub_processes,
+                    categories=self.categories,
+                    shifts=shifts,
+                )
 
                 if variable in hists.keys():
-                    hists[variable] += h_in
+                    hists[variable] += hist_per_config
                 else:
-                    hists[variable] = h_in
+                    hists[variable] = hist_per_config
 
         if self.debugger:
             from IPython import embed


### PR DESCRIPTION
This PR
- makes the HistogramsUserBase tasks compatible with MultiConfig
- updates the inspection tasks accordingly. I also moved this histogram slicing after the merging of histograms over all datasets to make things a bit more efficient, hopefully. The merging of histograms here is much less sophisticated compared to our default plotting task, e.g. the mapping of processes to datasets and the handling of missing shifts is not really considered.