### PR TITLE
Allow multiple nano inputs in first tasks.

### DIFF
--- a/columnflow/tasks/calibration.py
+++ b/columnflow/tasks/calibration.py
@@ -129,17 +129,19 @@ class CalibrateEvents(_CalibrateEvents):
         write_columns = self.calibrator_inst.produced_columns
         route_filter = RouteFilter(keep=write_columns)
 
-        # let the lfn_task prepare the nano file (basically determine a good pfn)
-        [(lfn_index, input_file)] = lfn_task.iter_nano_files(self)
+        # let the lfn_task locate and prepare the nano file(s)
+        nano_input = [nano_target for _, nano_target in lfn_task.iter_nano_files(self)]
+        if len(nano_input) == 1:
+            nano_input = nano_input[0]
 
         # prepare inputs for localization
         with law.localize_file_targets(
-            [input_file, *reader_targets.values()],
+            [nano_input, *reader_targets.values()],
             mode="r",
         ) as inps:
             # iterate over chunks
             for (events, *cols), pos in self.iter_chunked_io(
-                [inp.abspath for inp in inps],
+                law.util.map_struct(law.target.file.get_path, inps),
                 source_type=["coffea_root"] + (len(inps) - 1) * [None],
                 read_columns=len(inps) * [read_columns],
                 chunk_size=self.calibrator_inst.get_min_chunk_size(),
@@ -162,8 +164,8 @@ class CalibrateEvents(_CalibrateEvents):
                     self.raise_if_not_finite(events)
 
                 # save as parquet via a thread in the same pool
-                chunk = tmp_dir.child(f"file_{lfn_index}_{pos.index}.parquet", type="f")
-                output_chunks[(lfn_index, pos.index)] = chunk
+                chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
+                output_chunks[pos.index] = chunk
                 self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # teardown the calibrator

--- a/columnflow/tasks/reduction.py
+++ b/columnflow/tasks/reduction.py
@@ -188,11 +188,13 @@ class ReduceEvents(_ReduceEvents):
         n_all = 0
         n_reduced = 0
 
-        # let the lfn_task prepare the nano file (basically determine a good pfn)
-        [(lfn_index, input_file)] = lfn_task.iter_nano_files(self)
+        # let the lfn_task locate and prepare the nano file(s)
+        nano_input = [nano_target for _, nano_target in lfn_task.iter_nano_files(self)]
+        if len(nano_input) == 1:
+            nano_input = nano_input[0]
 
         # collect input targets
-        input_targets = [input_file]
+        input_targets = [nano_input]
         input_targets.append(inputs["selection"]["results"])
         input_targets.extend([inp["columns"] for inp in inputs["calibrations"]])
         if self.selector_inst.produced_columns:
@@ -203,7 +205,7 @@ class ReduceEvents(_ReduceEvents):
         with law.localize_file_targets(input_targets, mode="r") as inps:
             # iterate over chunks of events and diffs
             for (events, sel, *diffs), pos in self.iter_chunked_io(
-                [inp.abspath for inp in inps],
+                law.util.map_struct(law.target.file.get_path, inps),
                 source_type=["coffea_root"] + (len(inps) - 1) * ["awkward_parquet"],
                 read_columns=[read_columns, read_sel_columns] + (len(inps) - 2) * [read_columns],
                 chunk_size=self.reducer_inst.get_min_chunk_size(),
@@ -242,7 +244,7 @@ class ReduceEvents(_ReduceEvents):
                     self.raise_if_not_finite(events)
 
                 # save as parquet via a thread in the same pool
-                chunk = tmp_dir.child(f"file_{lfn_index}_{pos.index}.parquet", type="f")
+                chunk = tmp_dir.child(f"file_{pos.index}.parquet", type="f")
                 output_chunks[pos.index] = chunk
                 self.chunked_io.queue(sorted_ak_to_parquet, (ak.to_packed(events), chunk.abspath))
 

--- a/columnflow/tasks/selection.py
+++ b/columnflow/tasks/selection.py
@@ -185,13 +185,15 @@ class SelectEvents(_SelectEvents):
         write_columns |= self.selector_inst.produced_columns
         route_filter = RouteFilter(keep=write_columns)
 
-        # let the lfn_task prepare the nano file (basically determine a good pfn)
-        [(lfn_index, input_file)] = lfn_task.iter_nano_files(self)
+        # let the lfn_task locate and prepare the nano file(s)
+        nano_input = [nano_target for _, nano_target in lfn_task.iter_nano_files(self)]
+        if len(nano_input) == 1:
+            nano_input = nano_input[0]
 
         # prepare inputs for localization
         with law.localize_file_targets(
             [
-                input_file,
+                nano_input,
                 *(inp["columns"] for inp in inputs["calibrations"]),
                 *reader_targets.values(),
             ],
@@ -200,7 +202,7 @@ class SelectEvents(_SelectEvents):
             # iterate over chunks of events and diffs
             n_calib = len(inputs["calibrations"])
             for (events, *cols), pos in self.iter_chunked_io(
-                [inp.abspath for inp in inps],
+                law.util.map_struct(law.target.file.get_path, inps),
                 source_type=["coffea_root"] + ["awkward_parquet"] * n_calib + [None] * n_ext,
                 read_columns=[read_columns] * (1 + n_calib + n_ext),
                 chunk_size=self.selector_inst.get_min_chunk_size(),
@@ -238,8 +240,8 @@ class SelectEvents(_SelectEvents):
                     self.raise_if_not_finite(results_array)
 
                 # save results as parquet via a thread in the same pool
-                chunk = tmp_dir.child(f"res_{lfn_index}_{pos.index}.parquet", type="f")
-                result_chunks[(lfn_index, pos.index)] = chunk
+                chunk = tmp_dir.child(f"res_{pos.index}.parquet", type="f")
+                result_chunks[pos.index] = chunk
                 self.chunked_io.queue(sorted_ak_to_parquet, (results_array, chunk.abspath))
 
                 # remove columns
@@ -251,8 +253,8 @@ class SelectEvents(_SelectEvents):
                         self.raise_if_not_finite(events)
 
                     # save additional columns as parquet via a thread in the same pool
-                    chunk = tmp_dir.child(f"cols_{lfn_index}_{pos.index}.parquet", type="f")
-                    column_chunks[(lfn_index, pos.index)] = chunk
+                    chunk = tmp_dir.child(f"cols_{pos.index}.parquet", type="f")
+                    column_chunks[pos.index] = chunk
                     self.chunked_io.queue(sorted_ak_to_parquet, (events, chunk.abspath))
 
         # teardown the selector


### PR DESCRIPTION
**Before** going into the details of this PR:

This is the first of three planned PRs that have the goal to allow the initial tasks `{Calibrate,Select,Reduce}Events` to run over multiple input root files in a single branch.

This is *highly* necessary in case of many small inputs, like has been the case for latest central nano productions. In these scenarios, the overhead per branch is just far too high, putting unnecessary strain on job, storage and cache infrastructure. In general, one would just have to control the `file_merging` attribute.

Overall steps / upcoming PRs:

1. In the three tasks, allow passing multiple nano inputs to the `iter_chunked_io()` method that triggers the chunked reading. The `iter_nano_files()` helper respects the `file_merging` and can yield more than one file already. → **this PR!**
2. The IO methods `uproot_root` and `coffea_root` need to understand multiple sources and iterate over sequences, similar to TChain's. → https://github.com/columnflow/columnflow/pull/789
3. The reduction logic must consider these initial file merging settings, which we assume to be 1. → **PR will take some time**

---

As written above, this PR adjusts the `{Calibrate,Select,Reduce}Events` tasks to use multiple nano input files if configured to do so via a `file_merging` attribute on task level other than `1` or `None`. It's not used so far, but we slowly need to think in this direction.