### PR TITLE
pad with nominal if shift source missing in config

### DIFF
--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -117,18 +117,15 @@ class CreateDatacards(SerializeInferenceModelBase):
                     if not self.inference_model_inst.require_shapes_for_parameter(param_obj):
                         continue
                     # store the varied hists
-                    if config_inst.name in param_obj.config_data.keys():
-                        shift_source = param_obj.config_data[config_inst.name].shift_source
-                        for d in ["up", "down"]:
-                            shift_hists[(param_obj.name, d)] = h_proc[{
-                                "shift": hist.loc(config_inst.get_shift(f"{shift_source}_{d}").name),
-                            }]
-                    else:
-                        # when the parameter does not exist for this config, fill histogram with nominal value
-                        for d in ["up", "down"]:
-                            shift_hists[(param_obj.name, d)] = h_proc[{
-                                "shift": hist.loc("nominal"),
-                            }]
+                    shift_source = (
+                        param_obj.config_data[config_inst.name].shift_source
+                        if config_inst.name in param_obj.config_data
+                        else None
+                    )
+                    for d in ["up", "down"]:
+                        shift_hists[(param_obj.name, d)] = h_proc[{
+                            "shift": hist.loc(f"{shift_source}_{d}" if shift_source else "nominal"),
+                        }                        ]
 
         # forward objects to the datacard writer
         outputs = self.output()

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -117,11 +117,18 @@ class CreateDatacards(SerializeInferenceModelBase):
                     if not self.inference_model_inst.require_shapes_for_parameter(param_obj):
                         continue
                     # store the varied hists
-                    shift_source = param_obj.config_data[config_inst.name].shift_source
-                    for d in ["up", "down"]:
-                        shift_hists[(param_obj.name, d)] = h_proc[{
-                            "shift": hist.loc(config_inst.get_shift(f"{shift_source}_{d}").name),
-                        }]
+                    if config_inst.name in param_obj.config_data.keys():
+                        shift_source = param_obj.config_data[config_inst.name].shift_source
+                        for d in ["up", "down"]:
+                            shift_hists[(param_obj.name, d)] = h_proc[{
+                                "shift": hist.loc(config_inst.get_shift(f"{shift_source}_{d}").name),
+                            }]
+                    else:
+                        # when the parameter does not exist for this config, fill histogram with nominal value
+                        for d in ["up", "down"]:
+                            shift_hists[(param_obj.name, d)] = h_proc[{
+                                "shift": hist.loc("nominal"),
+                            }]
 
         # forward objects to the datacard writer
         outputs = self.output()

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -125,7 +125,7 @@ class CreateDatacards(SerializeInferenceModelBase):
                     for d in ["up", "down"]:
                         shift_hists[(param_obj.name, d)] = h_proc[{
                             "shift": hist.loc(f"{shift_source}_{d}" if shift_source else "nominal"),
-                        }                        ]
+                        }]
 
         # forward objects to the datacard writer
         outputs = self.output()


### PR DESCRIPTION
When a shift is defined in one config, but not another (e.g. `btag_hfstats_2022`), an error is thrown since there won't be a `config_data` of this shift for all configs. This PR fixes this issue by filling the corresponding keys with the nominal histogram