### PR TITLE
Add parent_mode flag to create_category_combinations, add change tracking.

### DIFF
--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -755,7 +755,7 @@ def track_category_changes(config: od.Config, summary_path: str | None = None) -
             prev_names = set(prev)
             if (added_names := curr_names - prev_names):
                 msgs.append(f"added categories    : {', '.join(sorted(added_names))}")
-            if (removed_names := prev_names - prev_names):
+            if (removed_names := prev_names - curr_names):
                 msgs.append(f"removed categories  : {', '.join(sorted(removed_names))}")
             # track id changes for names present in both
             changed_ids = {

--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -630,9 +630,9 @@ def create_category_combinations(
         # build all group combinations
         for _group_names in itertools.combinations(group_names, _n_groups):
             # when creating parents in "safe" mode, skip combinations that miss unsafe groups
+            # (i.e. they must be part of _group_names to be used later)
             if parent_mode == "safe":
-                missing_groups = set(group_names) - set(_group_names)
-                if missing_groups & unsafe_groups:
+                if (set(group_names) - set(_group_names)) & unsafe_groups:
                     continue
 
             # build the product of all categories for the given groups

--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -680,26 +680,20 @@ def create_category_combinations(
                     # only connect to root categories
                     parent_gen = ((name,) for name in _group_names)
                 else:  # safe
-                    # same as "all", but drop safe groups and ensure the resulting combination is only used once
+                    # same as "all", but unsafe groups must be part of the combinations
                     def _parent_gen():
                         seen = set()
+                        # choose 1 group to sum over from _n_groups available
                         for names in itertools.combinations(_group_names, _n_groups - 1):
                             # as above, if there is at least one unsafe group missing, the parent was not created
                             if (set(_group_names) - set(names)) & unsafe_groups:
                                 continue
-                            # remove safe groups to only connect to unsafe ones that were created before
-                            names = tuple(name for name in names if name in unsafe_groups)
                             if names and names not in seen:
                                 seen.add(names)
-                                seen.update((name,) for name in names)
                                 yield names
-                        # in case no intermediate parent was selected, connect to the root categories
+                        # in case no parent combination was yielded, yield all root categories separately
                         if not seen:
-                            for name in _group_names:
-                                names = (name,)
-                                if names not in seen:
-                                    seen.add(names)
-                                    yield names
+                            yield from ((name,) for name in _group_names)
                     parent_gen = _parent_gen()
 
                 # actual connections

--- a/columnflow/types.py
+++ b/columnflow/types.py
@@ -23,7 +23,7 @@ from collections.abc import KeysView, ValuesView  # noqa
 from types import ModuleType, GeneratorType, GenericAlias  # noqa
 from typing import (  # noqa
     Any, Union, TypeVar, ClassVar, Sequence, Callable, Generator, TextIO, Iterable, Hashable,
-    Type,
+    Type, Literal,
 )
 
 from typing_extensions import Annotated, _AnnotatedAlias as AnnotatedType, TypeAlias  # noqa


### PR DESCRIPTION
This PR adds two changes to the category handling in our `config_util.py`.

- `create_category_combinations` got a new flag `parent_mode`.
  - `all` means that - as before - all intermediate layers of category combinations are created.
  - `none` means that only leaf categories are created and connected to the provided root categories.
  - `safe` is a variant of `all`, but it considers the `is_complete` and `has_overlap` (or `is_partition` in short) flags of the underlying `CategoryGroups` to infer whether a downstream summation over child categories (e.g. during plotting) could potentially cause double (multi) counting, or missing phase space in case of incompleteness (e.g. for `[eq1j, ge2j]` which would miss `eq0j`).
  - ❗️ `all` is the default now as it prevents undesired and yet unnoticed side-effects. It might break current category definitions in the form of `name <-> id` mappings, but we simply **cannot** default to the `all` implementation that bears the risk of silent double counting. If backwards compatibility is desired, setting `parent_mode="all"` is always an option.
- `track_category_changes` is a new utility function that, when called, checks whether there have been changes to category names or ids since the last invocation (using a summary / checkpoint file with a sensible default). This can also help to prevent a mismatch between category ids in the code base, and those serialized to files in columnar outputs.

@aalvesan 