### PR TITLE
Sort configs by ids for the multi config representation

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -1504,7 +1504,7 @@ class ConfigTask(AnalysisTask):
 
     @property
     def config_repr(self) -> str:
-        return "__".join(config_inst.name for config_inst in self.config_insts)
+        return "__".join(config_inst.name for config_inst in sorted(self.config_insts, key=lambda c: c.id))
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()


### PR DESCRIPTION
Hi,

Currently, the configs are not internally sorted; therefore, for multi-config tasks, the output path depends on the order provided in the CLI.
The small implementation sorts the configs by IDs (just to have 22pre before 22post in the name), but we can also sort by names if it is preferred.
I am not sure if it is intentional, but it may lead to some inconsistencies since the same task will have different outputs depending on the CLI order.
