### PR TITLE
Add and use sum_hists helper.

### DIFF
--- a/columnflow/hist_util.py
+++ b/columnflow/hist_util.py
@@ -14,7 +14,7 @@ import order as od
 
 from columnflow.columnar_util import flat_np_view
 from columnflow.util import maybe_import
-from columnflow.types import TYPE_CHECKING, Any
+from columnflow.types import TYPE_CHECKING, Any, Sequence
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -306,3 +306,37 @@ def add_missing_shifts(
             h.fill(*dummy_fill, weight=0)
             # TODO: this might skip overflow and underflow bins
             h[{str_axis: hist.loc(missing_shift)}] = nominal.view()
+
+
+def sum_hists(hists: Sequence[hist.Hist]) -> hist.Hist:
+    """
+    Sums a sequence of histograms into a new histogram. In case axis labels differ, which typically leads to errors
+    ("axes not mergable"), the labels of the first histogram are used.
+
+    :param hists: The histograms to sum.
+    :return: The summed histogram.
+    """
+    hists = list(hists)
+    if not hists:
+        raise ValueError("no histograms given for summation")
+
+    # copy the first histogram
+    h_sum = hists[0].copy()
+    if len(hists) == 1:
+        return h_sum
+
+    # store labels of first histogram
+    axis_labels = {ax.name: ax.label for ax in h_sum.axes}
+
+    for h in hists[1:]:
+        # align axis labels if needed, only copy if necessary
+        h_aligned_labels = None
+        for ax in h.axes:
+            if ax.name not in axis_labels or ax.label == axis_labels[ax.name]:
+                continue
+            if h_aligned_labels is None:
+                h_aligned_labels = h.copy()
+            h_aligned_labels.axes[ax.name].label = axis_labels[ax.name]
+        h_sum = h_sum + (h if h_aligned_labels is None else h_aligned_labels)
+
+    return h_sum

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -30,7 +30,7 @@ from columnflow.plotting.plot_util import (
     remove_negative_contributions,
     join_labels,
 )
-from columnflow.hist_util import add_missing_shifts
+from columnflow.hist_util import add_missing_shifts, sum_hists
 from columnflow.types import TYPE_CHECKING, Iterable
 
 np = maybe_import("numpy")
@@ -265,7 +265,7 @@ def plot_shifted_variable(
         add_missing_shifts(h, all_shifts, str_axis="shift", nominal_bin="nominal")
 
     # create the sum of histograms over all processes
-    h_sum = sum(list(hists.values())[1:], list(hists.values())[0].copy())
+    h_sum = sum_hists(hists.values())
 
     # setup plotting configs
     plot_config = {}

--- a/columnflow/plotting/plot_functions_2d.py
+++ b/columnflow/plotting/plot_functions_2d.py
@@ -16,6 +16,7 @@ import law
 import order as od
 
 from columnflow.util import maybe_import
+from columnflow.hist_util import sum_hists
 from columnflow.plotting.plot_util import (
     remove_residual_axis,
     apply_variable_settings,
@@ -81,7 +82,7 @@ def plot_2d(
         extremes = "color"
 
     # add all processes into 1 histogram
-    h_sum = sum(list(hists.values())[1:], list(hists.values())[0].copy())
+    h_sum = sum_hists(hists.values())
     if shape_norm:
         h_sum = h_sum / h_sum.sum().value
 

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -19,7 +19,7 @@ import order as od
 import scinum as sn
 
 from columnflow.util import maybe_import, try_int, try_complex, safe_div, UNSET
-from columnflow.hist_util import copy_axis
+from columnflow.hist_util import copy_axis, sum_hists
 from columnflow.types import TYPE_CHECKING, Iterable, Any, Callable, Sequence, Hashable
 
 np = maybe_import("numpy")
@@ -548,9 +548,9 @@ def prepare_stack_plot_config(
 
     h_data, h_mc, h_mc_stack = None, None, None
     if data_hists:
-        h_data = sum(data_hists[1:], data_hists[0].copy())
+        h_data = sum_hists(data_hists)
     if mc_hists:
-        h_mc = sum(mc_hists[1:], mc_hists[0].copy())
+        h_mc = sum_hists(mc_hists)
         h_mc_stack = hist.Stack(*mc_hists)
 
     # setup plotting configs

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -21,6 +21,7 @@ from columnflow.tasks.framework.decorators import on_failure
 from columnflow.tasks.reduction import ReducedEventsUser
 from columnflow.tasks.production import ProduceColumns
 from columnflow.tasks.ml import MLEvaluation
+from columnflow.hist_util import sum_hists
 from columnflow.util import dev_sandbox
 
 
@@ -444,7 +445,7 @@ class MergeHistograms(_MergeHistograms):
 
             # merge them
             variable_hists = [h[variable_name] for h in hists]
-            merged = sum(variable_hists[1:], variable_hists[0].copy())
+            merged = sum_hists(variable_hists)
 
             # post-process the merged histogram
             merged = self.hist_producer_inst.run_post_process_merged_hist(merged, task=self)
@@ -542,7 +543,7 @@ class MergeShiftedHistograms(_MergeShiftedHistograms):
                 ]
 
                 # merge and write the output
-                merged = sum(variable_hists[1:], variable_hists[0].copy())
+                merged = sum_hists(variable_hists)
                 outp.dump(merged, formatter="pickle")
 
 


### PR DESCRIPTION
This PR adds a helper `sum_hists` which sums histograms, but unlike normal addition or `sum(...)` calls, is not prone to the "unmergable axes" issue in case axis labels do not match.

As before, axis names and other attributes have to exactly match, but histogram summation should not fail if mere labels changed. This is achieved by this PR.

I made all code locations that require summation use the new util.