### PR TITLE
Fix ExternalFiles bundle unpacking.

### DIFF
--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -565,12 +565,11 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
 
     @law.decorator.notify
     @law.decorator.log
-    @law.decorator.safe_output
     def run(self):
         outputs = self.output()
 
         # remove the bundle if recreating
-        if outputs["bundle"].exists() and self.recreate:
+        if self.recreate and outputs["bundle"].exists():
             outputs["bundle"].remove()
 
         # bundle only if needed
@@ -661,19 +660,25 @@ class BundleExternalFiles(ConfigTask, law.tasks.TransferLocalFile):
             # transfer the result
             self.transfer(tmp, outputs["bundle"])
 
-        # unpack the bundle to have local files available
-        with self.publish_step(f"unpacking to {outputs['local_files'].dir.abspath} ..."):
+        # remove all local files if recreating or if only existing partially to do a full refresh
+        local_files_exist = outputs["local_files"].exists()
+        if (self.recreate and local_files_exist) or not local_files_exist:
             outputs["local_files"].dir.remove()
-            bundle = outputs["bundle"]
-            if isinstance(bundle, law.FileCollection):
-                bundle = bundle.random_target()
-            bundle.load(outputs["local_files"].dir, formatter="tar")
+            local_files_exist = False
 
-            # check if unpacked files/directories are described by the correct target class
-            for target in outputs["local_files"]._flat_target_list:
-                mismatch = (
-                    (isinstance(target, law.FileSystemFileTarget) and not os.path.isfile(target.abspath)) or
-                    (isinstance(target, law.FileSystemDirectoryTarget) and not os.path.isdir(target.abspath))
-                )
-                if mismatch:
-                    raise Exception(f"mismatching file/directory type of unpacked target {target!r}")
+        # unpack the bundle to have local files available if needed
+        if not local_files_exist:
+            with self.publish_step(f"unpacking to {outputs['local_files'].dir.abspath} ..."):
+                bundle = outputs["bundle"]
+                if isinstance(bundle, law.FileCollection):
+                    bundle = bundle.random_target()
+                bundle.load(outputs["local_files"].dir, formatter="tar")
+
+                # check if unpacked files/directories are described by the correct target class
+                for target in outputs["local_files"]._flat_target_list:
+                    mismatch = (
+                        (isinstance(target, law.FileSystemFileTarget) and not os.path.isfile(target.abspath)) or
+                        (isinstance(target, law.FileSystemDirectoryTarget) and not os.path.isdir(target.abspath))
+                    )
+                    if mismatch:
+                        raise Exception(f"mismatching file/directory type of unpacked target {target!r}")


### PR DESCRIPTION
This PR fixes the way that external file bundles are unpacked.

We experienced a couple SSL handshake issues with the dCache, and in case many remote jobs start at the same time, the chance that at least on of them will treat the files as missing is quite large.

If this happens, the remote jobs are not allowed to *create* the bundle, but the can (and should) *unpack* it. However, this was also happening when the bundle was already unpacked, causing files to be needlessly deleted and re-written, and other jobs that were reading those files at the same time mostly crashed, creating a cascade of issues.

This PR makes the unpacking robust against that and more stable in general.