### PR TITLE
Add category id cache.

### DIFF
--- a/columnflow/config_util.py
+++ b/columnflow/config_util.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 __all__ = []
 
 import re
+import pathlib
 import dataclasses
 import itertools
 import collections
@@ -16,8 +17,8 @@ import collections
 import law
 import order as od
 
-from columnflow.util import maybe_import, get_docs_url
 from columnflow.columnar_util import flat_np_view, layout_ak_array
+from columnflow.util import maybe_import, get_docs_url, CacheBase, PersistentCache
 from columnflow.types import Callable, Any, Sequence, Literal
 
 ak = maybe_import("awkward")
@@ -418,6 +419,24 @@ def expand_shift_sources(shifts: Sequence[str] | set[str]) -> list[str]:
     return law.util.make_unique(_shifts)
 
 
+class CategoryIDCache(PersistentCache):
+
+    def __init__(self, cache_path: od.Config | str | pathlib.Path | law.FileSystemFileTarget) -> None:
+        # when a config object is given, store the cache in the law home dir
+        if isinstance(cache_path, od.Config):
+            cache_path = law.config.law_home_path(f"category_ids_{cache_path.name}.json")
+
+        super().__init__(cache_path)
+
+    def open(self) -> CategoryIDCache:
+        super().open()
+
+        # synchronize the maximum category id counter in order
+        od.Category._max_id = max(self.cache.values(), default=0)
+
+        return self
+
+
 def create_category_id(
     config: od.Config,
     category_name: str,
@@ -452,27 +471,50 @@ def add_category(
     **kwargs,
 ) -> od.Category:
     """
-    Creates a :py:class:`order.Category` instance by forwarding all *kwargs* to its constructor,
-    adds it to a *parent* object. such as a :py:class:`order.Config` or an other
-    :py:class:`order.Category`, and returns it. When *kwargs* do not contain a field *id*,
-    :py:func:`create_category_id` is used to create one.
+    Creates a :py:class:`order.Category` instance by forwarding all *kwargs* to its constructor, adds it to a *parent*
+    object. such as a :py:class:`order.Config` or an other :py:class:`order.Category`, and returns it.
+
+    When *kwargs* do not contain a field *id*, :py:func:`create_category_id` is used to create one. Additionally, if the
+    field *id* is given as a :py:class:`CacheBase` object, it is used to cache the created id for the given category
+    name.
 
     :param config: :py:class:`order.Config` object for which the category is created.
     :param parent: Parent object to which the category is added. If *None*, *config* is used.
     :param kwargs: Keyword arguments forwarded to the category constructor.
     :return: The newly created category instance.
     """
+    # name must be given
     if "name" not in kwargs:
         fields = ",".join(map(str, kwargs))
         raise ValueError(f"a field 'name' is required to create a category, got '{fields}'")
 
-    if "id" not in kwargs:
+    # default id
+    if kwargs.get("id") is None:
         kwargs["id"] = create_category_id(config, kwargs["name"])
 
+    # id can be a cache object
+    id_cache = None
+    if isinstance(kwargs["id"], CacheBase):
+        id_cache = kwargs["id"]
+        # use the cached id, or use "+" to auto-increment and store the id below
+        kwargs["id"] = (
+            id_cache.get(kwargs["name"])
+            if (id_cached := id_cache.has(kwargs["name"]))
+            else od.UniqueObject.AUTO_ID
+        )
+
+    # default parent
     if parent is None:
         parent = config
 
-    return parent.add_category(**kwargs)
+    # create the category
+    category = parent.add_category(**kwargs)
+
+    # cache if requested
+    if id_cache and not id_cached:
+        id_cache.set(category.name, category.id)
+
+    return category
 
 
 @dataclasses.dataclass
@@ -546,7 +588,8 @@ def create_category_combinations(
     *kwargs_fn*. This function is called with the categories (in a dictionary, mapped to the sequence names as given in
     *categories*) that contribute to the newly created category and should return a dictionary. If the fields ``"id"``
     and ``"selection"`` are missing, they are filled with reasonable defaults leading to a auto-generated, deterministic
-    id and a list of all parent selection statements.
+    id and a list of all parent selection statements. Similar to :py:func:`add_category`, the field ``"id"`` can be set
+    to a :py:class:`CacheBase` object to cache the created id for the given category name.
 
     If the name of a new category is already known to *config* it is skipped unless *skip_existing* is *False*. In
     addition, *skip_fn* can be a callable that receives a dictionary mapping group names to categories that represents
@@ -671,9 +714,24 @@ def create_category_combinations(
                 if "selection" not in kwargs:
                     kwargs["selection"] = [c.selection for c in root_cats.values()]
 
+                # use cache id if given
+                id_cache = None
+                if isinstance(kwargs["id"], CacheBase):
+                    id_cache = kwargs["id"]
+                    # use the cached id, or use "+" to auto-increment and store the id below
+                    kwargs["id"] = (
+                        id_cache.get(cat_name)
+                        if (id_cached := id_cache.has(cat_name))
+                        else od.UniqueObject.AUTO_ID
+                    )
+
                 # create the new category
                 cat = od.Category(name=cat_name, **kwargs)
-                created_categories[cat_name] = cat
+                created_categories[cat.name] = cat
+
+                # cache if requested
+                if id_cache and not id_cached:
+                    id_cache.set(cat.name, cat.id)
 
                 # add a tag to denote this category was auto-created
                 cat.add_tag("auto_created_by_combinations")
@@ -682,9 +740,9 @@ def create_category_combinations(
                 if isinstance(kwargs["id"], int):
                     if kwargs["id"] in unique_ids_cache:
                         matching_cat = config.get_category(kwargs["id"])
-                        if matching_cat.name != cat_name:
+                        if matching_cat.name != cat.name:
                             raise ValueError(
-                                f"non-unique category id '{kwargs['id']}' for '{cat_name}' has already been used for "
+                                f"non-unique category id '{kwargs['id']}' for '{cat.name}' has already been used for "
                                 f"category '{matching_cat.name}'",
                             )
                     unique_ids_cache.add(kwargs["id"])

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -17,6 +17,7 @@ import queue
 import threading
 import subprocess
 import importlib
+import pathlib
 import fnmatch
 import inspect
 import pprint
@@ -29,7 +30,7 @@ import law
 import luigi
 
 from columnflow import env_is_dev, env_is_remote, docs_url, github_url
-from columnflow.types import Callable, Any, Sequence, Union, ModuleType, Type, T, Hashable
+from columnflow.types import Callable, Any, Sequence, Union, ModuleType, Type, T, Hashable, Protocol, runtime_checkable
 
 
 #: Placeholder for an unset value.
@@ -1025,6 +1026,78 @@ class KeyValueMessage(luigi.worker.SchedulerMessage):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+@runtime_checkable
+class CacheBase(Protocol):
+
+    def has(self, key: Hashable) -> bool:
+        ...
+
+    def get(self, key: Hashable) -> Any:
+        ...
+
+    def set(self, key: Hashable, value: Any) -> None:
+        ...
+
+
+class PersistentCache(CacheBase):
+
+    def __init__(self, cache_path: str | pathlib.Path | law.FileSystemFileTarget) -> None:
+        super().__init__()
+
+        self.cache_target = (
+            cache_path
+            if isinstance(cache_path, law.FileSystemFileTarget)
+            else law.LocalFileTarget(cache_path)
+        )
+
+        # state
+        self.cache: dict[Hashable, Any] = {}
+        self.opened: bool = False
+        self.modified: bool = False
+
+    def __enter__(self) -> PersistentCache:
+        return self.open()
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def open(self) -> PersistentCache:
+        if self.opened:
+            raise Exception(f"{self.__class__.__name__} is already opened")
+
+        # when existing, overwrite cache in memory with that from file
+        self.cache.clear()
+        if self.cache_target.exists():
+            self.cache |= self.cache_target.load(formatter="json")
+
+        self.modified = False
+        self.opened = True
+
+        return self
+
+    def close(self) -> None:
+        if not self.opened:
+            raise Exception(f"{self.__class__.__name__} is not opened")
+
+        # write to file when modified
+        if self.modified:
+            self.cache_target.dump(self.cache, formatter="json", indent=2)
+
+        self.modified = False
+        self.opened = False
+
+    def has(self, key: Hashable) -> bool:
+        return key in self.cache
+
+    def get(self, key: Hashable) -> Any:
+        return self.cache[key]
+
+    def set(self, key: Hashable, value: Any) -> None:
+        if not self.modified and (not self.has(key) or self.get(key) != value):
+            self.modified = True
+        self.cache[key] = value
 
 
 def load_correction_set(target: law.FileSystemFileTarget | str) -> Any:


### PR DESCRIPTION
This PR adds a persistent caching mechanism for category ids by category name, and adjusts the `add_category()` and `create_category_combinations()` config utils to use it.

With that, the pattern of adding categories can become

```python
from columnflow.config_util import CategoryIDCache, add_category

id_cache = CategoryIDCache(config_inst).open()

add_category(name="etau", selection="cat_etau", id=id_cache)  # users might use partial :)
...  # more categories here

id_cache.close()
```

The cache makes sure to use an increasing id for yet unseen category names, and the previously seen id otherwise. Upon `close()`, the cache is saved to a common location.

