### PR TITLE
Apply jet_mask to events in btag_wp_weights.

### DIFF
--- a/columnflow/production/cms/btag.py
+++ b/columnflow/production/cms/btag.py
@@ -440,11 +440,12 @@ def btag_wp_weights(
         2. https://cms-analysis-corrections.docs.cern.ch/corrections_era/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/BTV/2026-01-30/#btagging_preliminaryjsongz  # noqa
         3. https://indico.cern.ch/event/1583955/contributions/6771046/attachments/3176162/5648591/BTVreportHIGPAG_18112025.pdf  # noqa
     """
-    # get inputs
-    discr = events.Jet[self.cfg.btag_column]
-    flavor = events[self.cfg.jet_name].hadronFlavour
-    abs_eta = abs(events[self.cfg.jet_name].eta)
-    pt = events[self.cfg.jet_name].pt
+    # get inputs, evaluated at jet_mask
+    jet_mask = (True if jet_mask is Ellipsis else jet_mask)
+    discr = events.Jet[self.cfg.btag_column][jet_mask]
+    flavor = events[self.cfg.jet_name].hadronFlavour[jet_mask]
+    abs_eta = abs(events[self.cfg.jet_name].eta[jet_mask])
+    pt = events[self.cfg.jet_name].pt[jet_mask]
 
     # helpers to get the sf and efficiencies
     def get_sf_and_eff(


### PR DESCRIPTION
This PR fixes the `btag_wp_weights` producer by applying the `jet_mask` to the inputs of the SF derivation. 