### PR TITLE
Refactor datacard parameter transformations.

### DIFF
--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -179,10 +179,11 @@ class CreateDatacards(SerializeInferenceModelBase):
                         # create histograms per shape shift
                         for param_obj in proc_obj.parameters:
                             # skip the parameter when varied hists are not needed
-                            if (
-                                not param_obj.type.is_shape and
-                                not any(trafo.from_shape for trafo in param_obj.transformations)
-                            ):
+                            need_shapes = (
+                                (param_obj.type.is_shape and not param_obj.transformations.any_from_rate) or
+                                (param_obj.type.is_rate and param_obj.transformations.any_from_shape)
+                            )
+                            if not need_shapes:
                                 continue
                             # store the varied hists
                             shift_source = (

--- a/columnflow/tasks/framework/inference.py
+++ b/columnflow/tasks/framework/inference.py
@@ -164,7 +164,10 @@ class SerializeInferenceModelBase(
                         if config_inst.name not in param_obj.config_data:
                             continue
                         # only add if a shift is required for this parameter
-                        if param_obj.type.is_shape or any(trafo.from_shape for trafo in param_obj.transformations):
+                        if (
+                            (param_obj.type.is_shape and not param_obj.transformations.any_from_rate) or
+                            (param_obj.type.is_rate and param_obj.transformations.any_from_shape)
+                        ):
                             shift_source = param_obj.config_data[config_inst.name].shift_source
                             for mc_dataset in mc_datasets:
                                 data["mc_datasets"][mc_dataset]["shift_sources"].add(shift_source)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -106,7 +106,7 @@ class TestInferenceModel(unittest.TestCase):
         # Test data
         name = "test_parameter"
         type = ParameterType.rate_gauss
-        transformations = [ParameterTransformation.centralize, ParameterTransformation.symmetrize]
+        transformations = [ParameterTransformation.symmetrize]
         config_name = "test_config"
         config_shift_source = "test_shift_source"
         effect = 1.5


### PR DESCRIPTION
This PR refactors the parameter transformations for writing CMS datacards.

Besides a specific type (usually `shape`, `rate_gauss`, etc), a parameter can define a sequence of transformations that are applied in that order to alter the the effect on a specific process in a specific datacard category. With the changes in this PR, the transformations now are:

- `none`: No transformation.
- `effect_from_rate`: Creates shape variations for a shape-type parameter using the single- or two-valued effect usually attributed to rate-type parameters. Only applies to shape-type parameters.
- `effect_from_shape`: Derive the effect of a rate-type parameter using the overall, integral effect of shape variations. Only applies to rate-type parameters.
- `effect_from_shape_if_small`: Same as `effect_from_shape`, but depending on a threshold on the size of the effect which can be subject to the serialization routine. Only applies to rate-type parameters.
- `symmetrize`: The overall (integral) effect of up and down variations is measured and centralized, updating the variations such that they are equidistant to the nominal one. Can apply to both rate- and shape-type parameters.
- `asymmetrize`: The symmetric effect on a rate-type parameter (usually given as a single value) is converted into an asymmetric representation (using two values). Only applies to rate-type parameters.
- `asymmetrize_if_large`: Same as `asymmetrize`, but depending on a threshold on the size of the symmetric effect which can be subject to the serialization routine. Only applies to rate-type parameters.
- `normalize`: Variations of shape-type parameters are changed such that their integral effect identical to the nominal one. Should only apply to shape-type parameters.
- `envelope`: Builds an evelope of the up and down variations of a shape-type parameter, potentially on a bin-by-bin basis. Only applies to shape-type parameters.
- `envelope_if_one_sided`: Same as `envelope`, but only if the shape variations are one-sided following a definition that can be subject to the serialization routine. Only applies to shape-type parameters.
- `envelope_enforce_two_sided`: Same as `envelope`, but it enforces that the up (down) variation of the constructed envelope is always above (below) the nominal one. Only applies to shape-type parameters.

Several checks are now implemented that make sure that specific transformations can be applied in the given order and for the given type of the parameter. All transformations were tested on our bbtautau datacards.