### PR TITLE
Implementation of plotting total uncertainties

### DIFF
--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -324,6 +324,12 @@ class PlotBase1D(PlotBase):
         significant=False,
         description="when True, no error bands for statistical uncertainty histograms are drawn; default: None",
     )
+    draw_total_unc = law.OptionalBoolParameter(
+        default=None,
+        significant=False,
+        description="when True, total error bands are drawn as root of sum of squares of statistical and systematic errors; default: None",
+    )
+
 
     def get_plot_parameters(self) -> DotDict:
         # convert parameters to usable values during plotting
@@ -333,6 +339,7 @@ class PlotBase1D(PlotBase):
         dict_add_strict(params, "yscale", None if self.yscale == law.NO_STR else self.yscale)
         dict_add_strict(params, "shape_norm", self.shape_norm)
         dict_add_strict(params, "hide_stat_errors", self.hide_stat_errors)
+        dict_add_strict(params, "draw_total_unc", self.draw_total_unc)
         return params
 
 


### PR DESCRIPTION
Here it is my attempt to implement a new function that allows to plot the total uncertainty dealing with QCD estimated with ABCD method.
For me these modifications do the job, but I believe that is not general enough to be used by everyone.
This pull request is mainly to show to someone more expert what I did and receive some hints and help to improve it and make usable for everyone.
I'm basically adding the nominal value of the QCD histogram to all the up and down variations for each shift. By doing so, the systematic uncertainties (that are evaluated, bin-by-bin, by differences between shifted and nominal histogram entries) are not the same order of magnitude of QCD contribution. 
At this point, QCD contributes only to the statistical error but it would be nice to have a way to introduce up and down shift at the stage of hist_hooks where QCD histogram is created (I have no clue how to do so, I just wanted to raise the interested towards the problem, maybe someone has the solution already at hand).
Another minor thing i did is fixing the situation in which up and down variation contributes in the same direction. The code was setting the systematic to 0 in that case, but I'm quite sure that the right thing to do is to set it to the difference with the highest absolute value.

Comments, questions and help are all very welcome.
Thank you for your time,
Jacopo