### PR TITLE
Add --multi-category suppport for plots.

### DIFF
--- a/columnflow/plotting/__init__.py
+++ b/columnflow/plotting/__init__.py
@@ -1,1 +1,34 @@
 # coding: utf-8
+
+from __future__ import annotations
+
+from columnflow.types import Any, Callable
+
+
+# helpers to decorate plot functions to assign them inspectable features
+def _add_plot_feature(plot_func: Callable, feature_name: str, feature_value: Any | None = None) -> None:
+    if getattr(plot_func, "_plot_features", None) is None:
+        plot_func._plot_features = {}
+    plot_func._plot_features[feature_name] = feature_value
+
+
+def _get_plot_features(plot_func: Callable) -> dict[str, Any]:
+    return getattr(plot_func, "_plot_features", {})
+
+
+def supports_multi_variable(plot_func: Callable) -> Callable:
+    _add_plot_feature(plot_func, "multi_variable")
+    return plot_func
+
+
+def check_multi_variable_support(plot_func: Callable) -> bool:
+    return "multi_variable" in _get_plot_features(plot_func)
+
+
+def supports_multi_category(plot_func: Callable) -> Callable:
+    _add_plot_feature(plot_func, "multi_category")
+    return plot_func
+
+
+def check_multi_category_support(plot_func: Callable) -> bool:
+    return "multi_category" in _get_plot_features(plot_func)

--- a/columnflow/plotting/__init__.py
+++ b/columnflow/plotting/__init__.py
@@ -17,18 +17,30 @@ def _get_plot_features(plot_func: Callable) -> dict[str, Any]:
 
 
 def supports_multi_variable(plot_func: Callable) -> Callable:
+    """
+    Decorator for plot functions to indicate that they support multi-variable plotting.
+    """
     _add_plot_feature(plot_func, "multi_variable")
     return plot_func
 
 
 def check_multi_variable_support(plot_func: Callable) -> bool:
+    """
+    Helper to check if a plot function supports multi-variable plotting.
+    """
     return "multi_variable" in _get_plot_features(plot_func)
 
 
 def supports_multi_category(plot_func: Callable) -> Callable:
+    """
+    Decorator for plot functions to indicate that they support multi-category plotting.
+    """
     _add_plot_feature(plot_func, "multi_category")
     return plot_func
 
 
 def check_multi_category_support(plot_func: Callable) -> bool:
+    """
+    Helper to check if a plot function supports multi-category plotting.
+    """
     return "multi_category" in _get_plot_features(plot_func)

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -97,12 +97,12 @@ def plot_variable_stack(
 
     # prepare and update the style config
     default_style_config = prepare_style_config(
-        config_inst,
-        category_inst,
-        variable_inst,
-        density,
-        shape_norm,
-        yscale,
+        config_inst=config_inst,
+        variable_inst=variable_inst,
+        category_inst=category_inst,
+        density=density,
+        shape_norm=shape_norm,
+        yscale=yscale,
     )
     # additional, plot function specific changes
     if shape_norm:
@@ -211,12 +211,12 @@ def plot_variable_variants(
 
     # setup style config
     default_style_config = prepare_style_config(
-        config_inst,
-        category_inst,
-        variable_inst,
-        density,
-        shape_norm,
-        yscale,
+        config_inst=config_inst,
+        variable_inst=variable_inst,
+        category_inst=category_inst,
+        density=density,
+        shape_norm=shape_norm,
+        yscale=yscale,
     )
     # plot-function specific changes
     default_style_config["rax_cfg"]["ylim"] = (0., 1.1)
@@ -315,12 +315,12 @@ def plot_shifted_variable(
         yscale = "log" if variable_inst.log_y else "linear"
 
     default_style_config = prepare_style_config(
-        config_inst,
-        category_inst,
-        variable_inst,
-        density,
-        shape_norm,
-        yscale,
+        config_inst=config_inst,
+        variable_inst=variable_inst,
+        category_inst=category_inst,
+        density=density,
+        shape_norm=shape_norm,
+        yscale=yscale,
     )
     default_style_config["rax_cfg"]["ylim"] = (0.25, 1.75)
     default_style_config["rax_cfg"]["ylabel"] = "Ratio"
@@ -516,9 +516,9 @@ def plot_profile(
                     plot_cfg[key]["yerr"] = None
 
     default_style_config = prepare_style_config(
-        config_inst,
-        category_inst,
-        variable_insts[0],
+        config_inst=config_inst,
+        variable_inst=variable_insts[0],
+        category_inst=category_inst,
         density=density,
         yscale=yscale,
         xtick_rotation=kwargs.get("rotate_xticks", None),

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -445,9 +445,10 @@ def remove_residual_axis(
 
 
 def prepare_style_config(
+    *,
     config_inst: od.Config,
-    category_inst: od.Category,
     variable_inst: od.Variable,
+    category_inst: od.Category | None = None,
     density: bool | None = False,
     shape_norm: bool | None = False,
     yscale: str | None = "",
@@ -464,9 +465,6 @@ def prepare_style_config(
         variable_inst.x("x_min", variable_inst.x_min),
         variable_inst.x("x_max", variable_inst.x_max),
     )
-
-    # build the label from category and optional variable selection labels
-    cat_label = join_labels(category_inst.label, variable_inst.x("selection_label", None))
 
     # unit format on axes (could be configurable)
     unit_format = "{title} [{unit}]"
@@ -499,12 +497,16 @@ def prepare_style_config(
             "xrotation": variable_inst.x("x_label_rotation", None),
         },
         "legend_cfg": {},
-        "annotate_cfg": {"text": cat_label or ""},
         "cms_label_cfg": {
             "lumi": f"{0.001 * config_inst.x.luminosity.get('nominal'):.1f}",  # /pb -> /fb
             "com": config_inst.campaign.ecm,
         },
     }
+
+    # build the label from category and optional variable selection labels
+    if category_inst:
+        cat_label = join_labels(category_inst.label, variable_inst.x("selection_label", None))
+        style_config["annotate_cfg"] = {"text": cat_label or ""}
 
     # disable minor ticks based on variable_inst
     axis_type = variable_inst.x("axis_type", "variable")

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -24,6 +24,7 @@ from columnflow.tasks.framework.plotting import (
 from columnflow.tasks.framework.decorators import view_output_plots
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
+from columnflow.plotting import check_multi_variable_support, check_multi_category_support
 from columnflow.util import DotDict, dev_sandbox, dict_add_strict
 from columnflow.hist_util import add_missing_shifts, sum_hists, select_category_bins
 from columnflow.config_util import get_shift_from_configs, expand_shift_sources
@@ -56,6 +57,12 @@ class PlotVariablesBase(_PlotVariablesBase):
         description="whether a single plot for all variables should be created; this requires that the used plot "
         "function accepts a nested dictionary with all variable and process histograms as an input; default: False",
     )
+    multi_category = luigi.BoolParameter(
+        default=False,
+        description="whether a single plot for all categories should be created; this requires that the used plot "
+        "function accepts a nested dictionary with all category and process histograms as an input; cannot be used in "
+        "conjunction with --multi-variable; default: False",
+    )
     bypass_branch_requirements = luigi.BoolParameter(
         default=False,
         description="whether to skip branch requirements and only use that of the workflow; default: False",
@@ -70,6 +77,28 @@ class PlotVariablesBase(_PlotVariablesBase):
     exclude_params_repr = {"bypass_branch_requirements"}
 
     exclude_index = True
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # check multi flags
+        if self.multi_variable and self.multi_category:
+            raise Exception("cannot use --multi-variable and --multi-category at the same time")
+
+        # the plot function support for multi-flags
+        plot_func = self.get_plot_func(self.plot_function)
+        if self.multi_variable and not check_multi_variable_support(plot_func):
+            raise Exception(
+                f"plot function '{self.plot_function}' does not support multi-variable plotting; please change the "
+                "plot function or, if it actually has multi-variable support, decorate it with "
+                "@columnflow.plotting.supports_multi_variable",
+            )
+        if self.multi_category and not check_multi_category_support(plot_func):
+            raise Exception(
+                f"plot function '{self.plot_function}' does not support multi-category plotting; please change the "
+                "plot function or, if it actually has multi-category support, decorate it with "
+                "@columnflow.plotting.supports_multi_category",
+            )
 
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -6,6 +6,7 @@ Tasks to plot different types of histograms.
 
 import itertools
 import functools
+import threading
 from collections import OrderedDict, defaultdict
 from abc import abstractmethod
 
@@ -55,13 +56,14 @@ class PlotVariablesBase(_PlotVariablesBase):
     multi_variable = luigi.BoolParameter(
         default=False,
         description="whether a single plot for all variables should be created; this requires that the used plot "
-        "function accepts a nested dictionary with all variable and process histograms as an input; default: False",
+        "function is decorated with '@columnflow.plotting.supports_multi_variable' and accepts a nested dictionary "
+        "for the 'hists' argument with all variable and process histograms as an input; default: False",
     )
     multi_category = luigi.BoolParameter(
         default=False,
         description="whether a single plot for all categories should be created; this requires that the used plot "
-        "function accepts a nested dictionary with all category and process histograms as an input; cannot be used in "
-        "conjunction with --multi-variable; default: False",
+        "function is decorated with '@columnflow.plotting.supports_multi_category' and accepts a list of categories "
+        "for the 'category_inst' argument; cannot be used in conjunction with --multi-variable; default: False",
     )
     bypass_branch_requirements = luigi.BoolParameter(
         default=False,
@@ -82,8 +84,7 @@ class PlotVariablesBase(_PlotVariablesBase):
         super().__init__(*args, **kwargs)
 
         # check multi flags
-        if self.multi_variable and self.multi_category:
-            raise Exception("cannot use --multi-variable and --multi-category at the same time")
+        self._check_multi_flags()
 
         # the plot function support for multi-flags
         plot_func = self.get_plot_func(self.plot_function)
@@ -100,14 +101,22 @@ class PlotVariablesBase(_PlotVariablesBase):
                 "@columnflow.plotting.supports_multi_category",
             )
 
+    def _check_multi_flags(self) -> None:
+        if self.multi_variable and self.multi_category:
+            raise Exception("cannot use --multi-variable and --multi-category at the same time")
+
     def store_parts(self) -> law.util.InsertableDict:
         parts = super().store_parts()
         parts.insert_before("version", "datasets", f"datasets_{self.datasets_repr}")
         return parts
 
     def create_branch_map(self):
-        keys = ["category"]
-        seqs = [self.categories]
+        self._check_multi_flags()
+        keys = []
+        seqs = []
+        if not self.multi_category:
+            keys.append("category")
+            seqs.append(self.categories)
         if not self.multi_variable:
             keys.append("variable")
             seqs.append(self.variables)
@@ -206,8 +215,12 @@ class PlotVariablesBase(_PlotVariablesBase):
     def run(self):
         import hist
 
+        self._check_multi_flags()
+
         # prepare other config objects
+        categories = list(self.categories) if self.multi_category else [self.branch_data.category]
         variables = list(self.variables) if self.multi_variable else [self.branch_data.variable]
+        category_variable_combis = list(itertools.product(categories, variables))
         plot_shifts = self.get_plot_shifts()
         plot_shift_names = set(shift_inst.name for shift_inst in plot_shifts) | {"nominal"}
 
@@ -215,13 +228,17 @@ class PlotVariablesBase(_PlotVariablesBase):
         config_process_map, process_shift_map = self.get_config_process_map()
 
         # read histograms per variable name, config and process
-        hists: dict[str, dict[od.Config, dict[od.Process, hist.Hist]]] = {var_name: {} for var_name in variables}
-        with self.publish_step(f"plotting {','.join(variables)} in {self.branch_data.category}"):
+        hists: dict[tuple[str, str], dict[od.Config, dict[od.Process, hist.Hist]]] = {
+            tpl: {}
+            for tpl in category_variable_combis
+        }
+        with self.publish_step(f"plotting {','.join(variables)} in {','.join(categories)}"):
             inputs = self.input() or self.workflow_input().merged_hists
-            for var_name in variables:
+            for cat_name, var_name in category_variable_combis:
+                hist_key = (cat_name, var_name)
                 for i, (config, dataset_dict) in enumerate(inputs.items()):
                     config_inst = self.config_insts[i]
-                    category_inst = config_inst.get_category(self.branch_data.category)
+                    category_inst = config_inst.get_category(cat_name)
 
                     hists_config = {}
 
@@ -267,7 +284,7 @@ class PlotVariablesBase(_PlotVariablesBase):
                         del h_in
 
                     # after merging all processes, sort the histograms by process order and store them
-                    hists[var_name][config_inst] = {
+                    hists[hist_key][config_inst] = {
                         proc_inst: hists_config[proc_inst]
                         for proc_inst in sorted(
                             hists_config.keys(),
@@ -284,33 +301,30 @@ class PlotVariablesBase(_PlotVariablesBase):
                         )
 
                 # update histograms using custom hooks
-                hists[var_name] = self.invoke_hist_hooks(
-                    hists[var_name],
-                    hook_kwargs={
-                        "category_name": self.branch_data.category,
-                        "variable_name": var_name,
-                    },
+                hists[hist_key] = self.invoke_hist_hooks(
+                    hists[hist_key],
+                    hook_kwargs={"category_name": cat_name, "variable_name": var_name},
                 )
 
                 # merge configs
                 if len(self.config_insts) != 1:
                     process_memory = {}
                     merged_hists = {}
-                    for _hists in hists[var_name].values():
+                    for _hists in hists[hist_key].values():
                         for process_inst, h in _hists.items():
                             if process_inst.id in merged_hists:
                                 merged_hists[process_inst.id] += h
                             else:
                                 merged_hists[process_inst.id] = h
                                 process_memory[process_inst.id] = process_inst
-                    hists[var_name] = {process_memory[process_id]: h for process_id, h in merged_hists.items()}
+                    hists[hist_key] = {process_memory[process_id]: h for process_id, h in merged_hists.items()}
                 else:
-                    hists[var_name] = hists[var_name][self.config_inst]
+                    hists[hist_key] = hists[hist_key][self.config_inst]
 
                 # axis selections and reductions
                 _hists = OrderedDict()
-                for process_inst in hists[var_name].keys():
-                    h = hists[var_name][process_inst]
+                for process_inst in hists[hist_key].keys():
+                    h = hists[hist_key][process_inst]
                     # determine expected shifts from intersection of requested shifts and those known for the process
                     process_shifts = (
                         process_shift_map[process_inst.name]
@@ -326,7 +340,7 @@ class PlotVariablesBase(_PlotVariablesBase):
                     h = select_category_bins(h, category_inst, use_leaves=True, prefer_parents=True, reduce=True)
                     # store
                     _hists[process_inst] = h
-                hists[var_name] = _hists
+                hists[hist_key] = _hists
 
             # copy process instances once so that their auxiliary data fields can be used as a storage for
             # process-specific plot parameters later on in plot scripts without affecting the original instances
@@ -337,27 +351,44 @@ class PlotVariablesBase(_PlotVariablesBase):
             ).copy()
             process_map = {proc_inst.name: proc_inst for proc_inst in fake_root.processes.values()}
             fake_root.processes.clear()
-            for var_name, _hists in hists.items():
-                hists[var_name] = {process_map[proc_inst.name]: h for proc_inst, h in _hists.items()}
+            for hist_key, _hists in hists.items():
+                hists[hist_key] = {process_map[proc_inst.name]: h for proc_inst, h in _hists.items()}
 
             # helper to get variable instances per variable name in tuples (split in case of n-d plots)
             get_var_insts = lambda var_name: list(map(self.config_inst.get_variable, self.variable_tuples[var_name]))
 
+            # prepare dynamic plot arguments
+            if self.multi_category:
+                plot_content = {
+                    "hists": {cat_name: hists[(cat_name, variables[0])] for cat_name in categories},
+                    "category_inst": [self.config_inst.get_category(cat_name).copy_shallow() for cat_name in categories],
+                    "variable_insts": get_var_insts(variables[0]),
+                }
+            elif self.multi_variable:
+                plot_content = {
+                    "hists": {var_name: hists[(categories[0], var_name)] for var_name in variables},
+                    "category_inst": self.config_inst.get_category(categories[0]).copy_shallow(),
+                    "variable_insts": {var_name: get_var_insts(var_name) for var_name in variables},
+                }
+            else:
+                plot_content = {
+                    "hists": hists[(categories[0], variables[0])],
+                    "category_inst": self.config_inst.get_category(categories[0]).copy_shallow(),
+                    "variable_insts": get_var_insts(variables[0]),
+                }
+
             # temporarily use a merged luminostiy value, assigned to the first config
             config_inst = self.config_insts[0]
+            if not config_inst.has_aux("lumi_plot_lock"):
+                config_inst.x.lumi_plot_lock = threading.RLock()
             lumi = sum([_config_inst.x.luminosity for _config_inst in self.config_insts])
-            with law.util.patch_object(config_inst.x, "luminosity", lumi):
+
+            with law.util.patch_object(config_inst.x, "luminosity", lumi, lock=config_inst.x.lumi_plot_lock):
                 # call the plot function
                 fig, _ = self.call_plot_func(
                     self.plot_function,
-                    hists=hists if self.multi_variable else hists[variables[0]],
+                    **plot_content,
                     config_inst=config_inst,
-                    category_inst=category_inst.copy_shallow(),
-                    variable_insts=(
-                        {var_name: get_var_insts(var_name) for var_name in variables}
-                        if self.multi_variable
-                        else get_var_insts(variables[0])
-                    ),
                     shift_insts=plot_shifts,
                     **self.get_plot_parameters(),
                 )
@@ -406,8 +437,15 @@ class PlotVariablesBaseSingleShift(
     def plot_parts(self) -> law.util.InsertableDict:
         parts = super().plot_parts()
 
+        self._check_multi_flags()
+
         parts["processes"] = f"proc_{self.processes_repr}"
-        parts["category"] = f"cat_{self.branch_data.category}"
+
+        if self.multi_category:
+            parts["category"] = f"cats_{self.categories_repr}"
+        else:
+            parts["category"] = f"cat_{self.branch_data.category}"
+
         if self.multi_variable:
             parts["variables"] = f"vars_{self.variables_repr}"
         else:
@@ -548,14 +586,22 @@ class PlotVariablesBaseMultiShifts(
     )
 
     def create_branch_map(self) -> list[DotDict]:
-        keys = ["category"]
-        seqs = [self.categories]
+        self._check_multi_flags()
+
+        keys = []
+        seqs = []
+        if not self.multi_category:
+            keys.append("category")
+            seqs.append(self.categories)
+
         if not self.multi_variable:
             keys.append("variable")
             seqs.append(self.variables)
+
         if not self.combine_shifts:
             seqs.append([source for source in self.shift_sources if source != "nominal"])
             keys.append("shift_source")
+
         return [DotDict(zip(keys, vals)) for vals in itertools.product(*seqs)]
 
     def requires(self):
@@ -591,8 +637,15 @@ class PlotVariablesBaseMultiShifts(
     def plot_parts(self) -> law.util.InsertableDict:
         parts = super().plot_parts()
 
+        self._check_multi_flags()
+
         parts["processes"] = f"proc_{self.processes_repr}"
-        parts["category"] = f"cat_{self.branch_data.category}"
+
+        if self.multi_category:
+            parts["category"] = f"cats_{self.categories_repr}"
+        else:
+            parts["category"] = f"cat_{self.branch_data.category}"
+
         if self.multi_variable:
             parts["variables"] = f"vars_{self.variables_repr}"
         else:


### PR DESCRIPTION
This PR adds a `--multi-category` parameter to most plot tasks. Its effect is similar to `--multi-variable`: when set, instead of looping over all given categories, a single plot (per variable) combining distributions in multiple categories is created. As before, this requires that a dedicated plot function is selected, that has the capabilities to create such a plot.

To make these "capabilities" of plot functions explicit, I added two decorators
- `@columnflow.plotting.supports_multi_variable`, and
- `@columnflow.plotting.supports_multi_category`.

They attach attributes to plot functions that are dynamically checked in case any of the two flags is set, and allows to fail early and verbosely in case a non-capable plot function is encountered.

Example: https://github.com/uhh-cms/hh2bbtautau/blob/748bd0f5b73935c89d913da876016ab07e7f57d2/hbt/plotting/multi.py#L19

**Note** that the generalization required a slight change to `prepare_style_config` which expects all arguments to be passed as keyword arguments (to better cope with the long list of potentially missing arguments). @mafrahm @jomatthi @Lara813 @LennertGriesing