### PR TITLE
Forward known values to hist hooks.

### DIFF
--- a/columnflow/tasks/framework/mixins.py
+++ b/columnflow/tasks/framework/mixins.py
@@ -2531,6 +2531,7 @@ class HistHookMixin(ConfigTask):
     def invoke_hist_hooks(
         self,
         hists: dict[od.Config, dict[od.Process, Any]],
+        hook_kwargs: dict | None = None,
     ) -> dict[od.Config, dict[od.Process, Any]]:
         """
         Invoke hooks to modify histograms before further processing such as plotting.
@@ -2552,7 +2553,7 @@ class HistHookMixin(ConfigTask):
 
             # invoke it
             self.publish_message(f"invoking hist hook '{hook}'")
-            hists = func(self, hists)
+            hists = func(self, hists, **(hook_kwargs or {}))
 
         return hists
 

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -236,7 +236,10 @@ class PlotVariablesBase(_PlotVariablesBase):
                     )
 
             # update histograms using custom hooks
-            hists = self.invoke_hist_hooks(hists)
+            hists = self.invoke_hist_hooks(
+                hists,
+                hook_kwargs={"category_name": self.branch_data.category, "variable_name": self.branch_data.variable},
+            )
 
             # merge configs
             if len(self.config_insts) != 1:


### PR DESCRIPTION
This is a rather small PR that allows passing specific values known at task-level to hist hooks.

Examples are - in case of the plotting tasks - the requested variable and category names. In this specific case, this info would also be accessible though the task's `branch_data` (and the `task` instance itself is already forwarded to hooks), but in other cases, this might not be the case (e.g. when the tasks performs a loop and important info is only *local* to that context.

Therefore, all hist hooks should - from now on - take arbitrary keyword arguments.