### PR TITLE
Streamline chunked io.

### DIFF
--- a/columnflow/columnar_util.py
+++ b/columnflow/columnar_util.py
@@ -1446,9 +1446,9 @@ def slice_across_chunks(
     entry_stop: int | None = None,
 ) -> ak.Array | np.ndarray:
     """
-    Loads multiple array chunks according to, concatenates them and returns the result. Each chunk is loaded by its own
-    slicing function in *slice_funcs* which receives the start and stop entry of the chunk to load. The total sizes of
-    the chunks are given in *sizes* and used for internal range calculation. By default, the full range of all chunks is
+    Loads multiple array chunks, concatenates them and returns the result. Each chunk is loaded by its own slicing
+    function in *slice_funcs* which receives the start and stop entry of the chunk to load. The total sizes of the
+    chunks are given in *sizes* and used for internal range calculation. By default, the full range of all chunks is
     loaded, but this can be limited by setting *entry_start* and *entry_stop* to the global start and stop entry to
     load, respectively.
 


### PR DESCRIPTION
As described in https://github.com/columnflow/columnflow/pull/788, this is the second step in the overall effort to allow the `{Calibrate,Select,Reduce}Events` tasks to read multiple nano input files.

This PR targets the IO part of this effort and does the following things:

- The `uproot_root` method now understands a list of uproot TTree's as inputs and reads/concatenates over multiple chunks if needed.
- Changed the `coffea_root` IO method to do exactly what `uproot_root` does, with the only difference that the nano schema is added using a new `attach_nano_schema` helper.
  - This is strictly necessary for the multi-source case as coffea's nano event arrays **cannot be concatenated**.
- Dropped the `coffea_parquet` and `dask_awkward_parquet` IO methods. They are not needed anymore.
  - As a result, `DaskArrayReader` is not needed any longer and thus removed.