### PR TITLE
Fix cf_inspect script after coffea update.

### DIFF
--- a/bin/cf_inspect.py
+++ b/bin/cf_inspect.py
@@ -51,7 +51,7 @@ def _load_nano_root(fname: str, treepath: str | None = None, **kwargs) -> ak.Arr
     return coffea.nanoevents.NanoEventsFactory.from_root(
         source,
         treepath=treepath,
-        delayed=False,
+        mode="eager",
         runtime_cache=None,
         persistent_cache=None,
     ).events()


### PR DESCRIPTION
This PR fixes the ```cf_inspect.py``` script as the ```delayed``` parameter has been replaced by the ```mode``` parameter in an update of coffea. More information can be found in the error message thrown by coffea [here](https://github.com/scikit-hep/coffea/blob/a83ed2d5b91f023143741eeeb75e0218baf71a0c/src/coffea/nanoevents/factory.py#L318C9-L329C51). I've replicated the old behaviour by setting ```mode="eager"```.