### PR TITLE
Keep object level association when filling histograms

### DIFF
--- a/columnflow/hist_util.py
+++ b/columnflow/hist_util.py
@@ -33,6 +33,7 @@ def fill_hist(
     *,
     last_edge_inclusive: bool | None = None,
     fill_kwargs: dict[str, Any] | None = None,
+    **kwargs,
 ) -> None:
     """
     Fills a histogram *h* with data from an awkward array, numpy array or nested dictionary *data*. The data is assumed
@@ -95,9 +96,42 @@ def fill_hist(
 
     # actual conversion
     if convert:
-        arrays = ak.flatten(ak.cartesian(data))
-        data = {field: arrays[field] for field in arrays.fields}
-        del arrays
+        if kwargs.get("var_associations", None):
+            var_associations = kwargs["var_associations"]
+            # build pairwise combinations for object level associated variables
+            for association in var_associations.keys():
+                # check that two or more variables are associated with each other
+                if len(var_associations[association]) < 2:
+                    raise logger.info(
+                        f"Variable '{var_associations[association][0]}' has unmatched association '{association}'"
+                        ", skipping association for this variable.",
+                    )
+                else:
+                    vars_to_zip = {}
+                    for var in var_associations[association]:
+                        vars_to_zip[var] = data.pop(var)
+                        associated_vars = ak.zip(vars_to_zip)
+                        data[association] = associated_vars
+
+            # build event level combinations of all axes
+            arrays = ak.cartesian(data)
+            # unpack the entries for the associated variables
+            unpacked_dict = {}
+            for field in arrays.fields:
+                if field not in var_associations.keys():
+                    unpacked_dict[field] = arrays[field]
+                else:
+                    for var in arrays[field].fields:
+                        unpacked_dict[var] = arrays[field][var]
+            unpacked_arrays = ak.zip(unpacked_dict)
+            # flatten
+            data = {field: ak.flatten(unpacked_arrays[field]) for field in unpacked_arrays.fields}
+            del arrays, unpacked_arrays
+
+        else:
+            arrays = ak.flatten(ak.cartesian(data))
+            data = {field: arrays[field] for field in arrays.fields}
+            del arrays
 
     # fill
     h.fill(**fill_kwargs, **data)

--- a/columnflow/hist_util.py
+++ b/columnflow/hist_util.py
@@ -102,7 +102,7 @@ def fill_hist(
             for association in var_associations.keys():
                 # check that two or more variables are associated with each other
                 if len(var_associations[association]) < 2:
-                    raise logger.info(
+                    logger.info(
                         f"Variable '{var_associations[association][0]}' has unmatched association '{association}'"
                         ", skipping association for this variable.",
                     )

--- a/columnflow/hist_util.py
+++ b/columnflow/hist_util.py
@@ -110,8 +110,8 @@ def fill_hist(
                     vars_to_zip = {}
                     for var in var_associations[association]:
                         vars_to_zip[var] = data.pop(var)
-                        associated_vars = ak.zip(vars_to_zip)
-                        data[association] = associated_vars
+
+                    data[association] = ak.zip(vars_to_zip)
 
             # build event level combinations of all axes
             arrays = ak.cartesian(data)

--- a/columnflow/histogramming/__init__.py
+++ b/columnflow/histogramming/__init__.py
@@ -239,11 +239,11 @@ class HistProducer(TaskArrayFunctionWithProducerRequirements):
         """
         return self.create_hist_func(variables, task=task)
 
-    def run_fill_hist(self, h: Any, data: dict[str, Any], task: law.Task) -> None:
+    def run_fill_hist(self, h: Any, data: dict[str, Any], task: law.Task, **kwargs) -> None:
         """
         Invokes the :py:meth:`fill_hist_func` of this instance and returns its result, forwarding all arguments.
         """
-        return self.fill_hist_func(h, data, task=task)
+        return self.fill_hist_func(h, data, task=task, **kwargs)
 
     def run_post_process_hist(self, h: Any, task: law.Task) -> Any:
         """

--- a/columnflow/histogramming/default.py
+++ b/columnflow/histogramming/default.py
@@ -58,11 +58,11 @@ def cf_default_create_hist(
 
 
 @cf_default.fill_hist
-def cf_default_fill_hist(self: HistProducer, h: hist.Hist, data: dict[str, Any], task: law.Task) -> None:
+def cf_default_fill_hist(self: HistProducer, h: hist.Hist, data: dict[str, Any], task: law.Task, **kwargs) -> None:
     """
     Fill the histogram with the data.
     """
-    fill_hist(h, data, last_edge_inclusive=task.last_edge_inclusive)
+    fill_hist(h, data, last_edge_inclusive=task.last_edge_inclusive, **kwargs)
 
 
 @cf_default.post_process_hist

--- a/columnflow/plotting/plot_functions_2d.py
+++ b/columnflow/plotting/plot_functions_2d.py
@@ -173,7 +173,7 @@ def plot_2d(
             "loc": "upper right",
         },
         "cms_label_cfg": {
-            "lumi": round(0.001 * config_inst.x.luminosity.get("nominal"), 1),  # /pb -> /fb
+            "lumi": round(0.001 * config_inst.x.luminosity.get("nominal")),  # /pb -> /fb
             "com": config_inst.campaign.ecm,
         },
         "plot2d_cfg": {
@@ -227,11 +227,11 @@ def plot_2d(
         label_options = {
             "wip": "Work in progress",
             "pre": "Preliminary",
-            "pw": "Private work",
+            "pw": "Private work (CMS data/simulation)",
             "sim": "Simulation",
             "simwip": "Simulation work in progress",
             "simpre": "Simulation preliminary",
-            "simpw": "Simulation private work",
+            "simpw": "Private work (CMS simulation)",
             "od": "OpenData",
             "odwip": "OpenData work in progress",
             "odpw": "OpenData private work",
@@ -242,6 +242,7 @@ def plot_2d(
             "llabel": label_options.get(cms_label, cms_label),
             "fontsize": 22,
             "data": False,
+            "exp": "",
         }
 
         cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
@@ -265,6 +266,8 @@ def plot_2d(
     with patch.object(plt, "colorbar", partial(plt.colorbar, extend=extend)):
         h_sum.plot2d(ax=ax, **style_config["plot2d_cfg"])
 
+    # ax.set_xlim(0, 2)
+    # ax.set_ylim(0, 250)
     # fix color bar minor ticks with SymLogNorm
     if isinstance(cbar_norm, mpl.colors.SymLogNorm):
         # returned collections can vary -> brute-force set

--- a/columnflow/plotting/plot_functions_2d.py
+++ b/columnflow/plotting/plot_functions_2d.py
@@ -173,7 +173,7 @@ def plot_2d(
             "loc": "upper right",
         },
         "cms_label_cfg": {
-            "lumi": round(0.001 * config_inst.x.luminosity.get("nominal")),  # /pb -> /fb
+            "lumi": round(0.001 * config_inst.x.luminosity.get("nominal"), 1),  # /pb -> /fb
             "com": config_inst.campaign.ecm,
         },
         "plot2d_cfg": {
@@ -227,11 +227,11 @@ def plot_2d(
         label_options = {
             "wip": "Work in progress",
             "pre": "Preliminary",
-            "pw": "Private work (CMS data/simulation)",
+            "pw": "Private work",
             "sim": "Simulation",
             "simwip": "Simulation work in progress",
             "simpre": "Simulation preliminary",
-            "simpw": "Private work (CMS simulation)",
+            "simpw": "Simulation private work",
             "od": "OpenData",
             "odwip": "OpenData work in progress",
             "odpw": "OpenData private work",
@@ -242,7 +242,6 @@ def plot_2d(
             "llabel": label_options.get(cms_label, cms_label),
             "fontsize": 22,
             "data": False,
-            "exp": "",
         }
 
         cms_label_kwargs.update(style_config.get("cms_label_cfg", {}))
@@ -266,8 +265,6 @@ def plot_2d(
     with patch.object(plt, "colorbar", partial(plt.colorbar, extend=extend)):
         h_sum.plot2d(ax=ax, **style_config["plot2d_cfg"])
 
-    # ax.set_xlim(0, 2)
-    # ax.set_ylim(0, 250)
     # fix color bar minor ticks with SymLogNorm
     if isinstance(cbar_norm, mpl.colors.SymLogNorm):
         # returned collections can vary -> brute-force set

--- a/columnflow/tasks/histograms.py
+++ b/columnflow/tasks/histograms.py
@@ -306,7 +306,14 @@ class CreateHistograms(_CreateHistograms):
                         "shift": self.global_shift_inst.id,
                         "weight": masked_weights,
                     }
+                    associations = {}
                     for variable_inst in variable_insts:
+                        if variable_inst.x("associated_with", False):
+                            if variable_inst.x("associated_with") in associations.keys():
+                                associations[variable_inst.x("associated_with")].append(variable_inst.name)
+                            else:
+                                associations[variable_inst.x("associated_with")] = [variable_inst.name]
+
                         # prepare the expression
                         expr = variable_inst.expression
                         if isinstance(expr, str):
@@ -319,7 +326,12 @@ class CreateHistograms(_CreateHistograms):
                         fill_data[variable_inst.name] = expr(masked_events)
 
                     # let the hist producer fill it
-                    self.hist_producer_inst.run_fill_hist(histograms[var_key], fill_data, task=self)
+                    self.hist_producer_inst.run_fill_hist(
+                        histograms[var_key],
+                        fill_data,
+                        task=self,
+                        var_associations=associations,
+                    )
 
         # post-process the histograms
         for var_key in self.variable_tuples.keys():


### PR DESCRIPTION
When filling histograms, currently ak.cartesian is used to build all combinations between all entries of an event. This is not an issue when plotting individual or event level variables. When plotting something like Jets pt vs Jets eta for all Jets, however, this counts all combinations of Jets pt and eta values, loosing the association between the two properties and effectively double counting of the events.
For two test variables with test_var1 = [0, 1] and test_var2 = [1, 3] for each event this results in [this plot](https://github.com/user-attachments/files/25844481/plot__proc_qcd__cat_incl__var_test_var1-test_var2.pdf), where all combinations are plotted.

This PR allows the addition of an entry called association in the variable auxillaries:
```
config.add_variable(
        name="test_var1",
        expression="test_var1",
        binning=(10, -5, 5),
        x_title="Test variable 1",
        aux={
            "associated_with": "test_vars",
        },
    )
```
When filling the histograms, if two or more variables with the same association exist, the only the pairwise combination of the associated entries are build, and then later combined with the usual axes (category, shift, process, etc...).
For the two test variables this now yields this [this new plot](https://github.com/user-attachments/files/25844596/plot__proc_qcd__cat_incl__var_test_var1-test_var2_diag.pdf), with only the diagonal entries filled.


