### PR TITLE
Add --merge-stat-errors option to shift plots.

### DIFF
--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -20,7 +20,7 @@ from columnflow.plotting.plot_util import (
     remove_label_placeholders,
     apply_label_placeholders,
     calculate_stat_error,
-    hatch_styles,
+    HatchStyles,
     get_hatch_kwargs,
 )
 from columnflow.types import TYPE_CHECKING, Sequence
@@ -35,7 +35,7 @@ def draw_stat_error_bands(
     ax: plt.Axes,
     h: hist.Hist,
     norm: float | Sequence | np.ndarray = 1.0,
-    hatch_style: hatch_styles = "black",
+    hatch_style: HatchStyles = "black",
     **kwargs,
 ) -> None:
     assert len(h.axes) == 1
@@ -68,7 +68,7 @@ def draw_syst_error_bands(
     shift_insts: Sequence[od.Shift],
     norm: float | Sequence | np.ndarray = 1.0,
     method: str = "quadratic_sum",
-    hatch_style: hatch_styles = "green_backwards",
+    hatch_style: HatchStyles = "green_backwards",
     **kwargs,
 ) -> None:
     import hist

--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -20,6 +20,8 @@ from columnflow.plotting.plot_util import (
     remove_label_placeholders,
     apply_label_placeholders,
     calculate_stat_error,
+    hatch_styles,
+    get_hatch_kwargs,
 )
 from columnflow.types import TYPE_CHECKING, Sequence
 
@@ -33,6 +35,7 @@ def draw_stat_error_bands(
     ax: plt.Axes,
     h: hist.Hist,
     norm: float | Sequence | np.ndarray = 1.0,
+    hatch_style: hatch_styles = "black",
     **kwargs,
 ) -> None:
     assert len(h.axes) == 1
@@ -52,11 +55,7 @@ def draw_stat_error_bands(
         "bottom": baseline * (1 - rel_stat_error),
         "height": baseline * 2 * rel_stat_error,
         "width": h.axes[0].edges[1:] - h.axes[0].edges[:-1],
-        "hatch": "///",
-        "linewidth": 0,
-        "color": "none",
-        "edgecolor": "black",
-        "alpha": 1.0,
+        **get_hatch_kwargs(hatch_style),
         **kwargs,
     }
     ax.bar(**bar_kwargs)
@@ -69,6 +68,7 @@ def draw_syst_error_bands(
     shift_insts: Sequence[od.Shift],
     norm: float | Sequence | np.ndarray = 1.0,
     method: str = "quadratic_sum",
+    hatch_style: hatch_styles = "green_backwards",
     **kwargs,
 ) -> None:
     import hist
@@ -155,11 +155,7 @@ def draw_syst_error_bands(
         "bottom": baseline * (1 - rel_syst_error_down),
         "height": baseline * (rel_syst_error_up + rel_syst_error_down),
         "width": h.axes[0].edges[1:] - h.axes[0].edges[:-1],
-        "hatch": "\\\\\\",
-        "linewidth": 0,
-        "color": "none",
-        "edgecolor": "#30c300",
-        "alpha": 1.0,
+        **get_hatch_kwargs(hatch_style),
         **kwargs,
     }
     ax.bar(**bar_kwargs)

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -19,8 +19,8 @@ import order as od
 import scinum as sn
 
 from columnflow.util import maybe_import, try_int, try_complex, safe_div, UNSET
-from columnflow.hist_util import copy_axis, sum_hists
-from columnflow.types import TYPE_CHECKING, Iterable, Any, Callable, Sequence, Hashable
+from columnflow.hist_util import copy_axis, sum_hists, ensure_bin_exists, insert_axis_values
+from columnflow.types import TYPE_CHECKING, Iterable, Any, Callable, Sequence, Hashable, Literal
 
 np = maybe_import("numpy")
 if TYPE_CHECKING:
@@ -521,7 +521,8 @@ def prepare_style_config(
 def prepare_stack_plot_config(
     hists: OrderedDict,
     shape_norm: bool | None = False,
-    hide_stat_errors: bool | None = None,
+    hide_stat_errors: bool = False,
+    merge_stat_errors: bool = False,
     shift_insts: Sequence[od.Shift] | None = None,
     density: bool = False,
     **kwargs,
@@ -615,31 +616,64 @@ def prepare_stack_plot_config(
                     plot_cfg[key]["yerr"] = False
 
     # draw statistical error for stack
-    if h_mc_stack is not None and not hide_stat_errors:
+    draw_stat_errors = bool(not hide_stat_errors and h_mc_stack is not None)
+    if draw_stat_errors and not merge_stat_errors:
         mc_norm = shape_norm_func(h_mc, shape_norm)
         plot_config["mc_stat_unc"] = {
             "method": "draw_stat_error_bands",
             "hist": h_mc,
-            "kwargs": {"norm": mc_norm, "label": "MC stat. unc."},
-            "ratio_kwargs": {"norm": h_mc.values()},
+            "kwargs": {
+                "norm": mc_norm,
+                "label": "MC stat. unc.",
+                "hatch_style": "black",
+            },
+            "ratio_kwargs": {
+                "norm": h_mc.values(),
+                "hatch_style": "black",
+            },
         }
 
     # draw systematic error for stack
-    if h_mc_stack is not None and mc_syst_hists:
+    draw_syst_errors = bool(mc_syst_hists and h_mc_stack is not None)
+    if draw_syst_errors:
         mc_norm = shape_norm_func(h_mc, shape_norm)
+        # when merging stat and syst errors, add a fake shift inst and extend shift axes of histograms to include it
+        _shift_insts = shift_insts
+        _mc_syst_hists = mc_syst_hists
+        label = "MC syst. unc."
+        hatch_style = "green_backwards"
+        if merge_stat_errors:
+            _shift_insts = [
+                *shift_insts,
+                od.Shift(name="mc_stat_up", id=100000, type="shape"),
+                od.Shift(name="mc_stat_down", id=100001, type="shape"),
+            ]
+            _mc_syst_hists = []
+            for h in mc_syst_hists:
+                h = ensure_bin_exists(h, "shift", ["mc_stat_up", "mc_stat_down"])  # always creates a copy
+                nom_view = h[{"shift": hist.loc("nominal")}].view()
+                stat_err = nom_view.variance**0.5
+                insert_axis_values(h, "shift", "mc_stat_up", nom_view.value + stat_err)
+                insert_axis_values(h, "shift", "mc_stat_down", nom_view.value - stat_err)
+                _mc_syst_hists.append(h)
+            label = "MC unc."
+            hatch_style = "black"
+        # add plot config
         plot_config["mc_syst_unc"] = {
             "method": "draw_syst_error_bands",
             "hist": h_mc,
             "kwargs": {
-                "syst_hists": mc_syst_hists,
-                "shift_insts": shift_insts,
+                "syst_hists": _mc_syst_hists,
+                "shift_insts": _shift_insts,
                 "norm": mc_norm,
-                "label": "MC syst. unc.",
+                "label": label,
+                "hatch_style": hatch_style,
             },
             "ratio_kwargs": {
                 "syst_hists": mc_syst_hists,
                 "shift_insts": shift_insts,
                 "norm": h_mc.values(),
+                "hatch_style": hatch_style,
             },
         }
 
@@ -671,6 +705,30 @@ def prepare_stack_plot_config(
                     plot_cfg[key]["yerr"] = False
 
     return plot_config
+
+
+hatch_styles = Literal["black", "green", "black_backwards", "green_backwards"]
+
+
+def get_hatch_kwargs(style: hatch_styles) -> dict[str, Any]:
+    kwargs = {
+        "linewidth": 0,
+        "color": "none",
+        "alpha": 1.0,
+    }
+
+    if style == "black":
+        kwargs.update({"hatch": "///", "edgecolor": "black"})
+    elif style == "black_backwards":
+        kwargs.update({"hatch": "\\\\\\", "edgecolor": "black"})
+    elif style == "green":
+        kwargs.update({"hatch": "///", "edgecolor": "#30c300"})
+    elif style == "green_backwards":
+        kwargs.update({"hatch": "\\\\\\", "edgecolor": "#30c300"})
+    else:
+        raise ValueError(f"unknown hatch style '{style}'")
+
+    return kwargs
 
 
 def split_ax_kwargs(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -707,10 +707,10 @@ def prepare_stack_plot_config(
     return plot_config
 
 
-hatch_styles = Literal["black", "green", "black_backwards", "green_backwards"]
+HatchStyles = Literal["black", "green", "black_backwards", "green_backwards"]
 
 
-def get_hatch_kwargs(style: hatch_styles) -> dict[str, Any]:
+def get_hatch_kwargs(style: HatchStyles) -> dict[str, Any]:
     kwargs = {
         "linewidth": 0,
         "color": "none",

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -489,6 +489,11 @@ class PlotVariablesBaseMultiShifts(
         description="sets the title of the legend; when empty and only one process is present in "
         "the plot, the process_inst label is used; empty default",
     )
+    merge_stat_errors = law.OptionalBoolParameter(
+        default=None,
+        significant=False,
+        description="whether to merge stat error bands into the combined shift error; default: None",
+    )
 
     # always ensure the nominal shift is present in shift sources
     enforce_nominal_shift_source = True
@@ -592,6 +597,7 @@ class PlotVariablesBaseMultiShifts(
         # convert parameters to usable values during plotting
         params = super().get_plot_parameters()
         dict_add_strict(params, "legend_title", None if self.legend_title == law.NO_STR else self.legend_title)
+        dict_add_strict(params, "merge_stat_errors", self.merge_stat_errors)
         return params
 
 


### PR DESCRIPTION
This PR adds an option `--merge-stat-errors` to shift plots like `PlotShiftedVariables1D` which causes the mc stat. and systematic errors bands to be merged.

Closes #779.