### PR TITLE
Extend pdf and alphas weights

### DIFF
--- a/columnflow/inference/__init__.py
+++ b/columnflow/inference/__init__.py
@@ -6,7 +6,6 @@ Basic objects for defining statistical inference models.
 
 from __future__ import annotations
 
-import enum
 import copy as _copy
 
 import law
@@ -15,7 +14,7 @@ import yaml
 
 from columnflow.types import Generator, Callable, TextIO, Sequence, Any, Hashable, Type, T
 from columnflow.util import (
-    CachedDerivableMeta, Derivable, DotDict, is_pattern, is_regex, pattern_matcher, get_docs_url, freeze,
+    CachedDerivableMeta, Derivable, DotDict, is_pattern, is_regex, pattern_matcher, get_docs_url, freeze, StrEnum,
 )
 
 
@@ -24,7 +23,7 @@ logger = law.logger.get_logger(__name__)
 default_dataset = law.config.get_expanded("analysis", "default_dataset")
 
 
-class ParameterType(enum.Enum):
+class ParameterType(StrEnum):
     """
     Parameter type flag.
 
@@ -38,12 +37,6 @@ class ParameterType(enum.Enum):
     rate_uniform = "rate_uniform"
     rate_unconstrained = "rate_unconstrained"
     shape = "shape"
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}.{self.value}>"
-
-    def __str__(self) -> str:
-        return self.value
 
     @property
     def is_rate(self) -> bool:
@@ -70,7 +63,7 @@ class ParameterType(enum.Enum):
         }
 
 
-class ParameterTransformation(enum.Enum):
+class ParameterTransformation(StrEnum):
     """
     Flags denoting transformations to be applied on parameters.
 
@@ -122,12 +115,6 @@ class ParameterTransformation(enum.Enum):
     envelope_enforce_two_sided = "envelope_enforce_two_sided"
     flip_smaller_if_one_sided = "flip_smaller_if_one_sided"
     flip_larger_if_one_sided = "flip_larger_if_one_sided"
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}.{self.value}>"
-
-    def __str__(self) -> str:
-        return self.value
 
     @property
     def from_shape(self) -> bool:
@@ -198,7 +185,7 @@ class ParameterTransformations(tuple):
         return any(t.from_rate for t in self)
 
 
-class FlowStrategy(enum.Enum):
+class FlowStrategy(StrEnum):
     """
     Strategy to handle over- and underflow bin contents.
 
@@ -212,9 +199,6 @@ class FlowStrategy(enum.Enum):
     warn = "warn"
     remove = "remove"
     move = "move"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 class InferenceModelMeta(CachedDerivableMeta):

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -32,6 +32,7 @@ fill_at_f32 = functools.partial(fill_at, value_type=np.float32)
     store_all_weights=False,
     # only run on mc
     mc_only=True,
+    store_split_sets=False,
 )
 def pdf_weights(
     self: Producer,
@@ -141,7 +142,37 @@ def pdf_weights(
 
     # store all weights if requested, then finish
     if self.store_all_weights:
-        return set_ak_column_f32(events, "pdf_weights", pdf_weights)
+        if self.store_split_sets:
+            # mask: valid events with alpha_s weights
+            has_alphas = (n_weights == 103) & (~invalid_mask)
+
+            # log if mixed content (valid events missing alpha_s)
+            if not ak.all(has_alphas | invalid_mask):
+                frac = ak.sum(has_alphas) / len(events) * 100
+                logger.warning(
+                    f"in dataset {self.dataset_inst.name}, only {frac:.2f}% of the events have valid "
+                    f"alpha_s weights; missing ones will be filled with 1",
+                )
+
+            # store hessian weights
+            events = set_ak_column_f32(events, "pdf_weights_hessian", pdf_weights)
+
+            # prepare default alpha_s weights (2 variations), filled with 1 when missing
+            ones_alphas = ak.ones_like(events.LHEPdfWeight[:, :2], dtype=np.float32)
+
+            # extract alpha_s weights where available, otherwise fill with ones
+            alphas_weights = ak.where(
+                has_alphas,
+                ak.without_parameters(events.LHEPdfWeight[:, 101:103]) / pdf_weight_nominal,
+                ones_alphas,
+            )
+
+            events = set_ak_column_f32(events, "pdf_weights_alphas", alphas_weights)
+
+        else:
+            events = set_ak_column_f32(events, "pdf_weights", pdf_weights)
+
+        return events
 
     # below this point, the weights are combined per-event into single up/down variations
 
@@ -201,8 +232,21 @@ def pdf_weights(
 
 @pdf_weights.init
 def pdf_weight_init(self: Producer, **kwargs) -> None:
-    # add produced columns: nominal+all, or nominal+up+down
-    self.produces.add("pdf_weight{,s}" if self.store_all_weights else "pdf_weight{,_up,_down}")
+    # add produced columns: nominal+all, nominal+up+down or nominal + hessian/alpha_s
+    self.produces.add("pdf_weight")
+
+    if not self.store_all_weights:
+        self.produces.update({
+            "pdf_weight_up",
+            "pdf_weight_down",
+        })
+    elif self.store_split_sets:
+        self.produces.update({
+            "pdf_weights_hessian",
+            "pdf_weights_alphas",
+        })
+    else:
+        self.produces.add("pdf_weights")
 
 
 def _raise_unknown_action(attr: str, action: str, known_actions: tuple[str]) -> None:

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -11,7 +11,7 @@ import functools
 import law
 
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import
+from columnflow.util import maybe_import, StrEnum
 from columnflow.columnar_util import set_ak_column, full_like, fill_at
 
 np = maybe_import("numpy")
@@ -25,14 +25,30 @@ set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 fill_at_f32 = functools.partial(fill_at, value_type=np.float32)
 
 
+def _raise_unknown_action(attr: str, action: str, known_actions: tuple[str]) -> None:
+    if action not in known_actions:
+        raise ValueError(f"unknown {attr} '{action}', known values are {','.join(known_actions)}")
+
+
+class PDFWeightOutput(StrEnum):
+    """
+    Flag to denote which type of weights to output in the :py:class:`pdf_weights` producer. Options:
+
+        - ``combined``: Produces `pdf_weight{,_up,_down}`, applying some algorithm per event to combine all weights into
+            an up/down variation pair.
+        - ``raw``: Produces all `pdf_weights_{hessian,alphas}`.
+    """
+
+    combined = "combined"
+    raw = "raw"
+
+
 @producer(
     uses={"LHEPdfWeight"},
-    # produced columns depend on store_all_weights and are added in the init
-    # whether to store all weights, or to compute nominal and varied weights per-event
-    store_all_weights=False,
+    # which types of weights to produce (influences produced columns, defined in init)
+    pdf_weight_output=PDFWeightOutput.raw,
     # only run on mc
     mc_only=True,
-    store_split_sets=False,
 )
 def pdf_weights(
     self: Producer,
@@ -44,31 +60,26 @@ def pdf_weights(
     **kwargs,
 ) -> ak.Array:
     """
-    Producer that determines and stores pdf weights with different methods. When
-    *store_all_weights* is *False*, the nominal weight and its up and down variations are computed
-    on an event-by-event basis. Otherwise, the nominal and all pdf set weights (normalized to the
-    nominal one) are stored.
+    Producer that determines and stores pdf weights with different methods.
 
-    For the per-event evaluation, the producer assumes that the nominal entry is always the first
-    LHEPdfWeight value and that the nominal weight is already included in the LHEWeight.
-    It can only be called with MC datasets.
+    The producer assumes that the nominal entry is always the first LHEPdfWeight value and that the nominal weight is
+    already included in the LHEWeight. It can only be called with MC datasets.
 
-    The *invalid_weights_action* defines the procedure of how to handle events with a an unexpected
-    number of pdf weights (not 101 or 103). Supported modes are:
+    The *invalid_weights_action* defines the procedure of how to handle events with a an unexpected number of pdf
+    weights (not 101 or 103). Supported modes are:
 
         - ``"raise"``: an exception is raised
         - ``"ignore"``: nominal weight is set to one, up/down weights too if not storing all weights
             and an empty vector for all weights otherwise
 
-    The *outlier_action* defines the procedure of how to handle events with a pdf
-    uncertainty above the *outlier_threshold*. Supported modes are:
+    The *outlier_action* defines the procedure of how to handle events with a pdf uncertainty above the
+    *outlier_threshold*. Supported modes are:
 
         - ``"ignore"``: events are kept unmodified
         - ``"remove"``: pdf weight nominal/up/down are all set to 0
         - ``"raise"``: an exception is raised
 
-    Additionally, the verbosity of the procedure can be set with *outlier_log_mode*,
-    which offers the following options:
+    Additionally, the verbosity of the procedure can be set with *outlier_log_mode*, which offers the following options:
 
         - ``"none"``: no message is given
         - ``"info"``: a `logger.info` message is given
@@ -76,7 +87,6 @@ def pdf_weights(
         - ``"warning"``: a `logger.warning` message is given
 
     Resources:
-
         - https://arxiv.org/pdf/1510.03865.pdf
     """
     _raise_unknown_action("invalid_weights_action", invalid_weights_action, ("ignore", "raise"))
@@ -92,8 +102,8 @@ def pdf_weights(
         bad_values = ",".join(map(str, set(n_weights[invalid_mask])))
         frac = ak.mean(invalid_mask)
         raise ValueError(
-            f"the number of LHEPdfWeights is expected to be 101 or 103, but also found numbers of "
-            f"'{bad_values}' in {frac * 100:.1f}% of events in dataset {self.dataset_inst.name}",
+            f"the number of LHEPdfWeights is expected to be 101 or 103, but also found numbers of '{bad_values}' in "
+            f"{frac * 100:.1f}% of events in dataset {self.dataset_inst.name}",
         )
 
     # write ones in case there are no weights at all
@@ -101,13 +111,13 @@ def pdf_weights(
     empty = full_like(events.LHEPdfWeight[:, :0], 0)
     if ak.all(invalid_mask):
         logger.warning("no 'LHEPdfWeight' vector with correct length found, setting weights to 1")
-        if self.store_all_weights:
-            events = set_ak_column_f32(events, "pdf_weights", empty)
-            events = set_ak_column_f32(events, "pdf_weight", ones)
-        else:
+        if self.pdf_weight_output == PDFWeightOutput.combined:
             events = set_ak_column_f32(events, "pdf_weight", ones)
             events = set_ak_column_f32(events, "pdf_weight_up", ones)
             events = set_ak_column_f32(events, "pdf_weight_down", ones)
+        else:
+            events = set_ak_column_f32(events, "pdf_weights_hessian", empty)
+            events = set_ak_column_f32(events, "pdf_weights_alphas", empty)
         return events
 
     # complain when the number of weights is unexpected
@@ -115,9 +125,8 @@ def pdf_weights(
         bad_values = ",".join(map(str, set(n_weights[invalid_mask])))
         frac = ak.sum(invalid_mask) / len(events) * 100
         logger.warning(
-            "the number of LHEPdfWeights is expected to be 101 or 103, but also found values "
-            f"'{bad_values}' in dataset {self.dataset_inst.name}, will set pdf weights to 1 for "
-            f"these events ({frac:.2f}%)",
+            f"the number of LHEPdfWeights is expected to be 101 or 103, but also found values '{bad_values}' in "
+            f"dataset '{self.dataset_inst.name}', will set pdf weights to 1 for these events ({frac:.2f}%)",
         )
 
     # log a message if nominal != 1
@@ -126,106 +135,91 @@ def pdf_weights(
     if ak.any(pdf_weight_nominal != 1):
         bad_values = ",".join(map(str, set(pdf_weight_nominal[pdf_weight_nominal != 1])))
         logger.debug(
-            "the nominal LHEPdfWeight is expected to be 1 but also found values "
-            f"'{bad_values}' in dataset {self.dataset_inst.name}; all variations will be "
-            "normalized to the nominal LHEPdfWeight and it is assumed that the nominal "
-            "weight is already included in the LHEWeight.",
+            f"the nominal LHEPdfWeight is expected to be 1 but also found values '{bad_values}' in dataset "
+            f"'{self.dataset_inst.name}'; all variations will be normalized to the nominal LHEPdfWeight and it is "
+            "assumed that the nominal weight is already included in the LHEWeight",
         )
 
-    # normalize all 100 weights by the nominal one, assumed to be the first value
-    # (for datasets with 103 weights, the last two weights are related to alpha_s variations)
-    pdf_weights = ak.where(invalid_mask, empty, ak.without_parameters(events.LHEPdfWeight[:, 1:101]))
+    # normalize all weights by the nominal one
+    pdf_weights = ak.where(invalid_mask, empty, ak.without_parameters(events.LHEPdfWeight[:, 1:]))
     pdf_weights = pdf_weights / pdf_weight_nominal
 
-    # store the nominal weight which is always 1 after normalization
-    events = set_ak_column_f32(events, "pdf_weight", ones)
+    if self.pdf_weight_output == PDFWeightOutput.combined:
+        # store the nominal weight which is always 1 after normalization
+        events = set_ak_column_f32(events, "pdf_weight", ones)
 
-    # store all weights if requested, then finish
-    if self.store_all_weights:
-        if self.store_split_sets:
-            # mask: valid events with alpha_s weights
-            has_alphas = (n_weights == 103) & (~invalid_mask)
+        # no treatment of alphas weights for the combined treatment, so only consider the first 100 variations
+        pdf_weights = pdf_weights[:, :100]
 
-            # log if mixed content (valid events missing alpha_s)
-            if not ak.all(has_alphas | invalid_mask):
-                frac = ak.sum(has_alphas) / len(events) * 100
-                logger.warning(
-                    f"in dataset {self.dataset_inst.name}, only {frac:.2f}% of the events have valid "
-                    f"alpha_s weights; missing ones will be filled with 1",
-                )
+        # PDF uncertainty as half the width of the central 68% CL
+        pdf_weights = ak.sort(pdf_weights, axis=1)
+        stddev = (pdf_weights[:, 83:84] - pdf_weights[:, 15:16]) / 2
+        stddev = ak.fill_none(ak.pad_none(stddev, 1, axis=1, clip=True), 0)[:, 0]
+        stddev = ak.values_astype(ak.where(invalid_mask, 0, stddev), np.float32)
 
-            # store hessian weights
-            events = set_ak_column_f32(events, "pdf_weights_hessian", pdf_weights)
+        # store columns
+        events = set_ak_column_f32(events, "pdf_weight_up", 1 + stddev)
+        events = set_ak_column_f32(events, "pdf_weight_down", 1 - stddev)
 
-            # prepare default alpha_s weights (2 variations), filled with 1 when missing
-            ones_alphas = ak.ones_like(events.LHEPdfWeight[:, :2], dtype=np.float32)
+        # handle outliers by identifying large, relative variations
+        if ak.any(outlier_mask := stddev > outlier_threshold):
+            occurances = ak.sum(outlier_mask)
+            frac = occurances / len(stddev) * 100
+            msg = (
+                f"in dataset {self.dataset_inst.name}, there are {occurances} ({frac:.2f}%) entries with pdf "
+                f"uncertainty above {outlier_threshold * 100:.0f}%"
+            )
+            if outlier_action == "raise":
+                raise Exception(msg)
+            if outlier_action == "remove":
+                # set all pdf weights to 0 when the *outlier_threshold* is passed
+                events = fill_at_f32(events, outlier_mask, "pdf_weight", 0)
+                events = fill_at_f32(events, outlier_mask, "pdf_weight_up", 0)
+                events = fill_at_f32(events, outlier_mask, "pdf_weight_down", 0)
+                msg += "; the nominal/up/down pdf_weight columns have been set to 0 for these events"
+            # trigger a specific log
+            msg_func = {
+                "none": lambda msg: None,
+                "info": logger.info,
+                "warning": logger.warning,
+                "debug": logger.debug,
+            }[outlier_log_mode]
+            msg_func(msg)
 
-            # extract alpha_s weights where available, otherwise fill with ones
-            alphas_weights = ak.where(
-                has_alphas,
-                ak.without_parameters(events.LHEPdfWeight[:, 101:103]) / pdf_weight_nominal,
-                ones_alphas,
+        # handle invalid values
+        if ak.any(invalid_pdf_weight := pdf_weight_nominal == 0):
+            # set all pdf weights to 0 when the nominal pdf weight is 0
+            logger.warning(
+                f"in dataset {self.dataset_inst.name}, {ak.sum(invalid_pdf_weight)} nominal LHEPdfWeights with values "
+                "0 have been found; the nominal/up/down pdf_weight columns have been set to 0 for these events",
+            )
+            events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight", 0)
+            events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_up", 0)
+            events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_down", 0)
+
+    else:  # raw
+        # mask to select events with alphas weights
+        has_alphas = n_weights == 103
+
+        # log if events have pdf weights but miss alpha_s
+        if ak.any(~has_alphas):
+            frac_abs = float(ak.mean(has_alphas)) * 100
+            frac_rel = float(ak.mean(has_alphas[~invalid_mask])) * 100
+            logger.warning(
+                f"in dataset {self.dataset_inst.name}, only {frac_abs:.2f}% of the events have valid alpha_s weights "
+                f"({frac_rel:.2f}% of those with valid pf weights);  issing ones will be filled with 1",
             )
 
-            events = set_ak_column_f32(events, "pdf_weights_alphas", alphas_weights)
+        # store hessian weights
+        events = set_ak_column_f32(events, "pdf_weights_hessian", pdf_weights[:, :100])
 
-        else:
-            events = set_ak_column_f32(events, "pdf_weights", pdf_weights)
-
-        return events
-
-    # below this point, the weights are combined per-event into single up/down variations
-
-    # PDF uncertainty as half the width of the central 68% CL
-    pdf_weights = ak.sort(pdf_weights, axis=1)
-    stddev = (pdf_weights[:, 83:84] - pdf_weights[:, 15:16]) / 2
-    stddev = ak.fill_none(ak.pad_none(stddev, 1, axis=1, clip=True), 0)[:, 0]
-    stddev = ak.values_astype(ak.where(invalid_mask, 0, stddev), np.float32)
-
-    # store columns
-    events = set_ak_column_f32(events, "pdf_weight_up", 1 + stddev)
-    events = set_ak_column_f32(events, "pdf_weight_down", 1 - stddev)
-
-    # handle outliers by identifying large, relative variations
-    outlier_mask = (stddev > outlier_threshold)
-    if ak.any(outlier_mask):
-        occurances = ak.sum(outlier_mask)
-        frac = occurances / len(stddev) * 100
-        msg = (
-            f"in dataset {self.dataset_inst.name}, there are {occurances} ({frac:.2f}%) "
-            f"entries with pdf uncertainty above {outlier_threshold * 100:.0f}%"
-        )
-
-        if outlier_action == "remove":
-            # set all pdf weights to 0 when the *outlier_threshold* is passed
-            events = fill_at_f32(events, outlier_mask, "pdf_weight", 0)
-            events = fill_at_f32(events, outlier_mask, "pdf_weight_up", 0)
-            events = fill_at_f32(events, outlier_mask, "pdf_weight_down", 0)
-            msg += "; the nominal/up/down pdf_weight columns have been set to 0 for these events"
-
-        elif outlier_action == "raise":
-            raise Exception(msg)
-
-        msg_func = {
-            "none": lambda msg: None,
-            "info": logger.info,
-            "warning": logger.warning,
-            "debug": logger.debug,
-        }[outlier_log_mode]
-        msg_func(msg)
-
-    # handle invalid values
-    invalid_pdf_weight = (pdf_weight_nominal == 0)
-    if ak.any(invalid_pdf_weight):
-        # set all pdf weights to 0 when the nominal pdf weight is 0
-        logger.warning(
-            f"in dataset {self.dataset_inst.name}, {ak.sum(invalid_pdf_weight)} nominal "
-            "LHEPdfWeights with values 0 have been found; the nominal/up/down pdf_weight "
-            "columns have been set to 0 for these events",
-        )
-        events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight", 0)
-        events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_up", 0)
-        events = fill_at_f32(events, invalid_pdf_weight, "pdf_weight_down", 0)
+        # create and store alphas weights, filled with 1 when missing
+        alphas_weights = ak.where(
+            has_alphas,
+            pdf_weights[:, 100:102],
+            full_like(events.LHEPdfWeight[:, :2], 1.0, dtype=np.float32),
+        )[:, [0, 1]]
+        events = set_ak_column_f32(events, "pdf_weights_alphas", alphas_weights)
 
     return events
 
@@ -234,22 +228,13 @@ def pdf_weights(
 def pdf_weight_init(self: Producer, **kwargs) -> None:
     super(pdf_weights, self).init_func(**kwargs)
 
-    # add produced columns: nominal+all, nominal+up+down or nominal + hessian/alpha_s
-    self.produces.add("pdf_weight")
-    if not self.store_all_weights:
-        self.produces.update({
-            "pdf_weight_up",
-            "pdf_weight_down",
-        })
-    elif self.store_split_sets:
-        self.produces.update({
-            "pdf_weights_hessian",
-            "pdf_weights_alphas",
-        })
-    else:
-        self.produces.add("pdf_weights")
+    # add produced columns
+    if self.pdf_weight_output == PDFWeightOutput.combined:
+        self.produces.add(r"pdf_weight{,_up,_down}")
+    else:  # raw
+        self.produces.add(r"pdf_weights_{hessian,alphas}")
 
 
-def _raise_unknown_action(attr: str, action: str, known_actions: tuple[str]) -> None:
-    if action not in known_actions:
-        raise ValueError(f"unknown {attr} '{action}', known values are {','.join(known_actions)}")
+pdf_weights_raw = pdf_weights.derive("pdf_weights_raw", cls_dict={
+    "pdf_weight_output": PDFWeightOutput.raw,
+})

--- a/columnflow/production/cms/pdf.py
+++ b/columnflow/production/cms/pdf.py
@@ -46,7 +46,7 @@ class PDFWeightOutput(StrEnum):
 @producer(
     uses={"LHEPdfWeight"},
     # which types of weights to produce (influences produced columns, defined in init)
-    pdf_weight_output=PDFWeightOutput.raw,
+    pdf_weight_output=PDFWeightOutput.combined,
     # only run on mc
     mc_only=True,
 )

--- a/columnflow/production/cms/scale.py
+++ b/columnflow/production/cms/scale.py
@@ -4,13 +4,12 @@
 Column production methods related to the renormalization and factorization scales.
 """
 
-import enum
 import functools
 
 import law
 
 from columnflow.production import Producer, producer
-from columnflow.util import maybe_import, DotDict
+from columnflow.util import maybe_import, DotDict, StrEnum
 from columnflow.columnar_util import set_ak_column, ak_concatenate_safe
 
 np = maybe_import("numpy")
@@ -23,7 +22,7 @@ logger = law.logger.get_logger(__name__)
 set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 
 
-class ScaleWeightOutput(enum.Enum):
+class ScaleWeightOutput(StrEnum):
     """
     Flag to denote which type of weights to output in the :py:class:`murmuf_weights` producer. Options:
 
@@ -37,12 +36,6 @@ class ScaleWeightOutput(enum.Enum):
     correlated = "correlated"
     single_correlated = "single_correlated"
     raw = "raw"
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}.{self.value}>"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 @producer(

--- a/columnflow/util.py
+++ b/columnflow/util.py
@@ -12,6 +12,7 @@ import os
 import io
 import re
 import abc
+import enum
 import uuid
 import queue
 import threading
@@ -618,6 +619,15 @@ def get_source_code(obj: Any, indent: str | int = None) -> str:
         )
 
     return code
+
+
+class StrEnum(enum.Enum):
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}.{self.value}>"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class DotDict(OrderedDict):


### PR DESCRIPTION
Continuation of #799 to align configuration setting w.r.t. other producers.

@LennertGriesing The `pdf_weights_raw` producer (with `pdf_weight_output` set to `PDFWeightOutput.raw`) is producing exactly what you intended now.