### PR TITLE
Fix workflow parameter passthrough in pilot mode.

### DIFF
--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -1142,6 +1142,20 @@ class AnalysisTask(BaseTask, law.SandboxTask):
 
         raise Exception(f"cannot determine output location based on '{location}'")
 
+    def pilot_workflow_requires(self, task: law.Task) -> Any:
+        """
+        Helper for situtations where *this* task is a workflow with ``--pilot`` activated to decide if an upstream task
+        itself should be required, or its own upstream dependencies.
+
+        :param task: The task to be required.
+        :return: Either the task itself or the result of its :py:meth:`~.workflow_requires` method.
+        """
+        return (
+            task.workflow_requires()
+            if self.pilot and isinstance(task, law.BaseWorkflow) and task.is_workflow()
+            else task
+        )
+
     def get_parquet_writer_opts(self, repeating_values: bool = False) -> dict[str, Any]:
         """
         Returns an option dictionary that can be passed as *writer_opts* to :py:meth:`~law.pyarrow.merge_parquet_task`,

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -94,26 +94,20 @@ class CreateHistograms(_CreateHistograms):
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        if not self.pilot:
-            if self.producer_insts:
-                reqs["producers"] = [
-                    self.reqs.ProduceColumns.req(
-                        self,
-                        producer=producer_inst.cls_name,
-                        producer_inst=producer_inst,
-                    )
-                    for producer_inst in self.producer_insts
-                    if producer_inst.produced_columns
-                ]
-            if self.ml_model_insts:
-                reqs["ml"] = [
-                    self.reqs.MLEvaluation.req(self, ml_model=ml_model_inst.cls_name)
-                    for ml_model_inst in self.ml_model_insts
-                ]
-        elif self.producer_insts:
-            # pass-through pilot workflow requirements of upstream task
-            t = self.reqs.ProduceColumns.req(self)
-            law.util.merge_dicts(reqs, t.workflow_requires(), inplace=True)
+        # depending on pilot flag, add upstream workflows or pass-through their own requirements only
+        reqs["producers"] = list(map(self.pilot_workflow_requires, (
+            self.reqs.ProduceColumns.req(
+                self,
+                producer=producer_inst.cls_name,
+                producer_inst=producer_inst,
+            )
+            for producer_inst in self.producer_insts
+            if producer_inst.produced_columns
+        )))
+        reqs["ml"] = list(map(self.pilot_workflow_requires, (
+            self.reqs.MLEvaluation.req(self, ml_model=ml_model_inst.cls_name)
+            for ml_model_inst in self.ml_model_insts
+        )))
 
         # add hist producer dependent requirements
         reqs["hist_producer"] = law.util.make_unique(law.util.flatten(self.hist_producer_inst.run_requires(task=self)))

--- a/columnflow/tasks/ml.py
+++ b/columnflow/tasks/ml.py
@@ -86,17 +86,16 @@ class PrepareMLEvents(
         if self.preparation_producer_inst:
             reqs["preparation_producer"] = self.preparation_producer_inst.run_requires(task=self)
 
-        # add producers to requirements
-        if not self.pilot and self.producer_insts:
-            reqs["producers"] = [
-                self.reqs.ProduceColumns.req(
-                    self,
-                    producer=producer_inst.cls_name,
-                    producer_inst=producer_inst,
-                )
-                for producer_inst in self.producer_insts
-                if producer_inst.produced_columns
-            ]
+        # depending on pilot flag, add upstream workflows or pass-through their own requirements only
+        reqs["producers"] = list(map(self.pilot_workflow_requires, (
+            self.reqs.ProduceColumns.req(
+                self,
+                producer=producer_inst.cls_name,
+                producer_inst=producer_inst,
+            )
+            for producer_inst in self.producer_insts
+            if producer_inst.produced_columns
+        )))
 
         # require the full merge forest
         reqs["events"] = self.reqs.ProvideReducedEvents.req(self)

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -63,21 +63,17 @@ class ReduceEvents(_ReduceEvents):
 
         reqs["lfns"] = self.reqs.GetDatasetLFNs.req(self)
 
-        if not self.pilot:
-            reqs["calibrations"] = [
-                self.reqs.CalibrateEvents.req(
-                    self,
-                    calibrator=calibrator_inst.cls_name,
-                    calibrator_inst=calibrator_inst,
-                )
-                for calibrator_inst in self.calibrator_insts
-                if calibrator_inst.produced_columns
-            ]
-            reqs["selection"] = self.reqs.SelectEvents.req(self)
-        else:
-            # pass-through pilot workflow requirements of upstream task
-            t = self.reqs.SelectEvents.req(self)
-            law.util.merge_dicts(reqs, t.workflow_requires(), inplace=True)
+        # depending on pilot flag, add upstream workflows or pass-through their own requirements only
+        reqs["calibrations"] = list(map(self.pilot_workflow_requires, (
+            self.reqs.CalibrateEvents.req(
+                self,
+                calibrator=calibrator_inst.cls_name,
+                calibrator_inst=calibrator_inst,
+            )
+            for calibrator_inst in self.calibrator_insts
+            if calibrator_inst.produced_columns
+        )))
+        reqs["selection"] = self.pilot_workflow_requires(self.reqs.SelectEvents.req(self))
 
         # add reducer dependent requirements
         reqs["reducer"] = law.util.make_unique(law.util.flatten(self.reducer_inst.run_requires(task=self)))

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -10,16 +10,15 @@ from collections import defaultdict
 import luigi
 import law
 
-from columnflow.types import Any
-
 from columnflow.tasks.framework.base import Requirements, AnalysisTask, wrapper_factory
 from columnflow.tasks.framework.mixins import CalibratorsMixin, SelectorMixin, ChunkedIOMixin, ProducerMixin
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.framework.decorators import on_failure
+from columnflow.tasks.framework.parameters import DerivableInstParameter
 from columnflow.tasks.external import GetDatasetLFNs
 from columnflow.tasks.calibration import CalibrateEvents
 from columnflow.util import maybe_import, ensure_proxy, dev_sandbox, safe_div, DotDict
-from columnflow.tasks.framework.parameters import DerivableInstParameter
+from columnflow.types import Any
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -70,20 +69,16 @@ class SelectEvents(_SelectEvents):
 
         reqs["lfns"] = self.reqs.GetDatasetLFNs.req(self)
 
-        if not self.pilot:
-            reqs["calibrations"] = [
-                self.reqs.CalibrateEvents.req(
-                    self,
-                    calibrator=calibrator_inst.cls_name,
-                    calibrator_inst=calibrator_inst,
-                )
-                for calibrator_inst in self.calibrator_insts
-                if calibrator_inst.produced_columns
-            ]
-        elif self.calibrator_insts:
-            # pass-through pilot workflow requirements of upstream task
-            t = self.reqs.CalibrateEvents.req(self)
-            law.util.merge_dicts(reqs, t.workflow_requires(), inplace=True)
+        # depending on pilot flag, add upstream workflows or pass-through their own requirements only
+        reqs["calibrations"] = list(map(self.pilot_workflow_requires, (
+            self.reqs.CalibrateEvents.req(
+                self,
+                calibrator=calibrator_inst.cls_name,
+                calibrator_inst=calibrator_inst,
+            )
+            for calibrator_inst in self.calibrator_insts
+            if calibrator_inst.produced_columns
+        )))
 
         # add selector dependent requirements
         reqs["selector"] = law.util.make_unique(law.util.flatten(self.selector_inst.run_requires(task=self)))

--- a/columnflow/tasks/union.py
+++ b/columnflow/tasks/union.py
@@ -63,22 +63,20 @@ class UniteColumns(_UniteColumns):
     def workflow_requires(self):
         reqs = super().workflow_requires()
 
-        if not self.pilot:
-            if self.producer_insts:
-                reqs["producers"] = [
-                    self.reqs.ProduceColumns.req(
-                        self,
-                        producer=producer_inst.cls_name,
-                        producer_inst=producer_inst,
-                    )
-                    for producer_inst in self.producer_insts
-                    if producer_inst.produced_columns
-                ]
-            if self.ml_model_insts:
-                reqs["ml"] = [
-                    self.reqs.MLEvaluation.req(self, ml_model=m)
-                    for m in self.ml_models
-                ]
+        # depending on pilot flag, add upstream workflows or pass-through their own requirements only
+        reqs["producers"] = list(map(self.pilot_workflow_requires, (
+            self.reqs.ProduceColumns.req(
+                self,
+                producer=producer_inst.cls_name,
+                producer_inst=producer_inst,
+            )
+            for producer_inst in self.producer_insts
+            if producer_inst.produced_columns
+        )))
+        reqs["ml"] = list(map(self.pilot_workflow_requires, (
+            self.reqs.MLEvaluation.req(self, ml_model=m)
+            for m in self.ml_models
+        )))
 
         # require the full merge forest
         reqs["events"] = self.reqs.ProvideReducedEvents.req(self)


### PR DESCRIPTION
In some of our workflow tasks, we provide the `--pilot` option which causes the workflow to drop *some* of its requirements to upstream workflows, and let the branch tasks themselves their upstream requirement. However, for consistency we need to pass the workflow requirements of the upstream tasks nevertheless (which then can decide about dropping pilot requirements on their own ...).

This was done in a very simplified way so far and did not work under all conditions (e.g. when multiple produces are triggered). This PR fixes this passthrough mechanism by wrapping specific requirements in a new `pilot_workflow_requires()` method, that does the distinction between the requirements dependent on the pilot mode.