### PR TITLE
Rename max-runtime -> {htcondor,slurm}-runtime.

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -65,6 +65,7 @@ htcondor_flavor: $CF_HTCONDOR_FLAVOR
 htcondor_share_software: False
 htcondor_memory: -1
 htcondor_disk: -1
+htcondor_runtime: 3h
 slurm_flavor: $CF_SLURM_FLAVOR
 slurm_partition: $CF_SLURM_PARTITION
 


### PR DESCRIPTION
This PR updates a parameter of our remote workflows, namely `--max-runtime`.

In our use case, we have htcondor and slurm jobs, and we want to configure the maximum runtime for specific tasks permanently in our law.cfg.

However, they share this parameter for historic reasons, which makes it impossible to pick different defaults. Looking at the code, `--max-runtime` is the only job parameter that is *not* workflow-specific, which is inconsistent anyways.

I introduced `--htcondor-runtime` and `--slurm-runtime`, and allowed different defaults being set from the law.cfg.