### PR TITLE
Add variabble_repr to control paths.

### DIFF
--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -25,15 +25,23 @@ from columnflow.hist_util import sum_hists
 from columnflow.util import dev_sandbox
 
 
+class VariablesMixinWorkflow(
+    VariablesMixin,
+    law.LocalWorkflow,
+    RemoteWorkflow,
+):
+
+    def control_output_postfix(self) -> str:
+        return f"{super().control_output_postfix()}__vars_{self.variables_repr}"
+
+
 class _CreateHistograms(
     ReducedEventsUser,
     ProducersMixin,
     MLModelsMixin,
     HistProducerMixin,
     ChunkedIOMixin,
-    VariablesMixin,
-    law.LocalWorkflow,
-    RemoteWorkflow,
+    VariablesMixinWorkflow,
 ):
     """
     Base classes for :py:class:`CreateHistograms`.
@@ -342,9 +350,7 @@ class _MergeHistograms(
     ProducersMixin,
     MLModelsMixin,
     HistProducerMixin,
-    VariablesMixin,
-    law.LocalWorkflow,
-    RemoteWorkflow,
+    VariablesMixinWorkflow,
 ):
     """
     Base classes for :py:class:`MergeHistograms`.
@@ -481,9 +487,7 @@ class _MergeShiftedHistograms(
     ProducerClassesMixin,
     MLModelsMixin,
     HistProducerClassMixin,
-    VariablesMixin,
-    law.LocalWorkflow,
-    RemoteWorkflow,
+    VariablesMixinWorkflow,
 ):
     """
     Base classes for :py:class:`MergeShiftedHistograms`.


### PR DESCRIPTION
`CreateHistograms`, `MergeHistograms` and `MergeShiftedHistograms` are remote workflows and "variable mixins", but the string representation of the selected variables is not part of the output directory.

The normal targets add the representation to the basename of outputs, which leaves them missing in paths of so-called "control outputs", i.e., htcondor job summaries and log files.

This PR adds them to the paths, avoiding collisions when running multiple variations of the above mentioned tasks.