### PR TITLE
efficiency information from muon correctionlib files

### DIFF
--- a/columnflow/production/cms/muon.py
+++ b/columnflow/production/cms/muon.py
@@ -122,9 +122,9 @@ def muon_weights(
 
         # optionally update variables for this corrector call
         if callable(self.update_corrector_variables):
-            _variable_map = self.update_corrector_variables(corrector, _variable_map)
+            _variable_map = self.update_corrector_variables(self.muon_sf_corrector, _variable_map)
 
-        inputs = [variable_map_syst[inp.name] for inp in self.muon_sf_corrector.inputs]
+        inputs = [_variable_map[inp.name] for inp in self.muon_sf_corrector.inputs]
         sf = self.muon_sf_corrector.evaluate(*inputs)
 
         # create the product over all muons in one event


### PR DESCRIPTION
Somewhat annyoing issue: the MUO POG files do not contain any efficiency information. Therefore, while this PR does not change anything to the until now functioning system of retrieval of sfs from the MUO POG files, the additional functionality given by this PR is based on custom files provided by specific groups and do not correspond to a general MUO POG policy. Would a new muon producer in the specific analysis be preferred in this case @riga ? 