### PR TITLE
Report access of central LFNs to rucio bookkeeping server

### DIFF
--- a/analysis_templates/cms_minimal/law.cfg
+++ b/analysis_templates/cms_minimal/law.cfg
@@ -197,6 +197,7 @@ cache_cleanup: $CF_WLCG_CACHE_CLEANUP
 cache_max_size: 15GB
 cache_global_lock: True
 cache_mtime_patience: -1
+rucio_report_access: True
 
 
 [wlcg_fs_global_redirector]
@@ -208,3 +209,4 @@ cache_cleanup: $CF_WLCG_CACHE_CLEANUP
 cache_max_size: 15GB
 cache_global_lock: True
 cache_mtime_patience: -1
+rucio_report_access: True

--- a/columnflow/tasks/external.py
+++ b/columnflow/tasks/external.py
@@ -17,11 +17,11 @@ import luigi
 import law
 import order as od
 
-from columnflow import env_is_local
+from columnflow import env_is_local, flavor as cf_flavor
 from columnflow.tasks.framework.base import AnalysisTask, ConfigTask, DatasetTask, wrapper_factory
 from columnflow.tasks.framework.parameters import user_parameter_inst
 from columnflow.tasks.framework.decorators import only_local_env
-from columnflow.util import wget, DotDict
+from columnflow.util import wget, DotDict, UNSET
 from columnflow.types import Sequence, ClassVar
 
 
@@ -281,6 +281,32 @@ class GetDatasetLFNs(DatasetTask, law.tasks.TransferLocalFile):
             # log the file size
             input_size = law.util.human_bytes(input_stat.st_size, fmt=True)
             task.publish_message(f"lfn {lfn} (lfn {lfn_index}), size is {input_size}")
+
+            # when cf is run in cms flavor, access to central files must be reported to a database for bookkeeping
+            if cf_flavor == "cms":
+                # the selected fs must have an option "rucio_report_access" in the config, which should be either a bool
+                # or the site name (rse) to report the access for
+                report_key = "rucio_report_access"
+                report_val = law.config.get_expanded(selected_fs, report_key, default=UNSET)
+                if report_val is UNSET:
+                    raise Exception(
+                        f"configuration section for selected fs '{selected_fs}' is missing an entry '{report_key}' "
+                        "which should be either a boolean flag or the name of a site (rse) to report the access for; "
+                        "this is required for reporting access to central files which is necessary for CMS bookkeeping",
+                    )
+                # check if the value is a bool, and otherwise assume a valid rse name
+                rse = None
+                try:
+                    report_val = law.config.Config.instance()._convert_to_boolean(report_val)
+                except ValueError:
+                    rse = report_val
+                    if not law.cms.Site.validate(rse):
+                        raise ValueError(
+                            f"entry '{report_key}' for selected fs '{selected_fs}' does not refer to a valid site ",
+                            f"name: {rse}",
+                        )
+                if report_val:
+                    law.cms.rucio_report_access(lfn, rse=rse)
 
             yield (lfn_index, input_file)
 

--- a/law.cfg
+++ b/law.cfg
@@ -214,6 +214,7 @@ cache_cleanup: $CF_WLCG_CACHE_CLEANUP
 cache_max_size: 15GB
 cache_global_lock: True
 cache_mtime_patience: -1
+rucio_report_access: T2_DE_DESY
 
 
 [wlcg_fs_infn_redirector]
@@ -225,6 +226,7 @@ cache_cleanup: $CF_WLCG_CACHE_CLEANUP
 cache_max_size: 15GB
 cache_global_lock: True
 cache_mtime_patience: -1
+rucio_report_access: True
 
 
 [wlcg_fs_fnal_redirector]
@@ -236,6 +238,7 @@ cache_cleanup: $CF_WLCG_CACHE_CLEANUP
 cache_max_size: 15GB
 cache_global_lock: True
 cache_mtime_patience: -1
+rucio_report_access: True
 
 
 [wlcg_fs_global_redirector]
@@ -247,6 +250,7 @@ cache_cleanup: $CF_WLCG_CACHE_CLEANUP
 cache_max_size: 15GB
 cache_global_lock: True
 cache_mtime_patience: -1
+rucio_report_access: True
 
 
 [luigi_core]

--- a/sandboxes/columnar.txt
+++ b/sandboxes/columnar.txt
@@ -1,4 +1,4 @@
-# version 18
+# version 19
 
 # exact versions for core array packages
 awkward==2.8.9
@@ -8,6 +8,7 @@ correctionlib==2.7.0
 coffea==2025.9.0
 
 # minimum versions for general packages
+rucio~=40.3.0
 zstandard~=0.25.0
 lz4~=4.4.4
 xxhash~=3.5.0

--- a/setup.sh
+++ b/setup.sh
@@ -277,8 +277,22 @@ cf_setup_common_variables() {
         export LC_ALL="${LC_ALL:-en_US.UTF-8}"
     fi
 
-    # proxy
+    # variables for external tools and libraries
+    export PYTHONWARNINGS="${PYTHONWARNINGS:-ignore}"
+    export PYTHONNOUSERSITE="${PYTHONNOUSERSITE:-1}"
+    export GLOBUS_THREAD_MODEL="${GLOBUS_THREAD_MODEL:-none}"
+    export VIRTUAL_ENV_DISABLE_PROMPT="${VIRTUAL_ENV_DISABLE_PROMPT:-1}"
+    export MYPROXY_SERVER="${MYPROXY_SERVER:-myproxy.cern.ch}"
     export X509_USER_PROXY="${X509_USER_PROXY:-/tmp/x509up_u$( id -u )}"
+    export X509_CERT_DIR="${X509_CERT_DIR:-/cvmfs/grid.cern.ch/etc/grid-security/certificates}"
+    export X509_VOMS_DIR="${X509_VOMS_DIR:-/cvmfs/grid.cern.ch/etc/grid-security/vomsdir}"
+    export X509_VOMSES="${X509_VOMSES:-/cvmfs/grid.cern.ch/etc/grid-security/vomses}"
+    export VOMS_USERCONF="${VOMS_USERCONF:-${X509_VOMSES}}"
+    ulimit -s unlimited
+    if [ "${CF_FLAVOR}" = "cms" ]; then
+        export RUCIO_ACCOUNT="${RUCIO_ACCOUNT:-${CF_CERN_USER}}"
+        export RUCIO_HOME="${RUCIO_HOME:-"/cvmfs/cms.cern.ch/rucio/x86_64/rhel9/py3/current"}"
+    fi
 
     # overwrite some variables in remote and ci jobs
     if ${CF_REMOTE_ENV}; then
@@ -312,15 +326,17 @@ cf_setup_common_variables() {
     export CF_SLURM_FLAVOR="${CF_SLURM_FLAVOR:-${cf_slurm_flavor_default}}"
     export CF_SLURM_PARTITION="${CF_SLURM_PARTITION:-${cf_slurm_partition_default}}"
 
+    # notification variables
+    export CF_MATTERMOST_HOOK_URL="${CF_MATTERMOST_HOOK_URL:-}"
+    export CF_MATTERMOST_CHANNEL="${CF_MATTERMOST_CHANNEL:-}"
+
     # show a warning in case no CF_REPO_BASE_ALIAS is set
     if [ -z "${CF_REPO_BASE_ALIAS}" ]; then
         cf_color yellow "the variable CF_REPO_BASE_ALIAS is unset"
         cf_color yellow "please consider setting it to the name of the variable that refers to your analysis base directory"
     fi
 
-    # notification variables
-    export CF_MATTERMOST_HOOK_URL="${CF_MATTERMOST_HOOK_URL:-}"
-    export CF_MATTERMOST_CHANNEL="${CF_MATTERMOST_CHANNEL:-}"
+    return "0"
 }
 
 cf_show_banner() {
@@ -599,19 +615,9 @@ cf_setup_software_stack() {
     export CF_CONDA_PYTHONPATH="${CF_CONDA_BASE}/lib/python${CF_PYTHON_VERSION}/site-packages"
     export PYTHONPATH="${PYTHONPATH}:${CF_CONDA_PYTHONPATH}"
 
-    # update paths and flags
+    # update mamba variables
     export MAMBA_ROOT_PREFIX="${CF_CONDA_BASE}"
     export MAMBA_EXE="${MAMBA_ROOT_PREFIX}/bin/micromamba"
-    export PYTHONWARNINGS="${PYTHONWARNINGS:-ignore}"
-    export PYTHONNOUSERSITE="${PYTHONNOUSERSITE:-1}"
-    export GLOBUS_THREAD_MODEL="${GLOBUS_THREAD_MODEL:-none}"
-    export VIRTUAL_ENV_DISABLE_PROMPT="${VIRTUAL_ENV_DISABLE_PROMPT:-1}"
-    export MYPROXY_SERVER="${MYPROXY_SERVER:-myproxy.cern.ch}"
-    export X509_CERT_DIR="${X509_CERT_DIR:-/cvmfs/grid.cern.ch/etc/grid-security/certificates}"
-    export X509_VOMS_DIR="${X509_VOMS_DIR:-/cvmfs/grid.cern.ch/etc/grid-security/vomsdir}"
-    export X509_VOMSES="${X509_VOMSES:-/cvmfs/grid.cern.ch/etc/grid-security/vomses}"
-    export VOMS_USERCONF="${VOMS_USERCONF:-${X509_VOMSES}}"
-    ulimit -s unlimited
 
     #
     # setup in local envs (not remote)


### PR DESCRIPTION
This PR adds a mechanism to report the access of central nanoAOD files to the rucio bookkeeping server as requested in #802.

- The actual server communication is done by a new cms-specific util in law.
- In cf, this util is invoked in the central method that provides the locations of nanoAOD files, `GetDatasetLFNs.iter_nano_files()`, before they are opened and traversed.

**Important**

Whether or not the file access should be reported or not (and if, which site this request should be reported for), depends on the origin of the nanoAOD file. If it is a custom file, the reporting obviously does not need to be triggered. For central locations, this is necessary though.

❗️From now on, this needs to be configured in the law.cfg under the relevant section for the file system that serves the lfn in question. The sections are required to have an entry `rucio_report_access` which should either be `True`, `False` or the name of a site (e.g. `T2_DE_DESY`). An issue is raised if this field is missing.

**Examples**

```ini
[wlcg_fs_desy_store]
base: davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2
rucio_report_access: T2_DE_DESY
... other settings



[wlcg_fs_infn_redirector]
base: root://xrootd-cms.infn.it
rucio_report_access: True
... other settings
```

Closes #802.

@Lara813 @jomatthi @mafrahm @LennertGriesing 