### PR TITLE
Sequentialize and optimize datacard writing.

### DIFF
--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -1306,8 +1306,8 @@ class InferenceModel(Derivable, metaclass=InferenceModelMeta):
             for process in _processes:
                 process.parameters.append(_copy.deepcopy(parameter))
 
-        # add to groups
-        if group:
+        # add to groups if it was added to at least one process
+        if group and processes and any(_processes for _processes in processes.values()):
             self.add_parameter_to_group(parameter.name, group)
 
         return parameter

--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -572,35 +572,6 @@ class InferenceModel(Derivable, metaclass=InferenceModelMeta):
             ("shift_source", str(shift_source) if shift_source else None),
         ])
 
-    @classmethod
-    def require_shapes_for_parameter(self, param_obj: dict) -> bool:
-        """
-        Function to check if for a certain parameter object *param_obj* varied
-        shapes are needed.
-
-        :param param_obj: The parameter object to check.
-        :returns: *True* if varied shapes are needed, *False* otherwise.
-        """
-        if param_obj.type.is_shape:
-            # the shape might be build from a rate, in which case input shapes are not required
-            if param_obj.transformations.any_from_rate:
-                return False
-            # in any other case, shapes are required
-            return True
-
-        if param_obj.type.is_rate:
-            # when the rate effect is extracted from shapes, they are required
-            if param_obj.transformations.any_from_shape:
-                return True
-            # in any other case, shapes are not required
-            return False
-
-        # other cases are not supported
-        raise Exception(
-            f"shape requirement cannot be evaluated for parameter '{param_obj.name}' with type " +
-            f"'{param_obj.type}' and transformations {param_obj.transformations}",
-        )
-
     def __init__(self, config_insts: list[od.Config]) -> None:
         super().__init__()
 

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -6,6 +6,8 @@ Tasks related to the creation of datacards for inference purposes.
 
 from __future__ import annotations
 
+import collections
+
 import law
 import order as od
 
@@ -47,145 +49,169 @@ class CreateDatacards(SerializeInferenceModelBase):
         inputs = self.input()
         outputs = self.output()
 
-        # step 1: gather histograms per variable and process for each config
-        input_hists: dict[str, dict[od.Config, dict[od.Process, hist.Hist]]] = {}
+        # overall strategy to load data efficiently and to write datacards:
+        # 1) determine which variables have to be loaded for which config (stored in a map), then loop over variables
+        # 2) load all histograms per config
+        # 3) start datacard writing by looping over datacard categories that use the specific variable
+        # 4) apply hist hooks
+        # 5) prepare histogram in the nested format expected by the datacard writer and write the card
+
+        # step 1: gather variable info, then loop
+        variable_data = collections.defaultdict(set)
         for config_inst, data in self.combined_config_data.items():
             for variable in data["variables"]:
-                if variable not in input_hists:
-                    input_hists[variable] = {}
-                input_hists[variable][config_inst] = self.load_process_hists(
+                variable_data[variable].add(config_inst)
+
+        for variable, variable_config_insts in variable_data.items():
+            # step 2
+            input_hists: dict[od.Config, dict[od.Process, hist.Hist]] = {}
+            for config_inst in variable_config_insts:
+                data = self.combined_config_data[config_inst]
+                input_hists[config_inst] = self.load_process_hists(
                     config_inst,
                     list(data["mc_datasets"]) + list(data["data_datasets"]),
                     variable,
                     inputs[config_inst.name],
                 )
 
-        # loop over all configs required by the datacard category and gather histograms
-        for cat_obj in self.inference_model_inst.categories:
-            # check which configs contribute to this category
-            config_insts = [config_inst for config_inst in self.config_insts if config_inst.name in cat_obj.config_data]
-            if not config_insts:
-                continue
-            self.publish_message(f"processing inputs for datacard category '{cat_obj.name}'")
+            # step 3
+            for cat_obj in self.inference_model_inst.categories:
+                # skip if the variable is not used in this category
+                if not any(d.variable == variable for d in cat_obj.config_data.values()):
+                    continue
+                # cross check that all configs use the same variable (should already be guarded by the model validation)
+                assert all(d.variable == variable for d in cat_obj.config_data.values())
 
-            # get config-based variable and category name
-            variable = cat_obj.config_data[config_insts[0].name].variable
-            category = cat_obj.config_data[config_insts[0].name].category
+                # check which configs contribute to this category
+                config_insts = [
+                    config_inst for config_inst in self.config_insts
+                    if config_inst.name in cat_obj.config_data
+                ]
+                if not config_insts:
+                    continue
+                self.publish_message(f"processing inputs for category '{cat_obj.name}' with variable '{variable}'")
 
-            # step 2: apply hist hooks for the selected variable
-            _input_hists = self.invoke_hist_hooks(
-                {config_inst: input_hists[variable][config_inst].copy() for config_inst in config_insts},
-                hook_kwargs={"variable_name": variable, "category_name": category},
-            )
+                # get config-based category name
+                category = cat_obj.config_data[config_insts[0].name].category
 
-            # step 3: transform to nested histogram as expected by the datacard writer
-            datacard_hists: DatacardHists = {cat_obj.name: {}}
-            for config_inst in _input_hists.keys():
-                config_data = cat_obj.config_data.get(config_inst.name)
+                # step 4: hist hooks
+                _input_hists = self.invoke_hist_hooks(
+                    {config_inst: input_hists[config_inst].copy() for config_inst in config_insts},
+                    hook_kwargs={"variable_name": variable, "category_name": category},
+                )
 
-                # determine leaf categories to gather
-                category_inst = config_inst.get_category(category)
-                leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
+                # step 5: transform to datacard format
+                datacard_hists: DatacardHists = {cat_obj.name: {}}
+                for config_inst in _input_hists.keys():
+                    config_data = cat_obj.config_data.get(config_inst.name)
 
-                # eagerly remove data histograms in case data is supposed to be faked from mc processes
-                if cat_obj.data_from_processes:
-                    for process_inst in list(_input_hists[config_inst]):
-                        if process_inst.is_data:
-                            del _input_hists[config_inst][process_inst]
+                    # determine leaf categories to gather
+                    category_inst = config_inst.get_category(category)
+                    leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
 
-                # start the transformation
-                proc_objs = list(cat_obj.processes)
-                if config_data.data_datasets and not cat_obj.data_from_processes:
-                    proc_objs.append(self.inference_model_inst.process_spec(name="data"))
-                for proc_obj in proc_objs:
-                    # get all process instances (keys in _input_hists) to be combined
-                    if proc_obj.is_dynamic:
-                        if not (process_name := proc_obj.config_data[config_inst.name].get("process", None)):
-                            raise ValueError(
-                                f"dynamic datacard process object misses 'process' entry in config data for "
-                                f"'{config_inst.name}': {proc_obj}",
-                            )
-                        process_insts = [config_inst.get_process(process_name)]
-                    else:
-                        process_insts = [
-                            config_inst.get_dataset(dataset_name).processes.get_first()
-                            for dataset_name in proc_obj.config_data[config_inst.name].mc_datasets
-                        ]
+                    # eagerly remove data histograms in case data is supposed to be faked from mc processes
+                    if cat_obj.data_from_processes:
+                        for process_inst in list(_input_hists[config_inst]):
+                            if process_inst.is_data:
+                                del _input_hists[config_inst][process_inst]
 
-                    # collect per-process histograms
-                    h_procs = []
-                    for process_inst in process_insts:
-                        # extract the histogram for the process
-                        # (removed from hists to eagerly cleanup memory)
-                        h_proc = _input_hists[config_inst].pop(process_inst, None)
-                        if h_proc is None:
-                            self.logger.error(
-                                f"found no histogram to model datacard process '{proc_obj.name}', please check your "
-                                f"inference model '{self.inference_model}'",
-                            )
-                            continue
-
-                        # select relevant categories
-                        h_proc = h_proc[{
-                            "category": [
-                                hist.loc(c.name)
-                                for c in leaf_category_insts
-                                if c.name in h_proc.axes["category"]
-                            ],
-                        }]
-                        h_proc = h_proc[{"category": sum}]
-
-                        h_procs.append(h_proc)
-
-                    if h_procs is None:
-                        continue
-
-                    # combine them
-                    h_proc = sum(h_procs[1:], h_procs[0].copy())
-
-                    # create the nominal hist
-                    datacard_hists[cat_obj.name].setdefault(proc_obj.name, {}).setdefault(config_inst.name, {})
-                    shift_hists: ShiftHists = datacard_hists[cat_obj.name][proc_obj.name][config_inst.name]
-                    shift_hists["nominal"] = h_proc[{
-                        "shift": hist.loc(config_inst.get_shift("nominal").name),
-                    }]
-
-                    # no additional shifts need to be created for data
-                    if proc_obj.name == "data":
-                        continue
-
-                    # create histograms per shape shift
-                    for param_obj in proc_obj.parameters:
-                        # skip the parameter when varied hists are not needed
-                        if (
-                            not param_obj.type.is_shape and
-                            not any(trafo.from_shape for trafo in param_obj.transformations)
-                        ):
-                            continue
-                        # store the varied hists
-                        shift_source = (
-                            param_obj.config_data[config_inst.name].shift_source
-                            if config_inst.name in param_obj.config_data
-                            else None
-                        )
-                        for d in ["up", "down"]:
-                            if shift_source and f"{shift_source}_{d}" not in h_proc.axes["shift"]:
+                    # start the transformation
+                    proc_objs = list(cat_obj.processes)
+                    if config_data.data_datasets and not cat_obj.data_from_processes:
+                        proc_objs.append(self.inference_model_inst.process_spec(name="data"))
+                    for proc_obj in proc_objs:
+                        # get all process instances (keys in _input_hists) to be combined
+                        if proc_obj.is_dynamic:
+                            if not (process_name := proc_obj.config_data[config_inst.name].get("process", None)):
                                 raise ValueError(
-                                    f"cannot find '{shift_source}_{d}' in shift axis of histogram for process "
-                                    f"'{proc_obj.name}' in config '{config_inst.name}' while handling parameter "
-                                    f"'{param_obj.name}' in datacard category '{cat_obj.name}', available shifts "
-                                    f"are: {list(h_proc.axes['shift'])}",
+                                    f"dynamic datacard process object misses 'process' entry in config data for "
+                                    f"'{config_inst.name}': {proc_obj}",
                                 )
-                            shift_hists[(param_obj.name, d)] = h_proc[{
-                                "shift": hist.loc(f"{shift_source}_{d}" if shift_source else "nominal"),
-                            }]
+                            process_insts = [config_inst.get_process(process_name)]
+                        else:
+                            process_insts = [
+                                config_inst.get_dataset(dataset_name).processes.get_first()
+                                for dataset_name in proc_obj.config_data[config_inst.name].mc_datasets
+                            ]
 
-            # forward objects to the datacard writer
-            outp = outputs[cat_obj.name]
-            writer = self.datacard_writer_cls(self.inference_model_inst, datacard_hists)
-            with outp["card"].localize("w") as tmp_card, outp["shapes"].localize("w") as tmp_shapes:
-                writer.write(tmp_card.abspath, tmp_shapes.abspath, shapes_path_ref=outp["shapes"].basename)
-            self.publish_message(f"datacard written to {outp['card'].abspath}")
+                        # collect per-process histograms
+                        h_procs = []
+                        for process_inst in process_insts:
+                            # extract the histogram for the process
+                            # (removed from hists to eagerly cleanup memory)
+                            h_proc = _input_hists[config_inst].pop(process_inst, None)
+                            if h_proc is None:
+                                self.logger.error(
+                                    f"found no histogram to model datacard process '{proc_obj.name}', please check your "
+                                    f"inference model '{self.inference_model}'",
+                                )
+                                continue
+
+                            # select relevant categories
+                            h_proc = h_proc[{
+                                "category": [
+                                    hist.loc(c.name)
+                                    for c in leaf_category_insts
+                                    if c.name in h_proc.axes["category"]
+                                ],
+                            }]
+                            h_proc = h_proc[{"category": sum}]
+
+                            h_procs.append(h_proc)
+
+                        if h_procs is None:
+                            continue
+
+                        # combine them
+                        h_proc = sum(h_procs[1:], h_procs[0].copy())
+
+                        # create the nominal hist
+                        datacard_hists[cat_obj.name].setdefault(proc_obj.name, {}).setdefault(config_inst.name, {})
+                        shift_hists: ShiftHists = datacard_hists[cat_obj.name][proc_obj.name][config_inst.name]
+                        shift_hists["nominal"] = h_proc[{
+                            "shift": hist.loc(config_inst.get_shift("nominal").name),
+                        }]
+
+                        # no additional shifts need to be created for data
+                        if proc_obj.name == "data":
+                            continue
+
+                        # create histograms per shape shift
+                        for param_obj in proc_obj.parameters:
+                            # skip the parameter when varied hists are not needed
+                            if (
+                                not param_obj.type.is_shape and
+                                not any(trafo.from_shape for trafo in param_obj.transformations)
+                            ):
+                                continue
+                            # store the varied hists
+                            shift_source = (
+                                param_obj.config_data[config_inst.name].shift_source
+                                if config_inst.name in param_obj.config_data
+                                else None
+                            )
+                            for d in ["up", "down"]:
+                                if shift_source and f"{shift_source}_{d}" not in h_proc.axes["shift"]:
+                                    raise ValueError(
+                                        f"cannot find '{shift_source}_{d}' in shift axis of histogram for process "
+                                        f"'{proc_obj.name}' in config '{config_inst.name}' while handling parameter "
+                                        f"'{param_obj.name}' in datacard category '{cat_obj.name}', available shifts "
+                                        f"are: {list(h_proc.axes['shift'])}",
+                                    )
+                                shift_hists[(param_obj.name, d)] = h_proc[{
+                                    "shift": hist.loc(f"{shift_source}_{d}" if shift_source else "nominal"),
+                                }]
+
+                # forward objects to the datacard writer
+                outp = outputs[cat_obj.name]
+                writer = self.datacard_writer_cls(self.inference_model_inst, datacard_hists)
+                with outp["card"].localize("w") as tmp_card, outp["shapes"].localize("w") as tmp_shapes:
+                    writer.write(tmp_card.abspath, tmp_shapes.abspath, shapes_path_ref=outp["shapes"].basename)
+                self.publish_message(f"datacard written to {outp['card'].abspath}")
+
+                # eager cleanup
+                del _input_hists
+            del input_hists
 
 
 CreateDatacardsWrapper = wrapper_factory(

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -19,122 +19,173 @@ from columnflow.inference.cms.datacard import DatacardHists, ShiftHists, Datacar
 class CreateDatacards(SerializeInferenceModelBase):
 
     resolution_task_cls = MergeHistograms
-
     datacard_writer_cls = DatacardWriter
 
     def output(self):
-        hooks_repr = self.hist_hooks_repr
-        cat_obj = self.branch_data
-
-        def basename(name: str, ext: str) -> str:
+        def basename(cat_obj, name, ext):
             parts = [name, cat_obj.name]
-            if hooks_repr:
+            if (hooks_repr := self.hist_hooks_repr):
                 parts.append(f"hooks_{hooks_repr}")
             if cat_obj.postfix is not None:
                 parts.append(cat_obj.postfix)
             return f"{'__'.join(map(str, parts))}.{ext}"
 
-        return {
-            "card": self.target(basename("datacard", "txt")),
-            "shapes": self.target(basename("shapes", "root")),
-        }
+        return law.SiblingFileCollection({
+            cat_obj.name: {
+                "card": self.target(basename(cat_obj, "datacard", "txt")),
+                "shapes": self.target(basename(cat_obj, "shapes", "root")),
+            }
+            for cat_obj in self.inference_model_inst.categories
+        })
 
     @law.decorator.log
     @law.decorator.safe_output
     def run(self):
         import hist
 
-        # prepare inputs
+        # prepare inputs and outputs
         inputs = self.input()
+        outputs = self.output()
+
+        # step 1: gather histograms per variable and process for each config
+        input_hists: dict[str, dict[od.Config, dict[od.Process, hist.Hist]]] = {}
+        for config_inst, data in self.combined_config_data.items():
+            for variable in data["variables"]:
+                if variable not in input_hists:
+                    input_hists[variable] = {}
+                input_hists[variable][config_inst] = self.load_process_hists(
+                    config_inst,
+                    list(data["mc_datasets"]) + list(data["data_datasets"]),
+                    variable,
+                    inputs[config_inst.name],
+                )
 
         # loop over all configs required by the datacard category and gather histograms
-        cat_obj = self.branch_data
-        datacard_hists: DatacardHists = {cat_obj.name: {}}
-
-        # step 1: gather histograms per process for each config
-        input_hists: dict[od.Config, dict[od.Process, hist.Hist]] = {}
-        for config_inst in self.config_insts:
-            # skip configs that are not required
-            if not cat_obj.config_data.get(config_inst.name):
+        for cat_obj in self.inference_model_inst.categories:
+            # check which configs contribute to this category
+            config_insts = [config_inst for config_inst in self.config_insts if config_inst.name in cat_obj.config_data]
+            if not config_insts:
                 continue
-            # load them
-            input_hists[config_inst] = self.load_process_hists(inputs, cat_obj, config_inst)
+            self.publish_message(f"processing inputs for datacard category '{cat_obj.name}'")
 
-        # step 2: apply hist hooks
-        input_hists = self.invoke_hist_hooks(input_hists)
+            # get config-based variable and category name
+            variable = cat_obj.config_data[config_insts[0].name].variable
+            category = cat_obj.config_data[config_insts[0].name].category
 
-        # step 3: transform to nested histogram as expected by the datacard writer
-        for config_inst in input_hists.keys():
-            config_data = cat_obj.config_data.get(config_inst.name)
+            # step 2: apply hist hooks for the selected variable
+            _input_hists = self.invoke_hist_hooks(
+                {config_inst: input_hists[variable][config_inst].copy() for config_inst in config_insts},
+                hook_kwargs={"variable_name": variable, "category_name": category},
+            )
 
-            # determine leaf categories to gather
-            category_inst = config_inst.get_category(config_data.category)
-            leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
+            # step 3: transform to nested histogram as expected by the datacard writer
+            datacard_hists: DatacardHists = {cat_obj.name: {}}
+            for config_inst in _input_hists.keys():
+                config_data = cat_obj.config_data.get(config_inst.name)
 
-            # start the transformation
-            proc_objs = list(cat_obj.processes)
-            if config_data.data_datasets and not cat_obj.data_from_processes:
-                proc_objs.append(self.inference_model_inst.process_spec(name="data"))
-            for proc_obj in proc_objs:
-                # get the corresponding process instance
-                if proc_obj.name == "data":
-                    process_inst = config_inst.get_process("data")
-                elif config_inst.name in proc_obj.config_data:
-                    process_inst = config_inst.get_process(proc_obj.config_data[config_inst.name].process)
-                else:
-                    # skip process objects that rely on data from a different config
-                    continue
+                # determine leaf categories to gather
+                category_inst = config_inst.get_category(category)
+                leaf_category_insts = category_inst.get_leaf_categories() or [category_inst]
 
-                # extract the histogram for the process
-                if not (h_proc := input_hists[config_inst].get(process_inst, None)):
-                    self.logger.warning(
-                        f"found no histogram to model datacard process '{proc_obj.name}', please check your "
-                        f"inference model '{self.inference_model}'",
-                    )
-                    continue
+                # eagerly remove data histograms in case data is supposed to be faked from mc processes
+                if cat_obj.data_from_processes:
+                    for process_inst in list(_input_hists[config_inst]):
+                        if process_inst.is_data:
+                            del _input_hists[config_inst][process_inst]
 
-                # select relevant categories
-                h_proc = h_proc[{
-                    "category": [
-                        hist.loc(c.name)
-                        for c in leaf_category_insts
-                        if c.name in h_proc.axes["category"]
-                    ],
-                }][{"category": sum}]
+                # start the transformation
+                proc_objs = list(cat_obj.processes)
+                if config_data.data_datasets and not cat_obj.data_from_processes:
+                    proc_objs.append(self.inference_model_inst.process_spec(name="data"))
+                for proc_obj in proc_objs:
+                    # get all process instances (keys in _input_hists) to be combined
+                    if proc_obj.is_dynamic:
+                        if not (process_name := proc_obj.config_data[config_inst.name].get("process", None)):
+                            raise ValueError(
+                                f"dynamic datacard process object misses 'process' entry in config data for "
+                                f"'{config_inst.name}': {proc_obj}",
+                            )
+                        process_insts = [config_inst.get_process(process_name)]
+                    else:
+                        process_insts = [
+                            config_inst.get_dataset(dataset_name).processes.get_first()
+                            for dataset_name in proc_obj.config_data[config_inst.name].mc_datasets
+                        ]
 
-                # create the nominal hist
-                datacard_hists[cat_obj.name].setdefault(proc_obj.name, {}).setdefault(config_inst.name, {})
-                shift_hists: ShiftHists = datacard_hists[cat_obj.name][proc_obj.name][config_inst.name]
-                shift_hists["nominal"] = h_proc[{
+                    # collect per-process histograms
+                    h_procs = []
+                    for process_inst in process_insts:
+                        # extract the histogram for the process
+                        # (removed from hists to eagerly cleanup memory)
+                        h_proc = _input_hists[config_inst].pop(process_inst, None)
+                        if h_proc is None:
+                            self.logger.error(
+                                f"found no histogram to model datacard process '{proc_obj.name}', please check your "
+                                f"inference model '{self.inference_model}'",
+                            )
+                            continue
 
-                    "shift": hist.loc(config_inst.get_shift("nominal").name),
-                }]
-
-                # no additional shifts need to be created for data
-                if proc_obj.name == "data":
-                    continue
-
-                # create histograms per shift
-                for param_obj in proc_obj.parameters:
-                    # skip the parameter when varied hists are not needed
-                    if not self.inference_model_inst.require_shapes_for_parameter(param_obj):
-                        continue
-                    # store the varied hists
-                    shift_source = (
-                        param_obj.config_data[config_inst.name].shift_source
-                        if config_inst.name in param_obj.config_data
-                        else None
-                    )
-                    for d in ["up", "down"]:
-                        shift_hists[(param_obj.name, d)] = h_proc[{
-                            "shift": hist.loc(f"{shift_source}_{d}" if shift_source else "nominal"),
+                        # select relevant categories
+                        h_proc = h_proc[{
+                            "category": [
+                                hist.loc(c.name)
+                                for c in leaf_category_insts
+                                if c.name in h_proc.axes["category"]
+                            ],
                         }]
+                        h_proc = h_proc[{"category": sum}]
 
-        # forward objects to the datacard writer
-        outputs = self.output()
-        writer = self.datacard_writer_cls(self.inference_model_inst, datacard_hists)
-        with outputs["card"].localize("w") as tmp_card, outputs["shapes"].localize("w") as tmp_shapes:
-            writer.write(tmp_card.abspath, tmp_shapes.abspath, shapes_path_ref=outputs["shapes"].basename)
+                        h_procs.append(h_proc)
+
+                    if h_procs is None:
+                        continue
+
+                    # combine them
+                    h_proc = sum(h_procs[1:], h_procs[0].copy())
+
+                    # create the nominal hist
+                    datacard_hists[cat_obj.name].setdefault(proc_obj.name, {}).setdefault(config_inst.name, {})
+                    shift_hists: ShiftHists = datacard_hists[cat_obj.name][proc_obj.name][config_inst.name]
+                    shift_hists["nominal"] = h_proc[{
+                        "shift": hist.loc(config_inst.get_shift("nominal").name),
+                    }]
+
+                    # no additional shifts need to be created for data
+                    if proc_obj.name == "data":
+                        continue
+
+                    # create histograms per shape shift
+                    for param_obj in proc_obj.parameters:
+                        # skip the parameter when varied hists are not needed
+                        if (
+                            not param_obj.type.is_shape and
+                            not any(trafo.from_shape for trafo in param_obj.transformations)
+                        ):
+                            continue
+                        # store the varied hists
+                        shift_source = (
+                            param_obj.config_data[config_inst.name].shift_source
+                            if config_inst.name in param_obj.config_data
+                            else None
+                        )
+                        for d in ["up", "down"]:
+                            if shift_source and f"{shift_source}_{d}" not in h_proc.axes["shift"]:
+                                raise ValueError(
+                                    f"cannot find '{shift_source}_{d}' in shift axis of histogram for process "
+                                    f"'{proc_obj.name}' in config '{config_inst.name}' while handling parameter "
+                                    f"'{param_obj.name}' in datacard category '{cat_obj.name}', available shifts "
+                                    f"are: {list(h_proc.axes['shift'])}",
+                                )
+                            shift_hists[(param_obj.name, d)] = h_proc[{
+                                "shift": hist.loc(f"{shift_source}_{d}" if shift_source else "nominal"),
+                            }]
+
+            # forward objects to the datacard writer
+            outp = outputs[cat_obj.name]
+            writer = self.datacard_writer_cls(self.inference_model_inst, datacard_hists)
+            with outp["card"].localize("w") as tmp_card, outp["shapes"].localize("w") as tmp_shapes:
+                writer.write(tmp_card.abspath, tmp_shapes.abspath, shapes_path_ref=outp["shapes"].basename)
+            self.publish_message(f"datacard written to {outp['card'].abspath}")
 
 
 CreateDatacardsWrapper = wrapper_factory(

--- a/columnflow/tasks/framework/inference.py
+++ b/columnflow/tasks/framework/inference.py
@@ -6,6 +6,8 @@ Base tasks for writing serialized statistical inference models.
 
 from __future__ import annotations
 
+import pickle
+
 import law
 import order as od
 
@@ -15,7 +17,7 @@ from columnflow.tasks.framework.mixins import (
     InferenceModelMixin, HistHookMixin, MLModelsMixin,
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
-from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
+from columnflow.tasks.histograms import MergeShiftedHistograms
 from columnflow.util import dev_sandbox, DotDict, maybe_import
 from columnflow.config_util import get_datasets_from_process
 
@@ -42,7 +44,6 @@ class SerializeInferenceModelBase(
     # upstream requirements
     reqs = Requirements(
         RemoteWorkflow.reqs,
-        MergeHistograms=MergeHistograms,
         MergeShiftedHistograms=MergeShiftedHistograms,
     )
 
@@ -106,153 +107,171 @@ class SerializeInferenceModelBase(
             )
         ]
 
-    def create_branch_map(self):
-        return list(self.inference_model_inst.categories)
-
-    def _requires_cat_obj(self, cat_obj: DotDict, merge_variables: bool = False, **req_kwargs):
-        """
-        Helper to create the requirements for a single category object.
-
-        :param cat_obj: category object from an InferenceModel
-        :param merge_variables: whether to merge the variables from all requested category objects
-        :return: requirements for the category object
-        """
-        reqs = {}
-        for config_inst in self.config_insts:
-            if not (config_data := cat_obj.config_data.get(config_inst.name)):
-                continue
-
-            if merge_variables:
-                variables = tuple(
-                    _cat_obj.config_data.get(config_inst.name).variable
-                    for _cat_obj in self.branch_map.values()
-                )
-            else:
-                variables = (config_data.variable,)
-
-            # add merged shifted histograms for mc
-            reqs[config_inst.name] = {
-                proc_obj.name: {
-                    dataset: self.reqs.MergeShiftedHistograms.req_different_branching(
-                        self,
-                        config=config_inst.name,
-                        dataset=dataset,
-                        shift_sources=tuple(
-                            param_obj.config_data[config_inst.name].shift_source
-                            for param_obj in proc_obj.parameters
-                            if (
-                                config_inst.name in param_obj.config_data and
-                                self.inference_model_inst.require_shapes_for_parameter(param_obj)
-                            )
-                        ),
-                        variables=variables,
-                        **req_kwargs,
-                    )
-                    for dataset in self.get_mc_datasets(config_inst, proc_obj)
-                }
-                for proc_obj in cat_obj.processes
-                if config_inst.name in proc_obj.config_data and not proc_obj.is_dynamic
+    @law.workflow_property(cache=True)
+    def combined_config_data(self) -> dict[od.ConfigInst, dict[str, dict | set]]:
+        # prepare data extracted from the inference model
+        config_data = {
+            config_inst: {
+                # all variables used in this config in any datacard category
+                "variables": set(),
+                # plain set of names of real data datasets
+                "data_datasets": set(),
+                # per name of mc dataset, the set of shift sources and the name of the datacard process object
+                "mc_datasets": {},
             }
-            # add merged histograms for data, but only if
-            # - data in that category is not faked from mc, or
-            # - at least one process object is dynamic (that usually means data-driven)
-            if (
-                (not cat_obj.data_from_processes or any(proc_obj.is_dynamic for proc_obj in cat_obj.processes)) and
-                (data_datasets := self.get_data_datasets(config_inst, cat_obj))
-            ):
-                reqs[config_inst.name]["data"] = {
-                    dataset: self.reqs.MergeHistograms.req_different_branching(
-                        self,
-                        config=config_inst.name,
-                        dataset=dataset,
-                        variables=variables,
-                        **req_kwargs,
-                    )
-                    for dataset in data_datasets
-                }
+            for config_inst in self.config_insts
+        }
+
+        # iterate over all model categories
+        for cat_obj in self.inference_model_inst.categories:
+            # keep track of per-category information for consistency checks
+            variables = set()
+            categories = set()
+
+            # iterate over configs relevant for this category
+            config_insts = [config_inst for config_inst in self.config_insts if config_inst.name in cat_obj.config_data]
+            for config_inst in config_insts:
+                data = config_data[config_inst]
+
+                # variables
+                data["variables"].add(cat_obj.config_data[config_inst.name].variable)
+
+                # data datasets, but only if
+                #   - data in that category is not faked from mc processes, or
+                #   - at least one process object is dynamic (that usually means data-driven)
+                if not cat_obj.data_from_processes or any(proc_obj.is_dynamic for proc_obj in cat_obj.processes):
+                    data["data_datasets"].update(self.get_data_datasets(config_inst, cat_obj))
+
+                # mc datasets over all process objects
+                #   - the process is not dynamic
+                for proc_obj in cat_obj.processes:
+                    mc_datasets = self.get_mc_datasets(config_inst, proc_obj)
+                    for dataset_name in mc_datasets:
+                        if dataset_name not in data["mc_datasets"]:
+                            data["mc_datasets"][dataset_name] = {
+                                "proc_name": proc_obj.name,
+                                "shift_sources": set(),
+                            }
+                        elif data["mc_datasets"][dataset_name]["proc_name"] != proc_obj.name:
+                            raise ValueError(
+                                f"dataset '{dataset_name}' was already assigned to datacard process "
+                                f"'{data['mc_datasets'][dataset_name]['proc_name']}' and cannot be re-assigned to "
+                                f"'{proc_obj.name}' in config '{config_inst.name}'",
+                            )
+
+                    # shift sources
+                    for param_obj in proc_obj.parameters:
+                        if config_inst.name not in param_obj.config_data:
+                            continue
+                        # only add if a shift is required for this parameter
+                        if param_obj.type.is_shape or any(trafo.from_shape for trafo in param_obj.transformations):
+                            shift_source = param_obj.config_data[config_inst.name].shift_source
+                            for mc_dataset in mc_datasets:
+                                data["mc_datasets"][mc_dataset]["shift_sources"].add(shift_source)
+
+                # for consistency checks later
+                variables.add(cat_obj.config_data[config_inst.name].variable)
+                categories.add(cat_obj.config_data[config_inst.name].category)
+
+            # consistency checks: the config-based variable and category names must be identical
+            if len(variables) != 1:
+                raise ValueError(
+                    f"found diverging variables to be used in datacard category '{cat_obj.name}' across configs "
+                    f"{', '.join(c.name for c in config_insts)}: {variables}",
+                )
+            if len(categories) != 1:
+                raise ValueError(
+                    f"found diverging categories to be used in datacard category '{cat_obj.name}' across configs "
+                    f"{', '.join(c.name for c in config_insts)}: {categories}",
+                )
+
+        return config_data
+
+    def create_branch_map(self):
+        # dummy branch map
+        return {0: None}
+
+    def _hist_requirements(self, **kwargs):
+        # gather data from inference model to define requirements in the structure
+        # config_name -> dataset_name -> MergeHistogramsTask
+        reqs = {}
+        for config_inst, data in self.combined_config_data.items():
+            reqs[config_inst.name] = {}
+            # mc datasets
+            for dataset_name in sorted(data["mc_datasets"]):
+                reqs[config_inst.name][dataset_name] = self.reqs.MergeShiftedHistograms.req_different_branching(
+                    self,
+                    config=config_inst.name,
+                    dataset=dataset_name,
+                    shift_sources=tuple(sorted(data["mc_datasets"][dataset_name]["shift_sources"])),
+                    variables=tuple(sorted(data["variables"])),
+                    **kwargs,
+                )
+            # data datasets
+            for dataset_name in sorted(data["data_datasets"]):
+                reqs[config_inst.name][dataset_name] = self.reqs.MergeShiftedHistograms.req_different_branching(
+                    self,
+                    config=config_inst.name,
+                    dataset=dataset_name,
+                    shift_sources=(),
+                    variables=tuple(sorted(data["variables"])),
+                    **kwargs,
+                )
 
         return reqs
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
-
-        reqs["merged_hists"] = hist_reqs = {}
-        for cat_obj in self.branch_map.values():
-            cat_reqs = self._requires_cat_obj(cat_obj, merge_variables=True)
-            for config_name, proc_reqs in cat_reqs.items():
-                hist_reqs.setdefault(config_name, {})
-                for proc_name, dataset_reqs in proc_reqs.items():
-                    hist_reqs[config_name].setdefault(proc_name, {})
-                    for dataset_name, task in dataset_reqs.items():
-                        hist_reqs[config_name][proc_name].setdefault(dataset_name, set()).add(task)
+        reqs["merged_hists"] = self._hist_requirements()
         return reqs
 
     def requires(self):
-        cat_obj = self.branch_data
-        return self._requires_cat_obj(cat_obj, branch=-1, workflow="local")
+        return self._hist_requirements(branch=-1, workflow="local")
 
     def load_process_hists(
         self,
-        inputs: dict,
-        cat_obj: DotDict,
         config_inst: od.Config,
-    ) -> dict[od.Process, hist.Hist]:
-        # loop over all configs required by the datacard category and gather histograms
-        config_data = cat_obj.config_data.get(config_inst.name)
-
-        # collect histograms per config process
+        dataset_names: list[str],
+        variable: str,
+        inputs: dict,
+    ) -> dict[str, dict[od.Process, hist.Hist]]:
+        # collect histograms per variable and process
         hists: dict[od.Process, hist.Hist] = {}
-        with self.publish_step(
-            f"extracting {config_data.variable} in {config_data.category} for config {config_inst.name}...",
-        ):
-            for proc_obj_name, inp in inputs[config_inst.name].items():
-                if proc_obj_name == "data":
+
+        with self.publish_step(f"extracting '{variable}' for config {config_inst.name} ..."):
+            for dataset_name in dataset_names:
+                dataset_inst = config_inst.get_dataset(dataset_name)
+                process_inst = dataset_inst.processes.get_first()
+
+                # for real data, fallback to the main data process
+                if process_inst.is_data:
                     process_inst = config_inst.get_process("data")
-                else:
-                    proc_obj = self.inference_model_inst.get_process(proc_obj_name, category=cat_obj.name)
-                    process_inst = config_inst.get_process(proc_obj.config_data[config_inst.name].process)
+
+                # gather all subprocesses for a full query later
                 sub_process_insts = [sub for sub, _, _ in process_inst.walk_processes(include_self=True)]
 
-                # loop over per-dataset inputs and extract histograms containing the process
-                h_proc = None
-                for dataset_name, _inp in inp.items():
-                    dataset_inst = config_inst.get_dataset(dataset_name)
+                # open the histogram and work on a copy
+                inp = inputs[dataset_name]["collection"][0]["hists"][variable]
+                try:
+                    h = inp.load(formatter="pickle").copy()
+                except pickle.UnpicklingError as e:
+                    raise Exception(
+                        f"failed to load '{variable}' histogram for dataset '{dataset_name}' in config "
+                        f"'{config_inst.name}' from {inp.abspath}",
+                    ) from e
 
-                    # skip when the dataset is already known to not contain any sub process
-                    if not any(map(dataset_inst.has_process, sub_process_insts)):
-                        self.logger.warning(
-                            f"dataset '{dataset_name}' does not contain process '{process_inst.name}' or any of "
-                            "its subprocesses which indicates a misconfiguration in the inference model "
-                            f"'{self.inference_model}'",
-                        )
-                        continue
+                # there must be at least one matching sub process
+                if not any(p.name in h.axes["process"] for p in sub_process_insts):
+                    raise Exception(f"no '{variable}' histograms found for process '{process_inst.name}'")
 
-                    # open the histogram and work on a copy
-                    h = _inp["collection"][0]["hists"][config_data.variable].load(formatter="pickle").copy()
+                # select and reduce over relevant processes
+                h = h[{"process": [hist.loc(p.name) for p in sub_process_insts if p.name in h.axes["process"]]}]
+                h = h[{"process": sum}]
 
-                    # axis selections
-                    h = h[{
-                        "process": [
-                            hist.loc(p.name)
-                            for p in sub_process_insts
-                            if p.name in h.axes["process"]
-                        ],
-                    }]
-
-                    # axis reductions
-                    h = h[{"process": sum}]
-
-                    # add the histogram for this dataset
-                    if h_proc is None:
-                        h_proc = h
-                    else:
-                        h_proc += h
-
-                # there must be a histogram
-                if h_proc is None:
-                    raise Exception(f"no histograms found for process '{process_inst.name}'")
-
-                # save histograms mapped to processes
-                hists[process_inst] = h_proc
+                # store it
+                if process_inst in hists:
+                    hists[process_inst] += h
+                else:
+                    hists[process_inst] = h
 
         return hists

--- a/columnflow/tasks/framework/inference.py
+++ b/columnflow/tasks/framework/inference.py
@@ -268,6 +268,9 @@ class SerializeInferenceModelBase(
                 h = h[{"process": [hist.loc(p.name) for p in sub_process_insts if p.name in h.axes["process"]]}]
                 h = h[{"process": sum}]
 
+                # additional custom reductions
+                h = self.modify_process_hist(process_inst, h)
+
                 # store it
                 if process_inst in hists:
                     hists[process_inst] += h
@@ -275,3 +278,13 @@ class SerializeInferenceModelBase(
                     hists[process_inst] = h
 
         return hists
+
+    def modify_process_hist(self, process_inst: od.Process, h: hist.Hist) -> hist.Hist:
+        """
+        Hook to modify a process histogram after it has been loaded. This can be helpful to reduce memory early on.
+
+        :param process_inst: The process instance the histogram belongs to.
+        :param histo: The histogram to modify.
+        :return: The modified histogram.
+        """
+        return h

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -177,34 +177,3 @@ class TestInferenceModel(unittest.TestCase):
         )
 
         self.assertDictEqual(result, expected_result)
-
-    def test_require_shapes_for_parameter_shape(self):
-        # No shape is required if the parameter type is a rate
-        types = [ParameterType.rate_gauss, ParameterType.rate_uniform, ParameterType.rate_unconstrained]
-        for t in types:
-            with self.subTest(t=t):
-                param_obj = DotDict(
-                    type=t,
-                    transformations=ParameterTransformations([ParameterTransformation.effect_from_rate]),
-                    name="test_param",
-                )
-                result = InferenceModel.require_shapes_for_parameter(param_obj)
-                self.assertFalse(result)
-
-                # if the transformation is shape-based expect True
-                param_obj.transformations = ParameterTransformations([ParameterTransformation.effect_from_shape])
-                result = InferenceModel.require_shapes_for_parameter(param_obj)
-                self.assertTrue(result)
-
-        # No shape is required if the transformation is from a rate
-        param_obj = DotDict(
-            type=ParameterType.shape,
-            transformations=ParameterTransformations([ParameterTransformation.effect_from_rate]),
-            name="test_param",
-        )
-        result = InferenceModel.require_shapes_for_parameter(param_obj)
-        self.assertFalse(result)
-
-        param_obj.transformations = ParameterTransformations([ParameterTransformation.effect_from_shape])
-        result = InferenceModel.require_shapes_for_parameter(param_obj)
-        self.assertTrue(result)


### PR DESCRIPTION
This is a crucial PR that optimizes the way that cms datacards are written.

### Our workflow / situation

When writing datacards with all systematic shifts, a lot of `{Create,Merge}Histograms` tasks are processed, and the resulting n-D histogram of `MergeShiftedHistograms` is consequently large. In our workflow we perform a late binning optimization which requires us to use 2-5k bins on the variable axis.

However, with about 100 variations, all the categories, sub-processes due to stitching, etc., the required memory to load all outputs of `MergeShiftedHistograms` inside the `CreateDatacards` task is in the order of 20-30GB.

### The current issue

`CreateDatacards` is a workflow that produces each datacard category in a new branch, i.e., a separate task. In case of - say - 10 categories, the memory mentioned above is exactly 10 times as large as roughly the same in-memory data is needed. This is prohibitively large.

### The fix

This PR sequentializes the datacard creation again and also cleans up some smaller code issues that I encountered along the way. Now, in our typical ("worst") case, data loading takes about 3 minutes (overhead) with all possible information loaded into memory **once**, and each datacard takes another 15 seconds per category (3min + 10 * 15s = 5.5min). This is an acceptable ratio compared to the situation before which effectively forced us to run the workflow in sequence with a single worker anyways due to the overly large memory requirement (10 * (3min + 15s) = 32.5min).