### PR TITLE
Fix typo in plot function.

### DIFF
--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -327,7 +327,7 @@ def plot_shifted_variable(
     if legend_title:
         default_style_config["legend_cfg"]["title"] = legend_title
     if shape_norm:
-        style_config["ax_cfg"]["ylabel"] = "Normalized entries"
+        default_style_config["ax_cfg"]["ylabel"] = "Normalized entries"
     style_config = law.util.merge_dicts(
         default_style_config,
         process_style_config,


### PR DESCRIPTION
This PR fixes the `plot_shifted_variable` plot function by calling the `default_style_config` in all places.