### PR TITLE
fix data uncertainties for density

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -277,6 +277,7 @@ def draw_errorbars(
     h: hist.Hist,
     norm: float | Sequence | np.ndarray = 1.0,
     error_type: str = "poisson_unweighted",
+    density: bool = False,
     **kwargs,
 ) -> None:
     import hist
@@ -301,7 +302,7 @@ def draw_errorbars(
                 "Error bars calculation only implemented for histograms with storage type WeightedSum "
                 "either change the Histogram storage_type or set yerr manually",
             )
-        yerr = calculate_stat_error(h, error_type)
+        yerr = calculate_stat_error(h, error_type, density=density)
         # normalize yerr to the histogram = error propagation on standard deviation
         yerr = abs(yerr / norm)
         # replace inf with nan for any bin where norm = 0 and calculate_stat_error returns a non zero value

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -91,6 +91,7 @@ def plot_variable_stack(
         hists,
         shape_norm=shape_norm,
         shift_insts=shift_insts,
+        density=density,
         **kwargs,
     )
 


### PR DESCRIPTION
When applying the `--density` parameter, the unweighted poisson error calculation does not take into account the rescaling, leading to wrong data stat. uncertainties.

This PR fixes this issue by "reverting" the density before error calculation and the reapplying the density afterwards.
To achieve this, one needs to pass the "density" argument through the plot functions. I only added this argument for the data error calculation in the `plot_variables_1d` function because the MC uncertainty bands are considering the variance of the histogram and therefore working out of the box.

I also updated the ylabel when using density to display e.g. "Entries / GeV" instead of "Entries"