### PR TITLE
Accelerate loading time and imports

### DIFF
--- a/columnflow/__version__.py
+++ b/columnflow/__version__.py
@@ -20,6 +20,7 @@ __credits__ = [
     "Tobias Kramer",
     "Matthias Schroeder",
     "Johannes Lange",
+    "Ana Andrade",
 ]
 __contact__ = "https://github.com/columnflow/columnflow"
 __license__ = "BSD-3-Clause"

--- a/columnflow/calibration/cms/jets.py
+++ b/columnflow/calibration/cms/jets.py
@@ -4,20 +4,24 @@
 Jet energy corrections and jet resolution smearing.
 """
 
+from __future__ import annotations
+
 import functools
 
 import law
 
-from columnflow.types import Any
 from columnflow.calibration import Calibrator, calibrator
 from columnflow.calibration.util import ak_random, propagate_met, sum_transverse
 from columnflow.production.util import attach_coffea_behavior
 from columnflow.util import UNSET, maybe_import, DotDict, load_correction_set
 from columnflow.columnar_util import set_ak_column, layout_ak_array, optional_column as optional
+from columnflow.types import TYPE_CHECKING, Any
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
-correctionlib = maybe_import("correctionlib")
+if TYPE_CHECKING:
+    correctionlib = maybe_import("correctionlib")
+
 
 logger = law.logger.get_logger(__name__)
 

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -32,13 +32,7 @@ from columnflow.util import (
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
-dak = maybe_import("dask_awkward")
 uproot = maybe_import("uproot")
-coffea = maybe_import("coffea")
-maybe_import("coffea.nanoevents")
-maybe_import("coffea.nanoevents.methods.base")
-maybe_import("coffea.nanoevents.methods.nanoaod")
-pq = maybe_import("pyarrow.parquet")
 
 
 # loggers
@@ -1237,6 +1231,8 @@ def attach_behavior(
     (*skip_fields*) can contain names or name patterns of fields that are kept (filtered).
     *keep_fields* has priority, i.e., when it is set, *skip_fields* is not considered.
     """
+    import coffea.nanoevents
+
     if behavior is None:
         behavior = getattr(ak_array, "behavior", None) or coffea.nanoevents.methods.nanoaod.behavior
         if behavior is None:
@@ -3076,6 +3072,7 @@ class DaskArrayReader(object):
                 open_options["split_row_groups"] = False
 
         # open the file
+        import dask_awkward as dak
         self.dak_array = dak.from_parquet(path, **open_options)
         self.path = path
 
@@ -3614,7 +3611,7 @@ class ChunkedIOHandler(object):
         chunk_pos: ChunkPosition,
         read_options: dict | None = None,
         read_columns: set[str | Route] | None = None,
-    ) -> coffea.nanoevents.methods.base.NanoEventsArray:
+    ) -> ak.Array:
         """
         Given a file location or opened uproot file, and a tree name in a 2-tuple *source_object*,
         returns an awkward array chunk referred to by *chunk_pos*, assuming nanoAOD structure.
@@ -3622,6 +3619,8 @@ class ChunkedIOHandler(object):
         *read_columns* are converted to strings and, if not already present, added as nested fields
         ``iteritems_options.filter_name`` to *read_options*.
         """
+        import coffea.nanoevents
+
         # default read options
         read_options = read_options or {}
         read_options["delayed"] = False
@@ -3669,6 +3668,8 @@ class ChunkedIOHandler(object):
         Given a parquet file located at *source*, returns a 2-tuple *(source, entries)*. Passing
         *open_options* or *read_columns* has no effect.
         """
+        import pyarrow.parquet as pq
+
         return (source, pq.ParquetFile(source).metadata.num_rows)
 
     @classmethod
@@ -3688,7 +3689,7 @@ class ChunkedIOHandler(object):
         chunk_pos: ChunkPosition,
         read_options: dict | None = None,
         read_columns: set[str | Route] | None = None,
-    ) -> coffea.nanoevents.methods.base.NanoEventsArray:
+    ) -> ak.Array:
         """
         Given a the location of a parquet file *source_object*, returns an awkward array chunk
         referred to by *chunk_pos*, assuming nanoAOD structure. *read_options* are passed to
@@ -3696,6 +3697,8 @@ class ChunkedIOHandler(object):
         strings and, if not already present, added as nested field
         ``parquet_options.read_dictionary`` to *read_options*.
         """
+        import coffea.nanoevents
+
         # default read options
         read_options = read_options or {}
         read_options["runtime_cache"] = None

--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1232,6 +1232,7 @@ def attach_behavior(
     *keep_fields* has priority, i.e., when it is set, *skip_fields* is not considered.
     """
     import coffea.nanoevents
+    import coffea.nanoevents.methods.nanoaod
 
     if behavior is None:
         behavior = getattr(ak_array, "behavior", None) or coffea.nanoevents.methods.nanoaod.behavior

--- a/columnflow/hist_util.py
+++ b/columnflow/hist_util.py
@@ -14,11 +14,12 @@ import order as od
 
 from columnflow.columnar_util import flat_np_view
 from columnflow.util import maybe_import
-from columnflow.types import Any
+from columnflow.types import TYPE_CHECKING, Any
 
-hist = maybe_import("hist")
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
 
 
 logger = law.logger.get_logger(__name__)
@@ -38,6 +39,8 @@ def fill_hist(
     determined automatically and depends on the variable axis type. In this case, shifting is applied to all continuous,
     non-circular axes.
     """
+    import hist
+
     if fill_kwargs is None:
         fill_kwargs = {}
 
@@ -163,6 +166,8 @@ def get_axis_kwargs(axis: hist.axis.AxesMixin) -> dict[str, Any]:
     :param axis: The axis instance to extract information from.
     :return: The extracted information in a dict.
     """
+    import hist
+
     axis_attrs = ["name", "label"]
     traits_attrs = []
     kwargs = {}
@@ -213,6 +218,8 @@ def create_hist_from_variables(
     weight: bool = True,
     storage: str | None = None,
 ) -> hist.Hist:
+    import hist
+
     histogram = hist.Hist.new
 
     # additional category axes
@@ -259,6 +266,8 @@ def translate_hist_intcat_to_strcat(
     axis_name: str,
     id_map: dict[int, str],
 ) -> hist.Hist:
+    import hist
+
     out_axes = [
         ax if ax.name != axis_name else hist.axis.StrCategory(
             [id_map[v] for v in list(ax)],
@@ -280,6 +289,8 @@ def add_missing_shifts(
     """
     Adds missing shift bins to a histogram *h*.
     """
+    import hist
+
     # get the set of bins that are missing in the histogram
     shift_bins = set(h.axes[str_axis])
     missing_shifts = set(expected_shifts_bins) - shift_bins

--- a/columnflow/histogramming/__init__.py
+++ b/columnflow/histogramming/__init__.py
@@ -11,13 +11,12 @@ import inspect
 import law
 import order as od
 
-from columnflow.types import Callable
-from columnflow.util import DerivableMeta, maybe_import
 from columnflow.columnar_util import TaskArrayFunction
-from columnflow.types import Any
+from columnflow.util import DerivableMeta, maybe_import
+from columnflow.types import TYPE_CHECKING, Any, Callable
 
-
-hist = maybe_import("hist")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
 
 
 class HistProducer(TaskArrayFunction):
@@ -247,7 +246,7 @@ class HistProducer(TaskArrayFunction):
             return h
         return self.post_process_hist_func(h, task=task)
 
-    def run_post_process_merged_hist(self, h: Any, task: law.Task) -> hist.Histogram:
+    def run_post_process_merged_hist(self, h: Any, task: law.Task) -> hist.Hist:
         """
         Invokes the :py:meth:`post_process_merged_hist_func` of this instance and returns its result, forwarding all
         arguments.

--- a/columnflow/histogramming/default.py
+++ b/columnflow/histogramming/default.py
@@ -10,14 +10,15 @@ import law
 import order as od
 
 from columnflow.histogramming import HistProducer, hist_producer
-from columnflow.util import maybe_import
-from columnflow.hist_util import create_hist_from_variables, fill_hist, translate_hist_intcat_to_strcat
 from columnflow.columnar_util import has_ak_column, Route
-from columnflow.types import Any
+from columnflow.hist_util import create_hist_from_variables, fill_hist, translate_hist_intcat_to_strcat
+from columnflow.util import maybe_import
+from columnflow.types import TYPE_CHECKING, Any
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
-hist = maybe_import("hist")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
 
 
 @hist_producer()
@@ -39,7 +40,7 @@ def cf_default_create_hist(
     variables: list[od.Variable],
     task: law.Task,
     **kwargs,
-) -> hist.Histogram:
+) -> hist.Hist:
     """
     Define the histogram structure for the default histogram producer.
     """
@@ -55,7 +56,7 @@ def cf_default_create_hist(
 
 
 @cf_default.fill_hist
-def cf_default_fill_hist(self: HistProducer, h: hist.Histogram, data: dict[str, Any], task: law.Task) -> None:
+def cf_default_fill_hist(self: HistProducer, h: hist.Hist, data: dict[str, Any], task: law.Task) -> None:
     """
     Fill the histogram with the data.
     """
@@ -63,7 +64,7 @@ def cf_default_fill_hist(self: HistProducer, h: hist.Histogram, data: dict[str, 
 
 
 @cf_default.post_process_hist
-def cf_default_post_process_hist(self: HistProducer, h: hist.Histogram, task: law.Task) -> hist.Histogram:
+def cf_default_post_process_hist(self: HistProducer, h: hist.Hist, task: law.Task) -> hist.Hist:
     """
     Post-process the histogram, converting integer to string axis for consistent lookup across configs where ids might
     be different.

--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -19,8 +19,8 @@ from columnflow.util import (
     freeze,
 )
 
-logger = law.logger.get_logger(__name__)
 
+logger = law.logger.get_logger(__name__)
 
 default_dataset = law.config.get_expanded("analysis", "default_dataset")
 

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -14,18 +14,19 @@ import law
 from columnflow import __version__ as cf_version
 from columnflow.inference import InferenceModel, ParameterType, ParameterTransformation, FlowStrategy
 from columnflow.util import DotDict, maybe_import, real_path, ensure_dir, safe_div, maybe_int
-from columnflow.types import Sequence, Any, Union, Hashable
+from columnflow.types import TYPE_CHECKING, Sequence, Any, Union, Hashable
 
-hist = maybe_import("hist")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
+
+    # type aliases for nested histogram structs
+    ShiftHists = dict[Union[str, tuple[str, str]], hist.Hist]  # "nominal" or (param_name, "up|down") -> hists
+    ConfigHists = dict[str, ShiftHists]  # config name -> hists
+    ProcHists = dict[str, ConfigHists]  # process name -> hists
+    DatacardHists = dict[str, ProcHists]  # category name -> hists
 
 
 logger = law.logger.get_logger(__name__)
-
-# type aliases for nested histogram structs
-ShiftHists = dict[Union[str, tuple[str, str]], hist.Hist]  # "nominal" or (param_name, "up|down") -> hists
-ConfigHists = dict[str, ShiftHists]  # config name -> hists
-ProcHists = dict[str, ConfigHists]  # process name -> hists
-DatacardHists = dict[str, ProcHists]  # category name -> hists
 
 
 class DatacardWriter(object):

--- a/columnflow/ml/__init__.py
+++ b/columnflow/ml/__init__.py
@@ -12,11 +12,12 @@ from collections import OrderedDict
 import law
 import order as od
 
-from columnflow.types import Any, Sequence
-from columnflow.util import maybe_import, Derivable, DotDict, KeyValueMessage
 from columnflow.columnar_util import Route
+from columnflow.util import maybe_import, Derivable, DotDict, KeyValueMessage
+from columnflow.types import TYPE_CHECKING, Any, Sequence
 
-ak = maybe_import("awkward")
+if TYPE_CHECKING:
+    ak = maybe_import("awkward")
 
 
 class MLModel(Derivable):

--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -10,7 +10,6 @@ __all__ = []
 
 import order as od
 
-from columnflow.types import Sequence
 from columnflow.util import maybe_import, try_float
 from columnflow.config_util import group_shifts
 from columnflow.plotting.plot_util import (
@@ -21,12 +20,12 @@ from columnflow.plotting.plot_util import (
     apply_label_placeholders,
     calculate_stat_error,
 )
+from columnflow.types import TYPE_CHECKING, Sequence
 
-hist = maybe_import("hist")
 np = maybe_import("numpy")
-mpl = maybe_import("matplotlib")
-plt = maybe_import("matplotlib.pyplot")
-mplhep = maybe_import("mplhep")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
+    plt = maybe_import("matplotlib.pyplot")
 
 
 def draw_stat_error_bands(
@@ -71,6 +70,8 @@ def draw_syst_error_bands(
     method: str = "quadratic_sum",
     **kwargs,
 ) -> None:
+    import hist
+
     assert len(h.axes) == 1
     assert method in ("quadratic_sum", "envelope")
 
@@ -169,6 +170,8 @@ def draw_stack(
     norm: float | Sequence | np.ndarray = 1.0,
     **kwargs,
 ) -> None:
+    import hist
+
     # check if norm is a number
     if try_float(norm):
         h = hist.Stack(*[i / norm for i in h])
@@ -202,6 +205,8 @@ def draw_hist(
     error_type: str = "variance",
     **kwargs,
 ) -> None:
+    import hist
+
     assert error_type in {"variance", "poisson_unweighted", "poisson_weighted"}
 
     if kwargs.get("color", "") is None:
@@ -243,6 +248,8 @@ def draw_profile(
     """
     Profiled histograms contains the storage type "Mean" and can therefore not be normalized
     """
+    import hist
+
     assert error_type in {"variance", "poisson_unweighted", "poisson_weighted"}
 
     if kwargs.get("color", "") is None:
@@ -272,6 +279,8 @@ def draw_errorbars(
     error_type: str = "poisson_unweighted",
     **kwargs,
 ) -> None:
+    import hist
+
     assert error_type in {"variance", "poisson_unweighted", "poisson_weighted"}
 
     values = h.values() / norm
@@ -342,6 +351,10 @@ def plot_all(
     :param magnitudes: Optional float parameter that defines the displayed ymin when plotting with a logarithmic scale.
     :return: tuple of plot figure and axes
     """
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    import mplhep
+
     # general mplhep style
     plt.style.use(mplhep.style.CMS)
 

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -11,8 +11,8 @@ __all__ = []
 from collections import OrderedDict
 
 import law
+import order as od
 
-from columnflow.types import Iterable
 from columnflow.util import maybe_import
 from columnflow.plotting.plot_all import plot_all
 from columnflow.plotting.plot_util import (
@@ -31,14 +31,12 @@ from columnflow.plotting.plot_util import (
     join_labels,
 )
 from columnflow.hist_util import add_missing_shifts
+from columnflow.types import TYPE_CHECKING, Iterable
 
-
-hist = maybe_import("hist")
 np = maybe_import("numpy")
-mpl = maybe_import("matplotlib")
-plt = maybe_import("matplotlib.pyplot")
-mplhep = maybe_import("mplhep")
-od = maybe_import("order")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
+    plt = maybe_import("matplotlib.pyplot")
 
 
 def plot_variable_stack(
@@ -249,6 +247,8 @@ def plot_shifted_variable(
     """
     TODO.
     """
+    import hist
+
     variable_inst = variable_insts[0]
 
     hists, process_style_config = apply_process_settings(hists, process_settings)
@@ -451,6 +451,8 @@ def plot_profile(
     :param base_distribution_yscale: yscale of the base distributions
     :param skip_variations: whether to skip adding the up and down variation of the profile plot
     """
+    import matplotlib.pyplot as plt
+
     if len(variable_insts) != 2:
         raise Exception("The plot_profile function can only be used for 2-dimensional input histograms.")
 

--- a/columnflow/plotting/plot_functions_2d.py
+++ b/columnflow/plotting/plot_functions_2d.py
@@ -6,11 +6,14 @@ Example 2d plot functions.
 
 from __future__ import annotations
 
+__all__ = []
+
 from collections import OrderedDict
 from functools import partial
 from unittest.mock import patch
 
 import law
+import order as od
 
 from columnflow.util import maybe_import
 from columnflow.plotting.plot_util import (
@@ -22,14 +25,11 @@ from columnflow.plotting.plot_util import (
     get_position,
     reduce_with,
 )
+from columnflow.types import TYPE_CHECKING
 
-hist = maybe_import("hist")
 np = maybe_import("numpy")
-mpl = maybe_import("matplotlib")
-plt = maybe_import("matplotlib.pyplot")
-mplhep = maybe_import("mplhep")
-od = maybe_import("order")
-mticker = maybe_import("matplotlib.ticker")
+if TYPE_CHECKING:
+    plt = maybe_import("matplotlib.pyplot")
 
 
 def plot_2d(
@@ -55,6 +55,10 @@ def plot_2d(
     variable_settings: dict | None = None,
     **kwargs,
 ) -> plt.Figure:
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    import mplhep
+
     # remove shift axis from histograms
     hists = remove_residual_axis(hists, "shift")
 
@@ -273,10 +277,10 @@ def plot_2d(
             _scale = cbar.ax.yaxis._scale
             _scale.subs = [2, 3, 4, 5, 6, 7, 8, 9]
             cbar.ax.yaxis.set_minor_locator(
-                mticker.SymmetricalLogLocator(_scale.get_transform(), subs=_scale.subs),
+                mpl.ticker.SymmetricalLogLocator(_scale.get_transform(), subs=_scale.subs),
             )
             cbar.ax.yaxis.set_minor_formatter(
-                mticker.LogFormatterSciNotation(_scale.base),
+                mpl.ticker.LogFormatterSciNotation(_scale.base),
             )
 
     plt.tight_layout()

--- a/columnflow/plotting/plot_ml_evaluation.py
+++ b/columnflow/plotting/plot_ml_evaluation.py
@@ -6,42 +6,45 @@ Useful plot functions for ML Evaluation
 
 from __future__ import annotations
 
+__all__ = []
+
 import re
 
-from columnflow.types import Sequence
+import order as od
+import scinum
+
 from columnflow.util import maybe_import
 from columnflow.plotting.plot_util import get_cms_label
+from columnflow.types import TYPE_CHECKING, Sequence
 
-ak = maybe_import("awkward")
-od = maybe_import("order")
 np = maybe_import("numpy")
-sci = maybe_import("scinum")
-plt = maybe_import("matplotlib.pyplot")
-hep = maybe_import("mplhep")
-colors = maybe_import("matplotlib.colors")
+ak = maybe_import("awkward")
+if TYPE_CHECKING:
+    plt = maybe_import("matplotlib.pyplot")
+
 
 # define a CF custom color maps
 cf_colors = {
-    "cf_green_cmap": colors.ListedColormap([
+    "cf_green_cmap": [
         "#212121", "#242723", "#262D25", "#283426", "#2A3A26", "#2C4227", "#2E4927",
         "#305126", "#325A25", "#356224", "#386B22", "#3B7520", "#3F7F1E", "#43891B",
         "#479418", "#4C9F14", "#52AA10", "#58B60C", "#5FC207", "#67cf02",
-    ]),
-    "cf_ygb_cmap": colors.ListedColormap([
+    ],
+    "cf_ygb_cmap": [
         "#003675", "#005B83", "#008490", "#009A83", "#00A368", "#00AC49", "#00B428",
         "#00BC06", "#0CC300", "#39C900", "#67cf02", "#72DB02", "#7EE605", "#8DF207",
         "#9CFD09", "#AEFF0B", "#C1FF0E", "#D5FF10", "#EBFF12", "#FFFF14",
-    ]),
-    "cf_cmap": colors.ListedColormap([
+    ],
+    "cf_cmap": [
         "#002C9C", "#00419F", "#0056A2", "#006BA4", "#0081A7", "#0098AA", "#00ADAB",
         "#00B099", "#00B287", "#00B574", "#00B860", "#00BB4C", "#00BD38", "#00C023",
         "#00C20D", "#06C500", "#1EC800", "#36CA00", "#4ECD01", "#67cf02",
-    ]),
-    "viridis": colors.ListedColormap([
+    ],
+    "viridis": [
         "#263DA8", "#1652CC", "#1063DB", "#1171D8", "#1380D5", "#0E8ED0", "#089DCC",
         "#0DA7C2", "#1DAFB3", "#2DB7A3", "#52BA91", "#73BD80", "#94BE71", "#B2BC65",
         "#D0BA59", "#E1BF4A", "#F4C53A", "#FCD12B", "#FAE61C", "#F9F90E",
-    ]),
+    ],
 }
 
 
@@ -111,6 +114,10 @@ def plot_cm(
         is not *None* and its shape doesn't match *predictions*.
     :raises AssertionError: If *normalization* is not one of *None*, "row", "column".
     """
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    import mplhep
+
     # defining some useful properties and output shapes
     true_labels = list(events.keys())
     pred_labels = [s.removeprefix("score_") for s in list(events.values())[0].fields]
@@ -136,7 +143,7 @@ def plot_cm(
                 counts[ind, index] += count
 
         if not skip_uncertainties:
-            vecNumber = np.vectorize(lambda n, count: sci.Number(n, float(n / np.sqrt(count) if count else 0)))
+            vecNumber = np.vectorize(lambda n, count: scinum.Number(n, float(n / np.sqrt(count) if count else 0)))
             result = vecNumber(result, counts)
 
         # normalize Matrix if needed
@@ -203,7 +210,7 @@ def plot_cm(
             Useful for seperating the error from the data
             """
             if matrix.dtype.name == "object":
-                get_errors_vec = np.vectorize(lambda x: x.get(sci.UP, unc=True))
+                get_errors_vec = np.vectorize(lambda x: x.get(scinum.UP, unc=True))
                 return get_errors_vec(matrix)
             return np.zeros_like(matrix)
 
@@ -219,13 +226,13 @@ def plot_cm(
             return "{}\n\u00B1{}".format(fmt(values[i][j]), fmt(np.nan_to_num(uncs[i][j])))
 
         # create the plot
-        plt.style.use(hep.style.CMS)
+        plt.style.use(mplhep.style.CMS)
         fig, ax = plt.subplots(dpi=300)
 
         # some useful variables and functions
         n_processes = cm.shape[0]
         n_classes = cm.shape[1]
-        cmap = cf_colors.get(colormap, cf_colors["cf_cmap"])
+        cmap = mpl.colors.ListedColormap(cf_colors.get(colormap, cf_colors["cf_cmap"]))
         x_labels = x_labels if x_labels else [f"out{i}" for i in range(n_classes)]
         y_labels = y_labels if y_labels else true_labels
         font_ax = 20
@@ -292,7 +299,7 @@ def plot_cm(
         if cms_llabel != "skip":
             cms_label_kwargs = get_cms_label(ax=ax, llabel=cms_llabel)
             cms_label_kwargs["rlabel"] = cms_rlabel
-            hep.cms.label(**cms_label_kwargs)
+            mplhep.cms.label(**cms_label_kwargs)
         plt.tight_layout()
 
         return fig
@@ -349,6 +356,8 @@ def plot_roc(
         is not *None* and its shape doesn't match *predictions*.
     :raises ValueError: If *normalization* is not one of *None*, 'row', 'column'.
     """
+    import mplhep
+
     # defining some useful properties and output shapes
     thresholds = np.linspace(0, 1, n_thresholds)
     weights = create_sample_weights(sample_weights, events, list(events.keys()))
@@ -478,7 +487,7 @@ def plot_roc(
         fpr = roc_data["fpr"]
         tpr = roc_data["tpr"]
 
-        plt.style.use(hep.style.CMS)
+        plt.style.use(mplhep.style.CMS)
         fig, ax = plt.subplots(dpi=300)
         ax.set_xlabel("FPR", loc="right", labelpad=10, fontsize=25)
         ax.set_ylabel("TPR", loc="top", labelpad=15, fontsize=25)
@@ -499,7 +508,7 @@ def plot_roc(
         if cms_llabel != "skip":
             cms_label_kwargs = get_cms_label(ax=ax, llabel=cms_llabel)
             cms_label_kwargs["rlabel"] = cms_rlabel
-            hep.cms.label(**cms_label_kwargs)
+            mplhep.cms.label(**cms_label_kwargs)
         plt.tight_layout()
 
         return fig

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 __all__ = []
 
 import re
+import math
 import operator
 import functools
 from collections import OrderedDict
@@ -19,13 +20,12 @@ import scinum as sn
 
 from columnflow.util import maybe_import, try_int, try_complex, UNSET
 from columnflow.hist_util import copy_axis
-from columnflow.types import Iterable, Any, Callable, Sequence, Hashable
+from columnflow.types import TYPE_CHECKING, Iterable, Any, Callable, Sequence, Hashable
 
-math = maybe_import("math")
-hist = maybe_import("hist")
 np = maybe_import("numpy")
-plt = maybe_import("matplotlib.pyplot")
-mplhep = maybe_import("mplhep")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
+    plt = maybe_import("matplotlib.pyplot")
 
 
 logger = law.logger.get_logger(__name__)
@@ -255,6 +255,8 @@ def apply_variable_settings(
     applies settings from *variable_settings* dictionary to the *variable_insts*;
     the *rebin*, *overflow*, *underflow*, and *slice* settings are directly applied to the histograms
     """
+    import hist
+
     # store info gathered along application of variable settings that can be inserted to the style config
     variable_style_config = {}
 
@@ -382,12 +384,12 @@ def apply_density(hists: dict, density: bool = True) -> dict:
     if not density:
         return hists
 
-    for key, hist in hists.items():
+    for key, h in hists.items():
         # bin area safe for multi-dimensional histograms
-        area = functools.reduce(operator.mul, hist.axes.widths)
+        area = functools.reduce(operator.mul, h.axes.widths)
 
         # scale hist by bin area
-        hists[key] = hist / area
+        hists[key] = h / area
 
     return hists
 
@@ -398,6 +400,8 @@ def remove_residual_axis_single(
     max_bins: int = 1,
     select_value: Any = None,
 ) -> hist.Hist:
+    import hist
+
     # force always returning a copy
     h = h.copy()
 
@@ -510,6 +514,8 @@ def prepare_stack_plot_config(
     backgrounds with uncertainty bands, unstacked processes as lines and
     data entrys with errorbars.
     """
+    import hist
+
     # separate histograms into stack, lines and data hists
     mc_hists, mc_colors, mc_edgecolors, mc_labels = [], [], [], []
     mc_syst_hists = []
@@ -943,6 +949,8 @@ def rebin_equal_width(
     :param axis_name: Name of the axis to rebin.
     :return: Tuple of the rebinned histograms and the new bin edges.
     """
+    import hist
+
     # get the variable axis from the first histogram
     assert hists
     for var_index, var_axis in enumerate(list(hists.values())[0].axes):
@@ -1049,6 +1057,7 @@ def calculate_stat_error(
         - 'poisson_unweighted': the plotted error is the poisson error for each bin
         - 'poisson_weighted': the plotted error is the poisson error for each bin, weighted by the variance
     """
+    import hist
 
     # determine the error type
     if error_type == "variance":

--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -18,6 +18,7 @@ from columnflow.types import Any
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
 
+
 logger = law.logger.get_logger(__name__)
 
 

--- a/columnflow/production/cms/dy.py
+++ b/columnflow/production/cms/dy.py
@@ -16,7 +16,7 @@ from columnflow.columnar_util import set_ak_column
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
-vector = maybe_import("vector")
+
 
 logger = law.logger.get_logger(__name__)
 
@@ -301,6 +301,8 @@ def recoil_corrected_met(self: Producer, events: ak.Array, **kwargs) -> ak.Array
 
     *get_dy_recoil_config* can be adapted in a subclass in case it is stored differently in the config.
     """
+    import vector
+
     # steps:
     # 1) Build transverse vectors for MET and the generator-level boson (full and visible).
     # 2) Compute the recoil vector U = MET + vis - full in the transverse plane.

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -486,7 +486,7 @@ def normalization_weights_setup(
         )
 
     # setup the event weight lookup table
-    process_weight_table = scipy.sparse.sparse.lil_matrix((max(process_ids) + 1, 1), dtype=np.float32)
+    process_weight_table = scipy.sparse.lil_matrix((max(process_ids) + 1, 1), dtype=np.float32)
 
     def fill_weight_table(process_inst: od.Process, xsec: float, sum_weights: float) -> None:
         if sum_weights == 0:

--- a/columnflow/production/normalization.py
+++ b/columnflow/production/normalization.py
@@ -21,8 +21,6 @@ from columnflow.columnar_util import set_ak_column
 from columnflow.types import Any, Sequence
 
 np = maybe_import("numpy")
-sp = maybe_import("scipy")
-maybe_import("scipy.sparse")
 ak = maybe_import("awkward")
 
 
@@ -413,6 +411,8 @@ def normalization_weights_setup(
             weights per process.
         - py: attr: `known_process_ids`: A set of all process ids that are known by the lookup table.
     """
+    import scipy.sparse
+
     # load the selection stats
     dataset_selection_stats = {
         dataset: copy.deepcopy(task.cached_value(
@@ -486,7 +486,7 @@ def normalization_weights_setup(
         )
 
     # setup the event weight lookup table
-    process_weight_table = sp.sparse.lil_matrix((max(process_ids) + 1, 1), dtype=np.float32)
+    process_weight_table = scipy.sparse.sparse.lil_matrix((max(process_ids) + 1, 1), dtype=np.float32)
 
     def fill_weight_table(process_inst: od.Process, xsec: float, sum_weights: float) -> None:
         if sum_weights == 0:

--- a/columnflow/production/util.py
+++ b/columnflow/production/util.py
@@ -3,9 +3,10 @@
 """
 General producers that might be utilized in various places.
 """
+
 from __future__ import annotations
 
-from functools import partial
+import functools
 
 from columnflow.types import Iterable, Sequence, Union
 from columnflow.production import Producer, producer
@@ -13,7 +14,6 @@ from columnflow.util import maybe_import
 from columnflow.columnar_util import attach_coffea_behavior as attach_coffea_behavior_fn
 
 ak = maybe_import("awkward")
-coffea = maybe_import("coffea")
 
 
 @producer(call_force=True)
@@ -69,15 +69,20 @@ def ak_extract_fields(arr: ak.Array, fields: list[str], **kwargs):
 # functions for operating on lorentz vectors
 #
 
-_lv_base = partial(ak_extract_fields, behavior=coffea.nanoevents.methods.nanoaod.behavior)
+def _lv_base(*args, **kwargs):
+    # scoped partial to defer coffea import
+    import coffea.nanoevents
+    kwargs["behavior"] = coffea.nanoevents.methods.nanoaod.behavior
+    return ak_extract_fields(*args, **kwargs)
 
-lv_xyzt = partial(_lv_base, fields=["x", "y", "z", "t"], with_name="LorentzVector")
+
+lv_xyzt = functools.partial(_lv_base, fields=["x", "y", "z", "t"], with_name="LorentzVector")
 lv_xyzt.__doc__ = """Construct a `LorentzVectorArray` from an input array."""
 
-lv_mass = partial(_lv_base, fields=["pt", "eta", "phi", "mass"], with_name="PtEtaPhiMLorentzVector")
+lv_mass = functools.partial(_lv_base, fields=["pt", "eta", "phi", "mass"], with_name="PtEtaPhiMLorentzVector")
 lv_mass.__doc__ = """Construct a `PtEtaPhiMLorentzVectorArray` from an input array."""
 
-lv_energy = partial(_lv_base, fields=["pt", "eta", "phi", "energy"], with_name="PtEtaPhiELorentzVector")
+lv_energy = functools.partial(_lv_base, fields=["pt", "eta", "phi", "energy"], with_name="PtEtaPhiELorentzVector")
 lv_energy.__doc__ = """Construct a `PtEtaPhiELorentzVectorArray` from an input array."""
 
 

--- a/columnflow/selection/cms/json_filter.py
+++ b/columnflow/selection/cms/json_filter.py
@@ -122,7 +122,6 @@ def json_filter_setup(
     :param inputs: Additional inputs, currently not used
     :param reader_targets: Additional targets, currently not used
     """
-    import scipy as sp
     import scipy.sparse
 
     bundle = reqs["external_files"]
@@ -135,7 +134,7 @@ def json_filter_setup(
     max_run = max(map(int, json.keys()))
 
     # build lookup table
-    self.run_ls_lookup = sp.sparse.lil_matrix((max_run + 1, max_ls + 1), dtype=bool)
+    self.run_ls_lookup = scipy.sparse.lil_matrix((max_run + 1, max_ls + 1), dtype=bool)
     for run, ls_ranges in json.items():
         run = int(run)
         for ls_range in ls_ranges:

--- a/columnflow/selection/cms/json_filter.py
+++ b/columnflow/selection/cms/json_filter.py
@@ -14,8 +14,6 @@ from columnflow.types import Any
 
 ak = maybe_import("awkward")
 np = maybe_import("numpy")
-sp = maybe_import("scipy")
-maybe_import("scipy.sparse")
 
 
 def get_lumi_file_default(self, external_files: DotDict) -> str:
@@ -124,6 +122,9 @@ def json_filter_setup(
     :param inputs: Additional inputs, currently not used
     :param reader_targets: Additional targets, currently not used
     """
+    import scipy as sp
+    import scipy.sparse
+
     bundle = reqs["external_files"]
 
     # import the correction sets from the external file

--- a/columnflow/tasks/cms/inference.py
+++ b/columnflow/tasks/cms/inference.py
@@ -14,8 +14,11 @@ import order as od
 from columnflow.tasks.framework.base import AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.inference import SerializeInferenceModelBase
 from columnflow.tasks.histograms import MergeHistograms
+from columnflow.inference.cms.datacard import DatacardWriter
+from columnflow.types import TYPE_CHECKING
 
-from columnflow.inference.cms.datacard import DatacardHists, ShiftHists, DatacardWriter
+if TYPE_CHECKING:
+    from columnflow.inference.cms.datacard import DatacardHists, ShiftHists
 
 
 class CreateDatacards(SerializeInferenceModelBase):

--- a/columnflow/tasks/framework/histograms.py
+++ b/columnflow/tasks/framework/histograms.py
@@ -16,8 +16,10 @@ from columnflow.tasks.framework.mixins import (
 )
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
 from columnflow.util import dev_sandbox, maybe_import
+from columnflow.types import TYPE_CHECKING
 
-hist = maybe_import("hist")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
 
 
 class HistogramsUserBase(

--- a/columnflow/tasks/framework/inference.py
+++ b/columnflow/tasks/framework/inference.py
@@ -18,10 +18,12 @@ from columnflow.tasks.framework.mixins import (
 )
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeShiftedHistograms
-from columnflow.util import dev_sandbox, DotDict, maybe_import
 from columnflow.config_util import get_datasets_from_process
+from columnflow.util import dev_sandbox, DotDict, maybe_import
+from columnflow.types import TYPE_CHECKING
 
-hist = maybe_import("hist")
+if TYPE_CHECKING:
+    hist = maybe_import("hist")
 
 
 class SerializeInferenceModelBase(
@@ -235,6 +237,8 @@ class SerializeInferenceModelBase(
         variable: str,
         inputs: dict,
     ) -> dict[str, dict[od.Process, hist.Hist]]:
+        import hist
+
         # collect histograms per variable and process
         hists: dict[od.Process, hist.Hist] = {}
 

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -35,7 +35,6 @@ from columnflow.tasks.production import ProduceColumns
 from columnflow.util import dev_sandbox, safe_div, DotDict, maybe_import
 from columnflow.columnar_util import set_ak_column
 
-
 ak = maybe_import("awkward")
 
 

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -21,7 +21,6 @@ from columnflow.tasks.calibration import CalibrateEvents
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox, safe_div, DotDict
 from columnflow.tasks.framework.parameters import DerivableInstParameter
 
-
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
 

--- a/columnflow/types.py
+++ b/columnflow/types.py
@@ -22,8 +22,8 @@ NOTE: you are running a python interpreter inside the columnflow source director
 from collections.abc import KeysView, ValuesView  # noqa
 from types import ModuleType, GeneratorType, GenericAlias  # noqa
 from typing import (  # noqa
-    Any, Union, TypeVar, ClassVar, Sequence, Callable, Generator, TextIO, Iterable, Hashable,
-    Type,
+    TYPE_CHECKING, Any, Union, TypeVar, ClassVar, Sequence, Callable, Generator, TextIO, Iterable, Hashable, Type,
+    Literal,
 )
 
 from typing_extensions import Annotated, _AnnotatedAlias as AnnotatedType, TypeAlias  # noqa

--- a/setup.sh
+++ b/setup.sh
@@ -760,6 +760,8 @@ cf_setup_post_install() {
     # Optional environment variables:
     #   CF_SKIP_SETUP_GIT_HOOKS
     #       When set to true, the setup of git hooks is skipped.
+    #   CF_SKIP_LAW_INDEX
+    #       When set to true, the initial indexing of law tasks is skipped.
     #   CF_SKIP_CHECK_TMP_DIR
     #       When set to true, the check of the size of the target tmp directory is skipped.
 
@@ -788,7 +790,9 @@ cf_setup_post_install() {
             complete -o bashdefault -o default -F _law_complete claw
 
             # silently index
-            law index -q
+            if ! ${CF_SKIP_LAW_INDEX}; then
+                law index -q
+            fi
         fi
     fi
 
@@ -1113,6 +1117,7 @@ for flag_name in \
         CF_REINSTALL_HOOKS \
         CF_SKIP_BANNER \
         CF_SKIP_SETUP_GIT_HOOKS \
+        CF_SKIP_LAW_INDEX \
         CF_SKIP_CHECK_TMP_DIR \
         CF_ON_HTCONDOR \
         CF_ON_SLURM \


### PR DESCRIPTION
I noticed that importing columnflow these days can take quite a while (granted, our go-to filesystem is known to be slow at times), and after some quick debugging I found that a significant part is spent importing large dependencies in the *global scope*. Especially `matplotlib`, `hist`, and `coffea.nanoevents` are quite heavy.

- In most cases, the imports are made only for type hinting, so I made use of the `typing.TYPE_CHECKING` flag to move these imports out of the global scope.
- In other cases, I moved the imports into the functions that actually need them.
- `numpy` and `awkward` are used extensively for type hinting as well as actual implementations. However, they are surprisingly fast to import, so I left them in the global scope. **We should agree to and make sure that these two are the only 3rd party dependencies that we allow in the global scope.**

In total, I found that these changes reduce the import lag to about half.