### PR TITLE
Add plot task for pre-fit shapes using model, externalize shape transformations.

### DIFF
--- a/columnflow/hist_util.py
+++ b/columnflow/hist_util.py
@@ -415,6 +415,44 @@ def sum_hists(hists: Sequence[hist.Hist]) -> hist.Hist:
     return h_sum
 
 
+def sum_hists_shift_aware(hists: Sequence[hist.Hist], shift_axis_name: str = "shift") -> hist.Hist:
+    """
+    Same as :py:func:`sum_hists`, but takes care of handling missing shift bins in subsets of histograms correctly.
+    In particular, in case histograms A miss shifts present in histograms B, the missing shifts are filled first with
+    values of the nominal bin.
+
+    :param hists: The histograms to sum.
+    :param shift_axis_name: The name of the axis that contains the shift bins. Defaults to "shift".
+    :return: The summed histogram.
+    """
+    import hist
+
+    # get unique list of all shifts
+    all_shift_names = set()
+    for h in hists:
+        if shift_axis_name not in h.axes.name:
+            raise ValueError(f"histogram {h} does not have a '{shift_axis_name}' axis")
+        all_shift_names.update(h.axes[shift_axis_name])
+
+    # extend histograms with nominal values for missing shifts
+    for i, h in enumerate(hists):
+        shift_names = set(h.axes[shift_axis_name])
+        missing_shifts = all_shift_names - shift_names
+        if missing_shifts:
+            if "nominal" not in shift_names:
+                raise ValueError(f"histogram {h} does not have a 'nominal' bin in its '{shift_axis_name}' axis")
+            h_nom = h[{shift_axis_name: hist.loc("nominal")}]
+            h = ensure_bin_exists(h, shift_axis_name, missing_shifts)
+            for missing_shift in missing_shifts:
+                insert_axis_values(h, shift_axis_name, missing_shift, h_nom)
+            hists[i] = h
+
+    # now sum as usual
+    h_sum = sum_hists(hists)
+
+    return h_sum
+
+
 def select_category_bins(
     h: hist.Hist,
     categories: od.Category | str | Sequence[od.Category | str],

--- a/columnflow/inference/cms/datacard.py
+++ b/columnflow/inference/cms/datacard.py
@@ -7,12 +7,16 @@ Helpers to write and work with datacards.
 from __future__ import annotations
 
 import os
-from collections import OrderedDict
+import dataclasses
+import collections
 
 import law
+import order as od
 
 from columnflow import __version__ as cf_version
-from columnflow.inference import InferenceModel, ParameterType, ParameterTransformation, FlowStrategy
+from columnflow.inference import InferenceModel, FlowStrategy
+from columnflow.inference.parameter import ParameterType
+from columnflow.inference.transformation import ShapeTransformer
 from columnflow.hist_util import sum_hists
 from columnflow.util import DotDict, maybe_import, real_path, ensure_dir, safe_div, maybe_int
 from columnflow.types import TYPE_CHECKING, TypeAlias, Sequence, Any, Union, Hashable
@@ -70,7 +74,8 @@ class DatacardWriter(object):
             Configurable via *asymmetrize_if_large_threshold*.
         - :py:attr:`ParameterTransformation.normalize`: Normalizes shape variations such that their integrals match that
             of the nominal shape.
-        - :py:attr:`ParameterTransformation.centralize`: # TODO: not yet implemented
+        - :py:attr:`ParameterTransformation.centralize`: Moves the nominal shape right in between the up and down
+            variations, both for rate- and shype-type parameters. Rate effects are updated accordingly.
         - :py:attr:`ParameterTransformation.envelope`: Takes the bin-wise maximum in each direction of the up and down
             variations of shape-type parameters and constructs new shapes.
         - :py:attr:`ParameterTransformation.envelope_if_one_sided`: Same as above, but only in bins where up and down
@@ -96,88 +101,31 @@ class DatacardWriter(object):
     # minimum separator between columns
     col_sep = "  "
 
-    @classmethod
-    def validate_model(cls, inference_model_inst: InferenceModel, silent: bool = False) -> bool:
-        # perform parameter checks one after another, collect errors along the way
-        errors: list[str] = []
-        for cat_name, proc_name, param_obj in inference_model_inst.iter_parameters():
-            # check the transformations
-            _errors: list[str] = []
-            for i, trafo in enumerate(param_obj.transformations):
-                if i != 0 and trafo.requires_first_index:
-                    _errors.append(
-                        f"parameter transformation '{trafo}' must be the first one to apply, but found at index {i}",
-                    )
-                if not param_obj.type.is_shape and trafo.affects_shape_only:
-                    _errors.append(
-                        f"parameter transformation '{trafo}' only applies to shape-type parameters, but found type "
-                        f"'{param_obj.type}'",
-                    )
-                if not param_obj.type.is_rate and trafo.affects_rate_only:
-                    _errors.append(
-                        f"parameter transformation '{trafo}' only applies to rate-type parameters, but found type "
-                        f"'{param_obj.type}'",
-                    )
-            errors.extend(
-                f"for parameter '{param_obj}' in process '{proc_name}' in category '{cat_name}': {err}"
-                for err in _errors
-            )
+    # reference to the shape transformer class to be used
+    shape_transformer_cls = ShapeTransformer
 
-        # handle errors
-        if errors:
-            if silent:
-                return False
-            errors_repr = "\n  - ".join(errors)
-            raise ValueError(f"inference model invalid, reasons:\n  - {errors_repr}")
+    @dataclasses.dataclass
+    class ShapeData:
+        """
+        Container object describing data returned after shape writing.
+        """
 
-        return True
-
-    @classmethod
-    def validate_histograms(cls, histograms: DatacardHists, silent: bool = False) -> bool:
-        import hist
-
-        # validate structure of histograms, shape keys and histogram types
-        errors: list[str] = []
-        for cat_name, proc_hists in histograms.items():
-            if not isinstance(cat_name, str):
-                errors.append(f"category name key '{cat_name}' is not a string")
-            for proc_name, config_hists in proc_hists.items():
-                if not isinstance(proc_name, str):
-                    errors.append(f"process name '{proc_name}' in category '{cat_name}' is not a string")
-                for config_name, shift_hists in config_hists.items():
-                    if not isinstance(config_name, str):
-                        errors.append(
-                            f"config name '{config_name}' for process '{proc_name}' in category '{cat_name}' is not a "
-                            f"string",
-                        )
-                    for shift_key, h in shift_hists.items():
-                        # shift_key must be nominal or a tuple of (param_name, "up|down")
-                        if (
-                            shift_key != "nominal" and
-                            (
-                                not isinstance(shift_key, (tuple, list)) or
-                                len(shift_key) != 2 or
-                                shift_key[1] not in {"up", "down"}
-                            )
-                        ):
-                            errors.append(
-                                f"invalid shift key '{shift_key}' in config '{config_name}' for process "
-                                f"'{proc_name}' in category '{cat_name}'",
-                            )
-                        if not isinstance(h, hist.Hist):
-                            errors.append(
-                                f"histogram for shift '{shift_key}' in config '{config_name}' for process "
-                                f"'{proc_name}' in category '{cat_name}' is not a hist.Hist instance",
-                            )
-
-        # handle errors
-        if errors:
-            if silent:
-                return False
-            errors_repr = "\n  - ".join(errors)
-            raise ValueError(f"datacard histograms invalid, reasons:\n  - {errors_repr}")
-
-        return True
+        # nominal histograms in a mapping "category -> process -> histogram"
+        nominal_hists: dict[str, dict[str, "hist.Hist"]]
+        # the nominal rates in a mapping "category -> process -> rate"
+        rates: dict[str, dict[str, float]]
+        # rate-changing effects of shapes in a mapping "category -> process -> parameter -> (down effect, up effect)"
+        shape_effects: dict[str, dict[str, dict[str, tuple[float, float]]]]
+        # evaluated parameter types after shape writing in a mapping "category -> process -> parameter -> type"
+        parameter_types: dict[str, dict[str, dict[str, ParameterType]]]
+        # parameters whose transformations have been evaluated in a mapping "category -> process -> parameter names"
+        evaluated_trafos: dict[str, dict[str, set[str]]]
+        # the datacard pattern for extracting nominal shapes in CMS combine notation
+        # (variables: $CHANNEL, $PROCESS)
+        nom_pattern: str
+        # the datacard pattern for extracting systematic shapes in CMS combine notation
+        # (variables: $CHANNEL, $PROCESS, $SYSTEMATIC)
+        syst_pattern: str
 
     def __init__(
         self,
@@ -185,9 +133,7 @@ class DatacardWriter(object):
         histograms: DatacardHists,
         rate_precision: int = 4,
         effect_precision: int = 4,
-        effect_from_shape_if_flat_max_outlier: float = 0.2,
-        effect_from_shape_if_flat_max_deviation: float = 0.1,
-        asymmetrize_if_large_threshold: float = 0.2,
+        shape_transformer_kwargs: dict[str, Any] | None = None,
     ) -> None:
         super().__init__()
 
@@ -196,9 +142,9 @@ class DatacardWriter(object):
         self.histograms = histograms
         self.rate_precision = rate_precision
         self.effect_precision = effect_precision
-        self.effect_from_shape_if_flat_max_outlier = effect_from_shape_if_flat_max_outlier
-        self.effect_from_shape_if_flat_max_deviation = effect_from_shape_if_flat_max_deviation
-        self.asymmetrize_if_large_threshold = asymmetrize_if_large_threshold
+
+        # create a shape transformer instance
+        self.transformer = self.shape_transformer_cls(**(shape_transformer_kwargs or {}))
 
         # validate the inference model and histograms
         self.validate_model(self.inference_model_inst)
@@ -222,10 +168,10 @@ class DatacardWriter(object):
             shapes_path_ref = os.path.relpath(shapes_path, os.path.dirname(datacard_path))
 
         # write the shapes files
-        rates, shape_effects, nom_pattern, syst_pattern = self.write_shapes(shapes_path)
+        shape_data = self.write_shapes(shapes_path)
 
         # get category objects
-        cat_objects = [self.inference_model_inst.get_category(cat_name) for cat_name in rates]
+        cat_objects = [self.inference_model_inst.get_category(cat_name) for cat_name in shape_data.rates]
 
         # prepare blocks and lines to write
         blocks: DotDict[str, list] = DotDict()
@@ -241,31 +187,31 @@ class DatacardWriter(object):
         separators.add("counts")
 
         # shape lines
-        blocks.shapes = [("shapes", "*", "*", shapes_path_ref, nom_pattern, syst_pattern)]
+        blocks.shapes = [("shapes", "*", "*", shapes_path_ref, shape_data.nom_pattern, shape_data.syst_pattern)]
         separators.add("shapes")
 
         # store rate precisions per category
         rate_precisions = {
             cat_obj.name: self.rate_precision if cat_obj.rate_precision <= 0 else cat_obj.rate_precision
-            for cat_obj in map(self.inference_model_inst.get_category, rates.keys())
+            for cat_obj in map(self.inference_model_inst.get_category, shape_data.rates.keys())
         }
 
         # observations
         blocks.observations = []
-        if all("data" in _rates for _rates in rates.values()):
+        if all("data" in _rates for _rates in shape_data.rates.values()):
             blocks.observations = [
-                ("bin", list(rates)),
+                ("bin", list(shape_data.rates)),
                 ("observation", [
                     maybe_int(round(_rates["data"], rate_precisions[cat_name]))
-                    for cat_name, _rates in rates.items()
+                    for cat_name, _rates in shape_data.rates.items()
                 ]),
             ]
             separators.add("observations")
 
         # expected rates
         proc_names, s_names, b_names = [], [], []
-        flat_rates = OrderedDict()
-        for cat_name, _rates in rates.items():
+        flat_rates = collections.OrderedDict()
+        for cat_name, _rates in shape_data.rates.items():
             for proc_name, rate in _rates.items():
                 if proc_name == "data":
                     continue
@@ -307,22 +253,23 @@ class DatacardWriter(object):
                     silent=True,
                 )
 
-                # skip line-style parameters as they are handled separately below
-                if param_obj and param_obj.type == ParameterType.rate_unconstrained:
-                    continue
-
-                # empty effect
+                # skip empty effects
                 if param_obj is None:
                     effects.append("-")
                     continue
 
+                # skip line-style parameters as they are handled separately below
+                param_type = shape_data.parameter_types[cat_name][proc_name][param_name]
+                if param_obj and param_type == ParameterType.rate_unconstrained:
+                    continue
+
                 # compare with previously seen types as combine cannot mix arbitrary parameter types acting differently
                 # on different processes
-                types.add(param_obj.type)
+                types.add(param_type)
                 if len(types) > 1 and types != {ParameterType.rate_gauss, ParameterType.shape}:
                     raise ValueError(
-                        f"misconfigured parameter '{param_name}' with type '{param_obj.type}' that was previously "
-                        f"seen with incompatible type(s) '{types - {param_obj.type}}'",
+                        f"misconfigured parameter '{param_name}' with type '{param_type}' that was previously seen "
+                        f"with incompatible type(s) '{types - {param_type}}'",
                     )
 
                 # get the effect
@@ -337,7 +284,6 @@ class DatacardWriter(object):
 
                 def rnd(f: float | int) -> float:
                     r = round(f, effect_precision)
-
                     # warn in case the precision is too low for the effect
                     if abs(1.0 - f) < 10**(-effect_precision):
                         logger.warning(
@@ -346,93 +292,49 @@ class DatacardWriter(object):
                             f"{effect_precision} for the paremeter '{param_name}' acting on process '{proc_name}' in "
                             f"category '{cat_name}'",
                         )
-
                     return r
 
                 # update and transform effects
-                if param_obj.type.is_rate:
-                    # apply transformations one by one
-                    for trafo in param_obj.transformations:
-                        if trafo.from_shape:
-                            # take effect from shape variations
-                            effect = shape_effects[cat_name][proc_name][param_name]
+                if param_type.is_shape:
+                    # when the shape was originally constructed from a rate, reset the effect to 1
+                    if param_obj.type.is_rate:
+                        effect = 1.0
 
-                        elif trafo == ParameterTransformation.symmetrize:
-                            # skip symmetric effects
-                            if not isinstance(effect, tuple) or len(effect) != 2:
-                                continue
-                            # skip one sided effects
-                            if not (min(effect) <= 1 <= max(effect)):
-                                continue
-                            d, u = effect
-                            diff = 0.5 * (d + u) - 1.0
-                            effect = (effect[0] - diff, effect[1] - diff)
+                elif param_type.is_rate:
+                    # when the rate was originally constructed from a shape, read the effect from the shape data
+                    if param_obj.type.is_shape:
+                        effect = shape_data.shape_effects[cat_name][proc_name][param_name]
 
-                        elif (
-                            trafo == ParameterTransformation.asymmetrize or
-                            (
-                                trafo == ParameterTransformation.asymmetrize_if_large and
-                                isinstance(effect, float) and
-                                abs(effect - 1.0) >= self.asymmetrize_if_large_threshold
-                            )
-                        ):
-                            # skip asymmetric effects
-                            if not isinstance(effect, float):
-                                continue
-                            effect = (2.0 - effect, effect)
+                    elif param_name not in shape_data.evaluated_trafos[cat_name][proc_name]:
+                        # in this case, the transformation sequence was not evaluated during shape writing, so do it now
+                        trafo_output: ShapeTransformer.TransormationOutput = self.transformer.apply_transformations(
+                            param_obj=param_obj,
+                            h_nom=shape_data.nominal_hists[cat_name][proc_name],
+                        )
 
-                        elif trafo in {
-                            ParameterTransformation.flip_smaller_if_one_sided,
-                            ParameterTransformation.flip_larger_if_one_sided,
-                        }:
-                            # skip symmetric effects
-                            if not isinstance(effect, tuple) or len(effect) != 2:
-                                continue
-                            flip_larger = trafo == ParameterTransformation.flip_larger_if_one_sided
-                            flip_smaller = trafo == ParameterTransformation.flip_smaller_if_one_sided
-                            # check sidedness and determine which of the two effect values to flip, identified by index
-                            if max(effect) < 1.0:
-                                # both below nominal
-                                flip_index = int(
-                                    (effect[1] > effect[0] and flip_larger) or
-                                    (effect[1] < effect[0] and flip_smaller),
-                                )
-                            elif min(effect) > 1.0:
-                                # both above nominal
-                                flip_index = int(
-                                    (effect[1] > effect[0] and flip_smaller) or
-                                    (effect[1] < effect[0] and flip_larger),
-                                )
-                            else:
-                                # skip one-sided effects
-                                continue
-                            effect = tuple(((2.0 - e) if i == flip_index else e) for i, e in enumerate(effect))
-
-                elif param_obj.type.is_shape:
-                    # apply transformations one by one
-                    for trafo in param_obj.transformations:
-                        if trafo.from_rate:
-                            # when the shape was constructed from a rate, reset the effect to 1
-                            effect = 1.0
+                        # store the effect
+                        effect = trafo_output.effect
 
                 # custom hook to modify the effect
                 effect = self.modify_parameter_effect(cat_obj, proc_obj, param_obj, effect)
 
                 # encode the effect
-                if isinstance(effect, (int, float)):
+                encoded_effect: str
+                if param_type.is_shape and effect in {None, 1}:
+                    encoded_effect = "1"
+                elif isinstance(effect, (int, float)):
                     if effect == 0.0:
-                        effects.append("-")
-                    elif effect == 1.0 and param_obj.type.is_shape:
-                        effects.append("1")
+                        encoded_effect = "-"
                     else:
-                        effects.append(str(rnd(effect)))
-                elif isinstance(effect, tuple) and len(effect) == 2:
-                    effects.append(f"{rnd(effect[0])}/{rnd(effect[1])}")
+                        encoded_effect = str(rnd(effect))
+                elif isinstance(effect, (tuple, list)) and self.transformer.validate_effect(effect):
+                    encoded_effect = f"{rnd(effect[0])}/{rnd(effect[1])}"
                 else:
                     raise ValueError(
-                        f"effect '{effect}' of parameter '{param_name}' with type {param_obj.type} on process "
-                        f"'{proc_name}' in category '{cat_name}' cannot be encoded",
+                        f"effect '{effect}' (type {type(effect)}) of parameter '{param_name}' with type "
+                        f"{param_obj.type} on process '{proc_name}' in category '{cat_name}' cannot be encoded",
                     )
+                effects.append(encoded_effect)
 
             # add the tabular line
             if types and effects:
@@ -448,7 +350,8 @@ class DatacardWriter(object):
                 elif types == {ParameterType.rate_gauss, ParameterType.shape}:
                     # when mixing lnN and shape effects, combine expects the "shape?" type and makes the actual decision
                     # dependent on the presence of shape variations in the accompanying shape files, see
-                    # https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/v10.2.X/part2/settinguptheanalysis/?h=shape%3F#template-shape-uncertainties # noqa
+                    # https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/v10.2.X/part2/settinguptheanalysis/?h=shape%3F#template-shape-uncertainties # noqa: E501
+                    # (this hopefully gets solved less hacky in the future)
                     type_str = "shape?"
                 if not type_str:
                     raise ValueError(f"misconfigured parameter '{param_name}' with incompatible type(s) '{types}'")
@@ -547,20 +450,10 @@ class DatacardWriter(object):
     def write_shapes(
         self,
         shapes_path: str,
-    ) -> tuple[
-        dict[str, dict[str, float]],
-        dict[str, dict[str, dict[str, tuple[float, float]]]],
-        str,
-        str,
-    ]:
+    ) -> ShapeData:
         """
-        Create the shapes file at *shapes_path* and returns a tuple with four items,
-
-            - the nominal rates in a nested mapping "category -> process -> rate",
-            - rate-changing effects of shape systematics in a nested mapping
-              "category -> process -> parameter -> (down effect, up effect)",
-            - the datacard pattern for extracting nominal shapes, and
-            - the datacard pattern for extracting systematic shapes.
+        Create the shapes file at *shapes_path* and returns a :py:class:`ShapeData` object, containing all info from
+        shape handling and serialization.
         """
         import uproot
 
@@ -576,12 +469,13 @@ class DatacardWriter(object):
         syst_pattern = "{category}/{process}__{parameter}{direction}"
         syst_pattern_comb = "$CHANNEL/$PROCESS__$SYSTEMATIC"
 
-        # prepare rates and shape effects
-        rates = OrderedDict()
-        effects = OrderedDict()
-
-        # create the output file
-        out_file = uproot.recreate(shapes_path)
+        # prepare book-keeping dicts
+        rates = collections.OrderedDict()
+        effects = collections.OrderedDict()
+        param_types = collections.OrderedDict()
+        evaluated_trafos = collections.OrderedDict()
+        nom_hists = collections.OrderedDict()
+        out_hists = collections.OrderedDict()
 
         # helper to handle and apply flow strategy to histogram
         def handle_flow(cat_obj, h, name):
@@ -649,8 +543,13 @@ class DatacardWriter(object):
         for cat_name, proc_hists in self.histograms.items():
             cat_obj = self.inference_model_inst.get_category(cat_name)
 
-            _rates = rates[cat_name] = OrderedDict()
-            _effects = effects[cat_name] = OrderedDict()
+            _rates = rates[cat_name] = collections.OrderedDict()
+            _effects = effects[cat_name] = collections.OrderedDict()
+            _param_types = param_types[cat_name] = collections.OrderedDict()
+            _evaluated_trafos = evaluated_trafos[cat_name] = collections.OrderedDict()
+            _nom_hists = nom_hists[cat_name] = collections.OrderedDict()
+            _out_hists = out_hists[cat_name] = collections.OrderedDict()
+
             for proc_name, config_hists in proc_hists.items():
                 # skip if process is not known to category
                 proc_obj = self.inference_model_inst.get_process(process=proc_name, category=cat_name, silent=True)
@@ -682,7 +581,7 @@ class DatacardWriter(object):
                     return sum_hists(map(get, hists))
 
                 # optionally skip the process under specific conditions
-                if (skip_reason := self.check_skip_process(cat_obj, proc_obj, get_hist_sum("nominal"))):
+                if (skip_reason := self.check_skip_process(cat_obj, proc_obj, get_hist_sum(od.Shift.NOMINAL))):
                     skip_msg = f"skipping process '{proc_name}' in category '{cat_name}'"
                     if not isinstance(skip_reason, bool):
                         skip_msg += f", reason: {skip_reason}"
@@ -706,171 +605,109 @@ class DatacardWriter(object):
 
                 # nominal shape
                 nom_name = nom_pattern.format(category=cat_name, process=proc_name)
-                h_nom = load(nom_name, "nominal", scale=scale)
-                out_file[nom_name] = h_nom
-                _rates[proc_name] = h_nom.sum().value
+                h_nom = load(nom_name, od.Shift.NOMINAL, scale=scale)
                 integral = lambda h: h.sum().value
 
-                # prepare effects
-                __effects = _effects[proc_name] = OrderedDict()
+                # prepare book-keeping dicts
+                __effects = _effects[proc_name] = collections.OrderedDict()
+                __param_types = _param_types[proc_name] = collections.OrderedDict()
+                __evaluated_trafos = _evaluated_trafos[proc_name] = set()
+                __out_hists = _out_hists[proc_name] = collections.OrderedDict()
 
                 # go through all parameters and potentially handle varied shapes
                 for _, _, param_obj in self.inference_model_inst.iter_parameters(category=cat_name, process=proc_name):
+                    # store the initial parameter type
+                    __param_types[param_obj.name] = param_obj.type
+
+                    # the parameter can be skipped under certain conditions
+                    if (
+                        # initially not a shape
+                        not param_obj.type.is_shape and
+                        # does not change to a shape
+                        not param_obj.transformations.any_changes_type and
+                        # does not change nominal
+                        not param_obj.transformations.any_changes_nominal
+                    ):
+                        continue
+                    __evaluated_trafos.add(param_obj.name)
+
+                    # prepare up/down shape names
                     down_name = syst_pattern.format(
                         category=cat_name,
                         process=proc_name,
                         parameter=param_obj.name,
-                        direction="Down",
+                        direction=od.Shift.DOWN.capitalize(),
                     )
                     up_name = syst_pattern.format(
                         category=cat_name,
                         process=proc_name,
                         parameter=param_obj.name,
-                        direction="Up",
+                        direction=od.Shift.UP.capitalize(),
                     )
 
-                    # read or create the varied histograms, or skip the parameter
+                    # extract the varied histograms from the input when needed
+                    h_varied = None
                     if param_obj.type.is_shape:
-                        # the source of the shape depends on the transformation
-                        if param_obj.transformations.any_from_rate:
-                            # create the shape from the nominal one and an integral rate effect
-                            if isinstance(param_obj.effect, float):
-                                f_down, f_up = 2.0 - param_obj.effect, param_obj.effect
-                            elif isinstance(param_obj.effect, tuple) and len(param_obj.effect) == 2:
-                                f_down, f_up = param_obj.effect
-                            else:
-                                raise ValueError(
-                                    f"cannot interpret effect of parameter '{param_obj.name}' to create shape: "
-                                    f"{param_obj.effect}",
-                                )
-                            h_down = h_nom.copy() * f_down
-                            h_up = h_nom.copy() * f_up
-                        else:
-                            # just extract the shapes from the inputs
-                            h_down = load(down_name, (param_obj.name, "down"), fallback_key="nominal", scale=scale)
-                            h_up = load(up_name, (param_obj.name, "up"), fallback_key="nominal", scale=scale)
+                        h_varied = (
+                            load(down_name, (param_obj.name, od.Shift.DOWN), fallback_key=od.Shift.NOMINAL, scale=scale),
+                            load(up_name, (param_obj.name, od.Shift.UP), fallback_key=od.Shift.NOMINAL, scale=scale),
+                        )
 
-                    elif param_obj.type.is_rate:
-                        if param_obj.transformations.any_from_shape:
-                            # just extract the shapes
-                            h_down = load(down_name, (param_obj.name, "down"), fallback_key="nominal", scale=scale)
-                            h_up = load(up_name, (param_obj.name, "up"), fallback_key="nominal", scale=scale)
-
-                            # in case the transformation is effect_from_shape_if_flat, and any of the two variations
-                            # do not qualify as "flat", convert the parameter to shape-type and drop all transformations
-                            # that do not apply to shapes
-                            if param_obj.transformations[0] == ParameterTransformation.effect_from_shape_if_flat:
-                                # check if flatness criteria are met
-                                for h in [h_down, h_up]:
-                                    # !!! TODO: bug! the relative difference should be flat, not the actual shape
-                                    values = h.view().value
-                                    mean, std = values.mean(), values.std()
-                                    max_rel_outlier = safe_div(max(abs(values - mean)), mean)
-                                    rel_deviation = safe_div(std, mean)
-                                    is_flat = (
-                                        max_rel_outlier <= self.effect_from_shape_if_flat_max_outlier and
-                                        rel_deviation <= self.effect_from_shape_if_flat_max_deviation
-                                    )
-                                    if not is_flat:
-                                        param_obj.type = ParameterType.shape
-                                        param_obj.transformations = type(param_obj.transformations)(
-                                            trafo for trafo in param_obj.transformations[1:]
-                                            if not trafo.affects_rate_only
-                                        )
-                                        break
-                        else:
-                            continue
-
-                    else:
-                        # other effect type that is not handled yet
-                        logger.warning(f"datacard parameter '{param_obj.name}' has unsupported type '{param_obj.type}'")
-                        continue
-
-                    # apply optional transformations one by one
-                    for trafo in param_obj.transformations:
-                        if trafo == ParameterTransformation.symmetrize:
-                            # get the absolute spread based on integrals
-                            n, d, u = integral(h_nom), integral(h_down), integral(h_up)
-                            # skip one sided effects
-                            if not (min(d, n) <= n <= max(d, n)):
-                                logger.info(
-                                    f"skipping shape symmetrization of parameter '{param_obj.name}' for process "
-                                    f"'{proc_name}' in category '{cat_name}' as effect is one-sided",
-                                )
-                                continue
-                            # find the central point, compute the diff w.r.t. nominal, and shift
-                            diff = 0.5 * (d + u) - n
-                            h_down *= safe_div(d - diff, d)
-                            h_up *= safe_div(u - diff, u)
-
-                        elif trafo == ParameterTransformation.normalize:
-                            # normale varied hists to the nominal integral
-                            n, d, u = integral(h_nom), integral(h_down), integral(h_up)
-                            h_down *= safe_div(n, d)
-                            h_up *= safe_div(n, u)
-
-                        elif trafo in {ParameterTransformation.envelope, ParameterTransformation.envelope_if_one_sided}:
-                            v_nom = h_nom.view()
-                            v_down = h_down.view()
-                            v_up = h_up.view()
-                            # compute masks denoting at which locations a variation is abs larger than the other
-                            diffs_up = v_up.value - v_nom.value
-                            diffs_down = v_down.value - v_nom.value
-                            up_mask = abs(diffs_up) > abs(diffs_down)
-                            down_mask = abs(diffs_down) > abs(diffs_up)
-                            # when only checking one-sided, remove True's from the masks where variations are two-sided
-                            if trafo == ParameterTransformation.envelope_if_one_sided:
-                                one_sided = (diffs_up * diffs_down) > 0
-                                up_mask &= one_sided
-                                down_mask &= one_sided
-                            # fill values from the larger variation
-                            v_up.value[down_mask] = v_nom.value[down_mask] - diffs_down[down_mask]
-                            v_up.variance[down_mask] = v_down.variance[down_mask]
-                            v_down.value[up_mask] = v_nom.value[up_mask] - diffs_up[up_mask]
-                            v_down.variance[up_mask] = v_up.variance[up_mask]
-
-                        elif trafo == ParameterTransformation.envelope_enforce_two_sided:
-                            # envelope creation with enforced two-sidedness
-                            v_nom = h_nom.view()
-                            v_down = h_down.view()
-                            v_up = h_up.view()
-                            # compute masks denoting at which locations a variation is abs larger than the other
-                            abs_diffs_up = abs(v_up.value - v_nom.value)
-                            abs_diffs_down = abs(v_down.value - v_nom.value)
-                            up_mask = abs_diffs_up >= abs_diffs_down
-                            down_mask = ~up_mask
-                            # fill values from the absolute larger variation
-                            v_up.value[up_mask] = v_nom.value[up_mask] + abs_diffs_up[up_mask]
-                            v_up.value[down_mask] = v_nom.value[down_mask] + abs_diffs_down[down_mask]
-                            v_up.variance[down_mask] = v_down.variance[down_mask]
-                            v_down.value[down_mask] = v_nom.value[down_mask] - abs_diffs_down[down_mask]
-                            v_down.value[up_mask] = v_nom.value[up_mask] - abs_diffs_up[up_mask]
-                            v_down.variance[up_mask] = v_up.variance[up_mask]
-
-                    # custom hook to modify the shapes
-                    h_nom, h_down, h_up = self.modify_parameter_shape(
-                        cat_obj,
-                        proc_obj,
-                        param_obj,
-                        h_nom,
-                        h_down,
-                        h_up,
+                    # apply the sequence of transformations
+                    trafo_output: ShapeTransformer.TransormationOutput = self.transformer.apply_transformations(
+                        param_obj=param_obj,
+                        h_nom=h_nom,
+                        h_varied=h_varied,
                     )
 
-                    # fill empty bins again after all transformations
-                    fill_empty(cat_obj, h_down)
-                    fill_empty(cat_obj, h_up)
+                    # update iteration variables
+                    h_nom = trafo_output.h_nom
+                    __param_types[param_obj.name] = trafo_output.param_type
 
-                    # save the effect
-                    __effects[param_obj.name] = (
-                        safe_div(integral(h_down), integral(h_nom)),
-                        safe_div(integral(h_up), integral(h_nom)),
-                    )
+                    if trafo_output.param_type.is_rate:
+                        # when then type changed to rate, we only need to save the converted rate effect
+                        __effects[param_obj.name] = trafo_output.effect
 
-                    # save them to file if they have shape-type
-                    if param_obj.type.is_shape:
-                        out_file[down_name] = h_down
-                        out_file[up_name] = h_up
+                    elif trafo_output.param_type.is_shape:
+                        # otherwise, handle shapes
+
+                        # create a shallow copy of the parameter object with potentially updated type
+                        _param_obj = DotDict({**param_obj, "type": trafo_output.param_type})
+
+                        # unpack shapes
+                        h_nom = trafo_output.h_nom
+                        h_down = trafo_output.h_varied[0]
+                        h_up = trafo_output.h_varied[1]
+
+                        # custom hook to modify the shapes
+                        h_nom, h_down, h_up = self.modify_parameter_shape(
+                            cat_obj,
+                            proc_obj,
+                            _param_obj,
+                            h_nom,
+                            h_down,
+                            h_up,
+                        )
+
+                        # fill empty bins again after all transformations
+                        fill_empty(cat_obj, h_down)
+                        fill_empty(cat_obj, h_up)
+
+                        # save the effect
+                        __effects[param_obj.name] = (
+                            safe_div(integral(h_down), integral(h_nom)),
+                            safe_div(integral(h_up), integral(h_nom)),
+                        )
+
+                        # store hists
+                        __out_hists[down_name] = h_down
+                        __out_hists[up_name] = h_up
+
+                # store the nominal hist too and move it to the front
+                __out_hists[nom_name] = h_nom
+                __out_hists.move_to_end(nom_name, last=False)
+                _nom_hists[proc_name] = h_nom
+                _rates[proc_name] = h_nom.sum().value
 
             # data handling, first checking if data should be faked, then if real data exists
             if cat_obj.data_from_processes:
@@ -878,7 +715,7 @@ class DatacardWriter(object):
                 h_data = []
                 for proc_name in cat_obj.data_from_processes:
                     if proc_name in proc_hists:
-                        h_data.extend([hd["nominal"] for hd in proc_hists[proc_name].values()])
+                        h_data.extend([hd[od.Shift.NOMINAL] for hd in proc_hists[proc_name].values()])
                     else:
                         logger.warning(f"process '{proc_name}' not found in histograms for creating fake data, skipping")
                 if not h_data:
@@ -888,7 +725,9 @@ class DatacardWriter(object):
                 h_data = sum_hists(h_data)
                 handle_flow(cat_obj, h_data, data_name)
                 h_data.view().variance = h_data.view().value
-                out_file[data_name] = h_data
+                _out_hists[data_name] = h_data
+                _out_hists.move_to_end(data_name, last=False)
+                _nom_hists["data"] = h_data
                 _rates["data"] = float(h_data.sum().value)
 
             elif proc_hists.get("data"):
@@ -908,13 +747,86 @@ class DatacardWriter(object):
                 h_data = sum_hists(h_data)
                 data_name = data_pattern.format(category=cat_name)
                 handle_flow(cat_obj, h_data, data_name)
-                out_file[data_name] = h_data
+                _out_hists[data_name] = h_data
+                _out_hists.move_to_end(data_name, last=False)
+                _nom_hists["data"] = h_data
                 _rates["data"] = h_data.sum().value
 
             else:
                 logger.warning(f"neither real data found nor fake data created in category '{cat_name}'")
 
-        return (rates, effects, nom_pattern_comb, syst_pattern_comb)
+        # write to file
+        q = collections.deque(out_hists.items())
+        with uproot.recreate(shapes_path) as out_file:
+            while q:
+                name, h = q.popleft()
+                if isinstance(h, dict):
+                    q.extendleft(reversed(h.items()))
+                else:
+                    out_file[name] = h
+
+        return self.ShapeData(
+            nominal_hists=nom_hists,
+            rates=rates,
+            shape_effects=effects,
+            parameter_types=param_types,
+            evaluated_trafos=evaluated_trafos,
+            nom_pattern=nom_pattern_comb,
+            syst_pattern=syst_pattern_comb,
+        )
+
+    def validate_model(self, inference_model_inst: InferenceModel) -> None:
+        # per category and process, validate all parameters
+        for cat_obj in inference_model_inst.categories:
+            for proc_obj in cat_obj.processes:
+                try:
+                    self.transformer.validate_parameters(proc_obj.parameters)
+                except Exception as e:
+                    raise ValueError(
+                        f"invalid parameters for process '{proc_obj.name}' in category '{cat_obj.name}': {e}",
+                    ) from e
+
+    def validate_histograms(self, histograms: DatacardHists) -> None:
+        import hist
+
+        # validate structure of histograms, shape keys and histogram types
+        errors: list[str] = []
+        for cat_name, proc_hists in histograms.items():
+            if not isinstance(cat_name, str):
+                errors.append(f"category name key '{cat_name}' is not a string")
+            for proc_name, config_hists in proc_hists.items():
+                if not isinstance(proc_name, str):
+                    errors.append(f"process name '{proc_name}' in category '{cat_name}' is not a string")
+                for config_name, shift_hists in config_hists.items():
+                    if not isinstance(config_name, str):
+                        errors.append(
+                            f"config name '{config_name}' for process '{proc_name}' in category '{cat_name}' is not a "
+                            f"string",
+                        )
+                    for shift_key, h in shift_hists.items():
+                        # shift_key must be nominal or a tuple of (param_name, "up|down")
+                        if (
+                            shift_key != od.Shift.NOMINAL and
+                            (
+                                not isinstance(shift_key, (tuple, list)) or
+                                len(shift_key) != 2 or
+                                shift_key[1] not in {od.Shift.UP, od.Shift.DOWN}
+                            )
+                        ):
+                            errors.append(
+                                f"invalid shift key '{shift_key}' in config '{config_name}' for process '{proc_name}' "
+                                f"in category '{cat_name}'",
+                            )
+                        if not isinstance(h, hist.Hist):
+                            errors.append(
+                                f"histogram for shift '{shift_key}' in config '{config_name}' for process "
+                                f"'{proc_name}' in category '{cat_name}' is not a hist.Hist instance",
+                            )
+
+        # handle errors
+        if errors:
+            errors_repr = "\n  - ".join(errors)
+            raise ValueError(f"datacard histograms invalid, reasons:\n  - {errors_repr}")
 
     @classmethod
     def align_lines(

--- a/columnflow/inference/transformation.py
+++ b/columnflow/inference/transformation.py
@@ -6,13 +6,22 @@ Parameter transformation definitions and utilities.
 
 from __future__ import annotations
 
+import dataclasses
+
 import law
 
-from columnflow.util import StrEnum, maybe_import
-from columnflow.types import TYPE_CHECKING, Sequence
+from columnflow.inference.parameter import ParameterType
+from columnflow.util import StrEnum, DotDict, maybe_import, safe_div
+from columnflow.types import TYPE_CHECKING, TypeAlias, Sequence, Union
 
+np = maybe_import("numpy")
 if TYPE_CHECKING:
     hist = maybe_import("hist")
+
+Effect: TypeAlias = Union[float, int, tuple[Union[float, int], Union[float, int]]]
+FloatEffect: TypeAlias = Union[float, tuple[float, float]]
+FloatsEffect: TypeAlias = tuple[float, float]
+DownUpHists: TypeAlias = tuple["hist.Hist", "hist.Hist"]
 
 
 logger = law.logger.get_logger(__name__)
@@ -182,15 +191,15 @@ ParameterTransformation.first_index_trafos = {
     ParameterTransformation.effect_from_shape_if_flat,
 }
 ParameterTransformation.shape_only_trafos = {
-    ParameterTransformation.effect_from_rate,
+    ParameterTransformation.effect_from_shape,
+    ParameterTransformation.effect_from_shape_if_flat,
     ParameterTransformation.normalize,
     ParameterTransformation.envelope,
     ParameterTransformation.envelope_if_one_sided,
     ParameterTransformation.envelope_enforce_two_sided,
 }
 ParameterTransformation.rate_only_trafos = {
-    ParameterTransformation.effect_from_shape,
-    ParameterTransformation.effect_from_shape_if_flat,
+    ParameterTransformation.effect_from_rate,
     ParameterTransformation.asymmetrize,
     ParameterTransformation.asymmetrize_if_large,
     ParameterTransformation.flip_smaller_if_one_sided,
@@ -272,3 +281,842 @@ class ParameterTransformations(tuple):
         :returns: *True* if any transformation changes the nominal histogram, *False* otherwise.
         """
         return any(t.changes_nominal for t in self)
+
+
+class ShapeTransformer:
+    """
+    Class that applies transformations to parameters and their associated histograms in a unified way.
+    """
+
+    default_effect_from_shape_if_flat_max_outlier: float = 0.2
+    default_effect_from_shape_if_flat_max_deviation: float = 0.1
+    default_asymmetrize_if_large_threshold: float = 0.2
+
+    class OutputType(StrEnum):
+        """
+        Flags denoting the output type of a transformation.
+        """
+
+        # effect values should be returned (if possible), and shapes otherwise
+        keep_effects = "keep_effects"
+        # rates are converted into varied shapes, and returned with actual shapes
+        convert_to_shapes = "convert_to_shapes"
+
+    @dataclasses.dataclass
+    class TransformationOutput:
+        """
+        Container object holding output of transformations in a unified format.
+        """
+
+        param_type: ParameterType
+        h_nom: hist.Hist | None
+        effect: Effect | None
+        h_varied: DownUpHists | None
+        param_type_changed: bool
+        nominal_changed: bool
+        variations_changed: bool
+        effect_changed: bool
+        output_type: ShapeTransformer.OutputType
+
+    @dataclasses.dataclass
+    class ProcessOutput:
+        """
+        Container object holding output of a sequence of parameters each with a potential sequence of transformations in
+        a unified format.
+        """
+
+        h_nom: hist.Hist | None
+        effects: dict[str, Effect | None]
+        h_varied: dict[str, DownUpHists | None]
+        trafo_outputs: dict[str, ShapeTransformer.TransformationOutput]
+        nominal_changed: bool
+        output_type: ShapeTransformer.OutputType
+
+    def __init__(
+        self,
+        effect_from_shape_if_flat_max_outlier: float | None = None,
+        effect_from_shape_if_flat_max_deviation: float | None = None,
+        asymmetrize_if_large_threshold: float | None = None,
+    ) -> None:
+        super().__init__()
+
+        # set thresholds
+        self.effect_from_shape_if_flat_max_outlier = (
+            self.default_effect_from_shape_if_flat_max_outlier
+            if effect_from_shape_if_flat_max_outlier is None
+            else effect_from_shape_if_flat_max_outlier
+        )
+        self.effect_from_shape_if_flat_max_deviation = (
+            self.default_effect_from_shape_if_flat_max_deviation
+            if effect_from_shape_if_flat_max_deviation is None
+            else effect_from_shape_if_flat_max_deviation
+        )
+        self.asymmetrize_if_large_threshold = (
+            self.default_asymmetrize_if_large_threshold
+            if asymmetrize_if_large_threshold is None
+            else asymmetrize_if_large_threshold
+        )
+
+    #
+    # high-level user interface
+    #
+
+    def apply_parameters(
+        self,
+        *,
+        param_objs: Sequence[DotDict],
+        h_nom: hist.Hist,
+        h_varied: Sequence[DownUpHists | None] | dict[str, DownUpHists | None] | None = None,
+        trafos: Sequence[Sequence[ParameterTransformation]] | None = None,
+        output_type: OutputType = OutputType.keep_effects,
+    ) -> ProcessOutput:
+        """
+        Applies a sequence of transformations to a sequence of parameters and their associated histograms.
+
+        :param param_objs: The parameter objects whose transformations are applied.
+        :param h_nom: The nominal histogram.
+        :param h_varied: The down/up variations of the nominal histogram, if applicable. Can be a sequence of
+            :py:class:`DownUpHists` or a dictionary mapping parameter names to :py:class:`DownUpHists`.
+        :param trafos: The sequence of transformations to apply for each parameter. If *None*, all transformations
+            registered to each parameter are used. The length must match the number of parameters.
+        :param output_type: The output type of the transformation.
+        :returns: A :py:class:`ProcessOutput` object containing the results of the transformations.
+        """
+        # validation across parameters
+        trafos = self.validate_parameters(param_objs, trafos)
+
+        # convert h_varied to dict type
+        if isinstance(h_varied, (list, tuple)):
+            if len(h_varied) != len(param_objs):
+                raise ValueError(
+                    f"number of passes varied histograms ({len(h_varied)}) does not match number of parameters "
+                    f"({len(param_objs)})",
+                )
+            h_varied = {param_obj.name: h for param_obj, h in zip(param_objs, h_varied)}
+
+        # eagerly build an output object that is adjusted in the param loop
+        output_type = self.OutputType(output_type)
+        output = self.ProcessOutput(
+            h_nom=h_nom,
+            effects={},
+            h_varied={},
+            trafo_outputs={},
+            nominal_changed=False,
+            output_type=output_type,
+        )
+
+        for param_obj, _trafos in zip(param_objs, trafos):
+            # apply trafos
+            trafos_output = self.apply_transformations(
+                param_obj=param_obj,
+                h_nom=output.h_nom,
+                h_varied=h_varied.get(param_obj.name, None),
+                trafos=_trafos,
+                output_type=output_type,
+            )
+
+            # update output fields
+            if trafos_output.nominal_changed:
+                output.h_nom = trafos_output.h_nom
+                output.nominal_changed = True
+            output.effects[param_obj.name] = trafos_output.effect
+            output.h_varied[param_obj.name] = trafos_output.h_varied
+            output.trafo_outputs[param_obj.name] = trafos_output
+
+        return output
+
+    def apply_transformations(
+        self,
+        *,
+        param_obj: DotDict,
+        h_nom: hist.Hist,
+        h_varied: DownUpHists | None = None,
+        trafos: Sequence[ParameterTransformation] | None = None,
+        output_type: OutputType = OutputType.keep_effects,
+    ) -> TransformationOutput:
+        """
+        Applies a sequence of transformations to a parameter and its associated histograms.
+
+        :param param_obj: The parameter object whose transformations are applied.
+        :param h_nom: The nominal histogram.
+        :param h_varied: The down/up variations of the nominal histogram, if applicable.
+        :param trafos: The sequence of transformations to apply. If *None*, all transformations registered to the
+            parameter are used.
+        :param output_type: The output type of the transformation.
+        :returns: A :py:class:`TransformationOutput` object containing the results of the transformations.
+        """
+        # default trafos
+        if trafos is None:
+            trafos = list(param_obj.transformations)
+
+        # eagerly build an output object that is adjusted in the trafo loop
+        output_type = self.OutputType(output_type)
+        output = self.TransformationOutput(
+            param_type=param_obj.type,
+            h_nom=h_nom,
+            effect=param_obj.effect if param_obj.type.is_rate else None,
+            h_varied=h_varied,
+            nominal_changed=False,
+            variations_changed=False,
+            effect_changed=False,
+            param_type_changed=False,
+            output_type=output_type,
+        )
+
+        # loop through transformations and apply them in order, including some validation
+        for i, trafo in enumerate(trafos):
+            # validation
+            if trafo.requires_first_index and i != 0:
+                raise ValueError(
+                    f"transformation '{trafo}' must be applied first, but is at sequence position {i} for parameter "
+                    f"'{param_obj.name}'",
+                )
+
+            # create an altered param_obj with values from the previous iteration injected
+            _param_obj = DotDict({**param_obj, "type": output.param_type, "effect": output.effect})
+
+            # apply the trafo
+            trafo_output = self.apply_transformation(
+                param_obj=_param_obj,
+                trafo=trafo,
+                h_nom=output.h_nom,
+                h_varied=output.h_varied,
+                output_type=self.OutputType.keep_effects,
+                _type_mismatch_postfix=f" after trafo sequence {','.join(map(str, trafos[:i]))}",
+            )
+
+            # update output fields
+            output.param_type = trafo_output.param_type
+            output.h_nom = trafo_output.h_nom
+            output.effect = trafo_output.effect
+            output.h_varied = trafo_output.h_varied
+            output.nominal_changed |= trafo_output.nominal_changed
+            output.variations_changed |= trafo_output.variations_changed
+            output.effect_changed |= trafo_output.effect_changed
+            output.param_type_changed |= trafo_output.param_type_changed
+
+        # adjust the output format
+        output = self.adjust_trafo_output(output, output_type, param_obj.name)
+
+        return output
+
+    def apply_transformation(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        h_varied: DownUpHists | None = None,
+        output_type: OutputType = OutputType.keep_effects,
+        _type_mismatch_postfix: str = "",
+    ) -> TransformationOutput:
+        """
+        Applies a single transformation to a parameter and the associated histograms.
+
+        :param param_obj: The parameter object whose transformation is applied.
+        :param trafo: The transformation to apply.
+        :param h_nom: The nominal histogram.
+        :param h_varied: The down/up variations of the nominal histogram, if applicable.
+        :param output_type: The output type of the transformation.
+        :returns: A :py:class:`TransformationOutput` object containing the results of the transformation.
+        """
+        # first check of the transormation can be applied to the parameter
+        if trafo.affects_rate_only and not param_obj.type.is_rate:
+            raise ValueError(
+                f"transformation '{trafo}' can only be applied to rate-type parameters, but parameter "
+                f"'{param_obj.name}' has type '{param_obj.type}'{_type_mismatch_postfix}",
+            )
+        if trafo.affects_shape_only and not param_obj.type.is_shape:
+            raise ValueError(
+                f"transformation '{trafo}' can only be applied to shape-type parameters, but parameter "
+                f"'{param_obj.name}' has type '{param_obj.type}'{_type_mismatch_postfix}",
+            )
+
+        # helper to raise in case varied hists are required but not provided
+        def require_h_varied() -> DownUpHists:
+            if h_varied is None:
+                raise ValueError(
+                    f"transformation '{trafo}' requires varied histograms, but none were provided for parameter "
+                    f"'{param_obj.name}'",
+                )
+            return h_varied
+
+        # eagerly build an output object that is adjusted below
+        output_type = self.OutputType(output_type)
+        output = self.TransformationOutput(
+            param_type=param_obj.type,
+            h_nom=h_nom,
+            effect=param_obj.effect if param_obj.type.is_rate else None,
+            h_varied=h_varied,
+            nominal_changed=False,
+            variations_changed=False,
+            effect_changed=False,
+            param_type_changed=False,
+            output_type=output_type,
+        )
+
+        # dispatch, and collect and unify output
+        if trafo.from_rate:
+            output.h_varied = self._apply_effect_from_rate(
+                param_obj=param_obj,
+                trafo=trafo,
+                h_nom=h_nom,
+                effect=param_obj.effect,
+            )
+            output.variations_changed = True
+            output.effect = None
+            output.effect_changed = True
+            output.param_type = ParameterType.shape
+            output.param_type_changed = True
+        elif trafo.from_shape:
+            d, u = self._apply_effect_from_shape(
+                param_obj=param_obj,
+                trafo=trafo,
+                h_nom=h_nom,
+                h_varied=require_h_varied(),
+            )
+            if isinstance(d, float):
+                output.effect = (d, u)
+                output.effect_changed = True
+                output.h_varied = None
+                output.variations_changed = True
+                output.param_type = ParameterType.rate_gauss
+                output.param_type_changed = True
+        elif trafo == ParameterTransformation.symmetrize:
+            if param_obj.type.is_rate:
+                output.effect = self._apply_symmetrize_rate(param_obj=param_obj, trafo=trafo, effect=param_obj.effect)
+                output.effect_changed = True
+            else:
+                output.h_varied = self._apply_symmetrize_shape(
+                    param_obj=param_obj,
+                    trafo=trafo,
+                    h_nom=h_nom,
+                    h_varied=require_h_varied(),
+                )
+                output.variations_changed = True
+        elif trafo in {
+            ParameterTransformation.asymmetrize,
+            ParameterTransformation.asymmetrize_if_large,
+        }:
+            output.effect = self._apply_asymmetrize_rate(param_obj=param_obj, trafo=trafo, effect=param_obj.effect)
+            output.effect_changed = True
+        elif trafo == ParameterTransformation.normalize:
+            output.h_varied = self._apply_normalize_shape(
+                param_obj=param_obj,
+                trafo=trafo,
+                h_nom=h_nom,
+                h_varied=require_h_varied(),
+            )
+            output.variations_changed = True
+        elif trafo == ParameterTransformation.centralize:
+            if param_obj.type.is_rate:
+                h_nom_updated, effect_updated = self._apply_centralize_rate(
+                    param_obj=param_obj,
+                    trafo=trafo,
+                    h_nom=h_nom,
+                    effect=param_obj.effect,
+                )
+                if h_nom_updated is not None:
+                    output.h_nom = h_nom_updated
+                    output.nominal_changed = True
+                    output.effect = effect_updated
+                    output.effect_changed = True
+            else:
+                output.h_nom = self._apply_centralize_shape(
+                    param_obj=param_obj,
+                    trafo=trafo,
+                    h_nom=h_nom,
+                    h_varied=require_h_varied(),
+                )
+                output.nominal_changed = True
+        elif trafo in {
+            ParameterTransformation.envelope,
+            ParameterTransformation.envelope_if_one_sided,
+            ParameterTransformation.envelope_enforce_two_sided,
+        }:
+            output.h_varied = self._apply_envelope_shape(
+                param_obj=param_obj,
+                trafo=trafo,
+                h_nom=h_nom,
+                h_varied=require_h_varied(),
+            )
+            output.variations_changed = True
+        elif trafo in {
+            ParameterTransformation.flip_smaller_if_one_sided,
+            ParameterTransformation.flip_larger_if_one_sided,
+        }:
+            output.effect = self._apply_flip_if_one_sided_rate(
+                param_obj=param_obj,
+                trafo=trafo,
+                effect=param_obj.effect,
+            )
+            output.effect_changed = True
+        else:
+            raise ValueError(f"unknown transformation '{trafo}'")
+
+        # adjust the output format
+        output = self.adjust_trafo_output(output, output_type, param_obj.name)
+
+        return output
+
+    #
+    # helpers to determine shape & effect features
+    #
+
+    @classmethod
+    def get_values(cls, inp: hist.Hist | np.ndarray, flow: bool = True) -> np.ndarray:
+        import hist
+        if isinstance(inp, hist.Hist):
+            view = inp.view(flow=flow)
+            inp = (
+                view.value
+                if isinstance(inp.storage_type(), (hist.storage.Weight, hist.storage.WeightedMean))
+                else view
+            )
+        if not isinstance(inp, np.ndarray):
+            raise TypeError(f"cannot extract values from unknown type {type(inp)}: {inp}")
+        return inp
+
+    @classmethod
+    def get_integral(cls, inp: hist.Hist | np.ndarray, flow: bool = True) -> float:
+        return float(sum(cls.get_values(inp, flow=flow)))
+
+    @classmethod
+    def validate_effect(cls, effect: Effect) -> bool:
+        valid_num = lambda n: isinstance(n, (float, int)) and n >= 0
+        if valid_num(effect):
+            return True
+        if isinstance(effect, tuple) and len(effect) == 2 and all(map(valid_num, effect)):
+            return True
+        raise ValueError(f"invalid effect {effect}: must be single value of 2-tuple of a non-negative float, int")
+
+    @classmethod
+    def split_effect(cls, effect: Effect) -> FloatsEffect:
+        cls.validate_effect(effect)
+        return (
+            (2.0 - float(effect), float(effect))
+            if isinstance(effect, (float, int))
+            else (float(effect[0]), float(effect[1]))
+        )
+
+    @classmethod
+    def assert_trafo_type(cls, trafo: ParameterTransformation, expected_trafos: set[ParameterTransformation]) -> None:
+        if trafo not in expected_trafos:
+            raise ValueError(
+                f"transformation '{trafo}' is not in the expected set of transformations: "
+                f"{', '.join(map(str, expected_trafos))}",
+            )
+
+    @classmethod
+    def validate_parameters(
+        cls,
+        param_objs: Sequence[DotDict],
+        trafos: Sequence[Sequence[ParameterTransformation]] | None = None,
+    ) -> Sequence[ParameterTransformations]:
+        # default trafos
+        if not trafos:
+            trafos = [list(param_obj.transformations) for param_obj in param_objs]
+        elif len(trafos) != len(param_objs):
+            raise ValueError(
+                f"number of transformation sequences ({len(trafos)}) does not match number of parameters "
+                f"({len(param_objs)})",
+            )
+
+        # cast
+        trafos = list(map(ParameterTransformations, trafos))
+
+        # two checks:
+        # 1. there can only be a single parameter with a transformation that can change the nominal shape
+        # 2. when a parameter has a transformation that might change the nominal shape, all other parameters must be
+        #    rate-type without any transformation that could convert them into a shape-type
+        nominal_changing_params = {
+            param_obj.name
+            for param_obj, _trafos in zip(param_objs, trafos)
+            if _trafos.any_changes_nominal
+        }
+        # check 1
+        if len(nominal_changing_params) > 1:
+            raise ValueError(
+                f"multiple parameters have transformations that change the nominal shape which is not supported: "
+                f"{', '.join(map(str, [p.name for p in nominal_changing_params]))}",
+            )
+        # check 2
+        if len(nominal_changing_params) == 1:
+            for param_obj, _trafos in zip(param_objs, trafos):
+                # only loop over other parameters
+                if param_obj.name in nominal_changing_params:
+                    continue
+                if param_obj.type.is_shape or (param_obj.type.is_rate and _trafos.any_changes_type):
+                    raise ValueError(
+                        f"parameter '{param_obj.name}' has transformations that could change its type to shape, but "
+                        f"another parameter has a transformation that changes the nominal shape which is not supported",
+                    )
+
+        return trafos
+
+    @classmethod
+    def adjust_trafo_output(
+        cls,
+        output: TransformationOutput,
+        output_type: OutputType,
+        param_name: str,
+    ) -> TransformationOutput:
+        # output is meant to be in "keep_effects" format initially
+
+        # do some cleaning first, saving normalization factors in the effect when variations are given
+        if output.h_varied is not None and output.effect is None:
+            output.effect = (
+                safe_div(cls.get_integral(output.h_varied[0]), cls.get_integral(output.h_nom)),
+                safe_div(cls.get_integral(output.h_varied[1]), cls.get_integral(output.h_nom)),
+            )
+
+        # nothing to be changed
+        if output_type == cls.OutputType.keep_effects:
+            return output
+
+        # below this point, effects must be converted into shapes
+        if output.h_varied is None:
+            if output.effect is None:
+                raise ValueError(
+                    f"output object for parameter '{param_name}' has neither varied histograms nor effect values: "
+                    f"'{output}'",
+                )
+            effect = cls.split_effect(output.effect)
+            output.h_varied = (
+                output.h_nom * effect[0],
+                output.h_nom * effect[1],
+            )
+
+        return output
+
+    def determine_shape_effect_is_flat(
+        self,
+        h_nom: hist.Hist | np.ndarray,
+        h_var: hist.Hist | np.ndarray,
+        flow: bool = True,
+    ) -> bool:
+        """
+        Determines if the effect of a shape variation is "flat".
+
+        :param h_nom: The nominal histogram.
+        :param h_var: The varied histogram.
+        :param flow: Whether to include underflow and overflow bins in the calculation.
+        :returns: *True* if the effect is flat, *False* otherwise.
+        """
+        diffs = self.get_values(h_nom, flow=flow) - self.get_values(h_var, flow=flow)
+        mean, std = abs(diffs.mean()), abs(diffs.std())
+        max_rel_outlier = safe_div(max(abs(diffs)), mean)
+        rel_deviation = safe_div(std, mean)
+        return (
+            max_rel_outlier <= self.effect_from_shape_if_flat_max_outlier and
+            rel_deviation <= self.effect_from_shape_if_flat_max_deviation
+        )
+
+    def determine_effect_is_large(self, effect: Effect) -> bool:
+        """
+        Determines if the effect is "large" based on the configured threshold.
+
+        :param effect: The effect to check.
+        :returns: *True* if the effect is large, *False* otherwise.
+        """
+        self.validate_effect(effect)
+        d, u = self.split_effect(effect)
+        return max(abs(d), abs(u)) >= self.asymmetrize_if_large_threshold
+
+    #
+    # low-level implementations of transformations with varying inputs & outputs
+    #
+
+    def _apply_effect_from_rate(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        effect: Effect,
+    ) -> DownUpHists:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.effect_from_rate` transformation. Only
+        applicable to rate-type parameters.
+        """
+        self.assert_trafo_type(trafo, {ParameterTransformation.effect_from_rate})
+        d, u = self.split_effect(effect)
+        return (
+            h_nom * d,
+            h_nom * u,
+        )
+
+    def _apply_effect_from_shape(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        h_varied: DownUpHists,
+    ) -> FloatsEffect | DownUpHists:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.effect_from_shape` and
+        :py:attr:`ParameterTransformation.effect_from_shape_if_flat` transformations. Only applicable to
+        shape-type parameters.
+        """
+        self.assert_trafo_type(
+            trafo,
+            {ParameterTransformation.effect_from_shape, ParameterTransformation.effect_from_shape_if_flat},
+        )
+        if trafo == ParameterTransformation.effect_from_shape_if_flat:
+            # check flat-ness criteria on both variations
+            d_flat = self.determine_shape_effect_is_flat(h_nom, h_varied[0])
+            u_flat = self.determine_shape_effect_is_flat(h_nom, h_varied[1])
+            # when any of them is not flat, return the shapes unchanged
+            if not d_flat or not u_flat:
+                return h_varied
+
+        # return integral down/up ratios w.r.t. nominal
+        n = self.get_integral(h_nom)
+        d = self.get_integral(h_varied[0])
+        u = self.get_integral(h_varied[1])
+        return (safe_div(d, n), safe_div(u, n))
+
+    def _apply_symmetrize_rate(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        effect: Effect,
+    ) -> Effect:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.symmetrize` transformation. Only applicable to
+        rate-type parameters.
+        """
+        self.assert_trafo_type(trafo, {ParameterTransformation.symmetrize})
+        if effect == 1:
+            return effect
+        d, u = self.split_effect(effect)
+        # skip one sided effects
+        if not (min(d, u) <= 1 <= max(d, u)):
+            logger.debug(
+                f"skipping rate symmetrization of parameter '{param_obj.name}' as effect '{effect}' is one-sided",
+            )
+            return (d, u)
+        # symmetrize by taking the mean of differences to 1
+        mean = 0.5 * (u + d) - 1
+        return (1 - mean, 1 + mean) if u >= d else (1 + mean, 1 - mean)
+
+    def _apply_symmetrize_shape(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        h_varied: DownUpHists,
+    ) -> DownUpHists:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.symmetrize` transformation. Only applicable to
+        shape-type parameters.
+        """
+        self.assert_trafo_type(trafo, {ParameterTransformation.symmetrize})
+        # get the absolute spread based on integrals
+        n = self.get_integral(h_nom)
+        d = self.get_integral(h_varied[0])
+        u = self.get_integral(h_varied[1])
+        # skip one sided effects
+        if not (min(d, n) <= n <= max(d, n)):
+            logger.info(f"skipping shape symmetrization of parameter '{param_obj.name}' as effect is one-sided")
+            return h_varied
+        # find the central point, compute the diff w.r.t. nominal, and shift
+        diff = 0.5 * (d + u) - n
+        h_d = h_varied[0] * safe_div(d - diff, d)
+        h_u = h_varied[1] * safe_div(u - diff, u)
+        return (h_d, h_u)
+
+    def _apply_asymmetrize_rate(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        effect: Effect,
+    ) -> Effect:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.asymmetrize` and
+        :py:attr:`ParameterTransformation.asymmetrize_if_large` transformations. Only applicable to rate-type
+        parameters.
+        """
+        self.assert_trafo_type(
+            trafo,
+            {ParameterTransformation.asymmetrize, ParameterTransformation.asymmetrize_if_large},
+        )
+        d, u = self.split_effect(effect)
+        # when the effect is too small, maybe return the original effect unchanged
+        if trafo == ParameterTransformation.asymmetrize_if_large:
+            if max(d, u) < self.asymmetrize_if_large_threshold:
+                return effect
+        # return the asymmetric representation
+        return (d, u)
+
+    def _apply_normalize_shape(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        h_varied: DownUpHists,
+    ) -> DownUpHists:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.normalize` transformation. Only applicable to
+        shape-type parameters.
+        """
+        self.assert_trafo_type(trafo, {ParameterTransformation.normalize})
+        n = self.get_integral(h_nom)
+        d = self.get_integral(h_varied[0])
+        u = self.get_integral(h_varied[1])
+        # return scaled variations
+        return (
+            h_varied[0] * safe_div(n, d),
+            h_varied[1] * safe_div(n, u),
+        )
+
+    def _apply_centralize_rate(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        effect: Effect,
+    ) -> tuple[hist.Hist | None, Effect]:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.centralize` transformation. Only applicable to
+        rate-type parameters.
+        """
+        self.assert_trafo_type(trafo, {ParameterTransformation.centralize})
+        d, u = self.split_effect(effect)
+        # do nothing when the effect is symmetric
+        if isinstance(effect, (float, int)) or (mean := 0.5 * (u + d)) == 1:
+            return None, effect
+        # simply scale histogram to mean and return adjust effects
+        width = u - d
+        return (
+            h_nom * mean,
+            (1 - 0.5 * width, 1 + 0.5 * width),
+        )
+
+    def _apply_centralize_shape(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        h_varied: DownUpHists,
+        propagate_variance: bool = False,
+    ) -> hist.Hist:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.centralize` transformation. Only applicable to
+        shape-type parameters.
+        """
+        self.assert_trafo_type(trafo, {ParameterTransformation.centralize})
+        # create copy of nominal histogram change values to be the mean of the two variations
+        h_central = h_nom.copy()
+        v_c = h_central.view(flow=True)
+        v_d = h_varied[0].view(flow=True)
+        v_u = h_varied[1].view(flow=True)
+        v_c.value[...] = 0.5 * (v_d.value + v_u.value)
+        # optionally use the error-propagated variance of the variations
+        if propagate_variance:
+            v_c.variance[...] = 0.25 * (v_d.variance + v_u.variance)
+        return h_central
+
+    def _apply_envelope_shape(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        h_nom: hist.Hist,
+        h_varied: DownUpHists,
+    ) -> DownUpHists:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.envelope`,
+        :py:attr:`ParameterTransformation.envelope_if_one_sided`, and
+        :py:attr:`ParameterTransformation.envelope_enforce_two_sided` transformations. Only applicable to shape-type
+        parameters.
+        """
+        self.assert_trafo_type(
+            trafo,
+            {
+                ParameterTransformation.envelope,
+                ParameterTransformation.envelope_if_one_sided,
+                ParameterTransformation.envelope_enforce_two_sided,
+            },
+        )
+        # prepare copies of histograms and views for in-place modifications
+        h_d = h_varied[0].copy()
+        h_u = h_varied[1].copy()
+        v_n = h_nom.view(flow=True)
+        v_d = h_d.view(flow=True)
+        v_u = h_u.view(flow=True)
+
+        if trafo in {ParameterTransformation.envelope, ParameterTransformation.envelope_if_one_sided}:
+            # compute masks denoting at which locations a variation is abs larger than the other
+            diffs_u = v_u.value - v_n.value
+            diffs_d = v_d.value - v_n.value
+            mask_u = abs(diffs_u) > abs(diffs_d)
+            mask_d = abs(diffs_d) > abs(diffs_u)
+            # when only checking one-sided, remove True's from the masks where variations are two-sided
+            if trafo == ParameterTransformation.envelope_if_one_sided:
+                one_sided = (diffs_u * diffs_d) > 0
+                mask_u &= one_sided
+                mask_d &= one_sided
+            # fill values from the larger variation
+            v_u.value[mask_d] = v_n.value[mask_d] - diffs_d[mask_d]
+            v_u.variance[mask_d] = v_d.variance[mask_d]
+            v_d.value[mask_u] = v_n.value[mask_u] - diffs_u[mask_u]
+            v_d.variance[mask_u] = v_u.variance[mask_u]
+
+        else:  # envelope_enforce_two_sided
+            # compute masks denoting at which locations a variation is abs larger than the other
+            abs_diffs_u = abs(v_u.value - v_n.value)
+            abs_diffs_d = abs(v_d.value - v_n.value)
+            mask_u = abs_diffs_u >= abs_diffs_d
+            mask_d = ~mask_u
+            # fill values from the absolute larger variation
+            v_u.value[mask_u] = v_n.value[mask_u] + abs_diffs_u[mask_u]
+            v_u.value[mask_d] = v_n.value[mask_d] + abs_diffs_d[mask_d]
+            v_u.variance[mask_d] = v_d.variance[mask_d]
+            v_d.value[mask_d] = v_n.value[mask_d] - abs_diffs_d[mask_d]
+            v_d.value[mask_u] = v_n.value[mask_u] - abs_diffs_u[mask_u]
+            v_d.variance[mask_u] = v_u.variance[mask_u]
+
+        return (h_d, h_u)
+
+    def _apply_flip_if_one_sided_rate(
+        self,
+        *,
+        param_obj: DotDict,
+        trafo: ParameterTransformation,
+        effect: Effect,
+    ) -> Effect:
+        """
+        Low-level implementation of the :py:attr:`ParameterTransformation.flip_smaller_if_one_sided` and
+        :py:attr:`ParameterTransformation.flip_larger_if_one_sided` transformations. Only applicable to rate-type
+        parameters.
+        """
+        self.assert_trafo_type(
+            trafo,
+            {ParameterTransformation.flip_smaller_if_one_sided, ParameterTransformation.flip_larger_if_one_sided},
+        )
+        d, u = self.split_effect(effect)
+        if isinstance(effect, (int, float)):
+            return effect
+        _min = min(d, u)
+        _max = max(d, u)
+        # handle cases
+        if _min < 1 and _max <= 1:
+            if trafo == ParameterTransformation.flip_smaller_if_one_sided:
+                return (d, 2 - u) if d < u else (2 - d, u)
+            else:  # flip_larger_if_one_sided
+                return (2 - d, u) if d < u else (d, 2 - u)
+        if _min >= 1 and _max > 1:
+            if trafo == ParameterTransformation.flip_smaller_if_one_sided:
+                return (2 - d, u) if d < u else (d, 2 - u)
+            else:  # flip_larger_if_one_sided
+                return (d, 2 - u) if d < u else (2 - d, u)
+        # not one-sided, return unchanged
+        return effect

--- a/columnflow/tasks/framework/base.py
+++ b/columnflow/tasks/framework/base.py
@@ -25,7 +25,7 @@ import order as od
 
 from columnflow.columnar_util import mandatory_coffea_columns, Route, ColumnCollection
 from columnflow.util import is_regex, prettify, DotDict, freeze
-from columnflow.types import Sequence, Callable, Any, T
+from columnflow.types import Sequence, Callable, Any, T, Literal
 
 
 logger = law.logger.get_logger(__name__)
@@ -449,7 +449,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         accept_patterns: bool = True,
         deep: bool | None = None,
         strict: bool = False,
-        multi_strategy: str = "first",
+        multi_strategy: Literal["first", "same", "union", "intersection", "all"] = "first",
     ) -> list[str] | dict[od.UniqueObject, list[str]]:
         """
         Returns all names of objects of type *object_cls* known to a *container* (e.g. :py:class:`od.Analysis` or
@@ -574,7 +574,7 @@ class AnalysisTask(BaseTask, law.SandboxTask):
         task_params: dict[str, Any],
         container: str | od.AuxDataMixin | Sequence[od.AuxDataMixin],
         default_str: str | None = None,
-        multi_strategy: str = "first",
+        multi_strategy: Literal["first", "same", "union", "intersection", "all"] = "first",
         debug: bool = False,
     ) -> Any | list[Any] | dict[od.AuxDataMixin, Any]:
         """

--- a/columnflow/tasks/framework/inference.py
+++ b/columnflow/tasks/framework/inference.py
@@ -178,11 +178,9 @@ class InferenceModelUser(
                     for param_obj in proc_obj.parameters:
                         if config_inst.name not in param_obj.config_data:
                             continue
-                        # only add if a shift is required for this parameter
-                        if (
-                            (param_obj.type.is_shape and not param_obj.transformations.any_from_rate) or
-                            (param_obj.type.is_rate and param_obj.transformations.any_from_shape)
-                        ):
+                        # check if a shift source is required for this parameter
+                        needs_source = param_obj.type.is_shape
+                        if needs_source and config_inst.name in param_obj.config_data:
                             shift_source = param_obj.config_data[config_inst.name].shift_source
                             for mc_dataset in mc_datasets:
                                 data["mc_datasets"][mc_dataset]["shift_sources"].add(shift_source)

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -24,12 +24,17 @@ from columnflow.tasks.framework.mixins import (
 from columnflow.tasks.framework.plotting import (
     PlotBase, PlotBase1D, PlotBase2D, PlotBase1DWithErrorBands, ProcessPlotSettingMixin, VariablePlotSettingMixin,
 )
+from columnflow.tasks.framework.inference import InferenceModelUser
 from columnflow.tasks.framework.decorators import view_output_plots
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
+from columnflow.inference import ParameterType
+from columnflow.inference.transformation import ShapeTransformer
 from columnflow.plotting import check_multi_variable_support, check_multi_category_support
-from columnflow.util import DotDict, dev_sandbox, maybe_import
-from columnflow.hist_util import add_missing_shifts, sum_hists, select_category_bins
+from columnflow.util import DotDict, dev_sandbox, maybe_import, pattern_matcher
+from columnflow.hist_util import (
+    add_missing_shifts, sum_hists, select_category_bins, insert_axis_values, ensure_bin_exists,
+)
 from columnflow.config_util import get_shift_from_configs, expand_shift_sources
 from columnflow.types import TYPE_CHECKING, TypeAlias, Any
 
@@ -763,3 +768,462 @@ class PlotShiftedVariablesPerShiftAndProcess1D(
             process: self.reqs.PlotShiftedVariablesPerShift1D.req(self, processes=(process,))
             for process in self.processes
         }
+
+
+class PlotVariablesBaseShiftsFromModel(
+    PlotVariablesBase,
+    InferenceModelUser,
+):
+    variables = PlotVariablesBase.variables.copy(
+        default=(),
+        add_default_to_description=True,
+    )
+    categories = law.CSVParameter(
+        default=(),
+        description="comma-separated category names or patterns to select from the inference model; to request a "
+        "category _not_ used by the model, a category string should have the format 'ANALYSIS_CATEGORY:MODEL_CATEGORY' "
+        "which will serve a mapping between them; if empty, all categories defined by the model will be used; default: "
+        "empty",
+        brace_expand=True,
+    )
+    skip_processes = law.CSVParameter(
+        default=(),
+        brace_expand=True,
+        description="names or patterns of processes to skip, based on all processes extract from the inference model; "
+        "default: empty",
+    )
+    nuisances = law.CSVParameter(
+        default=(),
+        brace_expand=True,
+        description="names or patterns of nuisance parameters to use from the inference model; if empty, all nuisances "
+        "defined by the model will be used; default: empty",
+    )
+    skip_nuisances = law.CSVParameter(
+        default=(),
+        brace_expand=True,
+        description="names or patterns of nuisance parameters to skip after evaluating --nuisances; default: empty",
+    )
+    split_nuisances = luigi.BoolParameter(
+        default=False,
+        description="whether to split the nuisance parameters and create plots for each nuisances; default: False",
+    )
+    # fix some upstream parameters
+    multi_variable = False
+    multi_category = False
+
+    # arguments to be passed to the internally used ShapeTransformer
+    shape_transformer_kwargs: dict[str, Any] = {}
+
+    # class-level settings from upstream tasks
+    allow_empty_categories = True
+    allow_empty_variables = True
+    resolution_task_cls = MergeShiftedHistograms
+
+    transfer_params_to_inst = {"category_map"}
+
+    @classmethod
+    def resolve_param_values_post_init(cls, params: dict[str, Any]) -> dict[str, Any]:
+        # skip category resolution
+        categories_orig = params.get("categories")
+        params = super().resolve_param_values_post_init(params)
+        params["categories"] = categories_orig
+
+        # model specific defaults and validations
+        if (config_insts := params.get("config_insts")) and (inference_model_inst := params.get("inference_model_inst")):
+            combined_config_data = params[cls._combined_config_data_attr]  # provided by InferenceModelUser
+
+            # expand / default variables
+            if (variables := params.get("variables")):
+                variables = cls.find_config_objects(
+                    names=variables,
+                    container=config_insts,
+                    object_cls=od.Variable,
+                    groups_str="variable_groups",
+                    multi_strategy="intersection",
+                )
+            else:
+                variables = sorted(law.util.make_unique(law.util.flatten(
+                    config_data["variables"] for config_data in combined_config_data.values()
+                )))
+            params["variables"] = tuple(variables)
+
+            # before evaluating categories, build a map "model category -> config categories"
+            full_catogory_map_rev = {
+                cat_obj.name: {
+                    config_data.category
+                    for config_name, config_data in cat_obj.config_data.items()
+                    if config_name in params["configs"]
+                }
+                for cat_obj in inference_model_inst.categories
+            }
+            full_category_map = {
+                cat_name: model_cat_name
+                for model_cat_name, cat_names in full_catogory_map_rev.items()
+                for cat_name in cat_names
+            }
+
+            # expand / default categories
+            category_map = {}
+            if (categories := params.get("categories")):
+                for cat_expr in categories:
+                    cat_pattern, model_cat_pattern = cat_expr.split(":", 1) if ":" in cat_expr else (cat_expr, None)
+
+                    # when model cat is a pattern, it should expand to exactly one actual name
+                    model_cat_name = None
+                    if model_cat_pattern:
+                        matcher = pattern_matcher(model_cat_pattern)
+                        for _model_cat_name in full_catogory_map_rev.keys():
+                            if matcher(_model_cat_name):
+                                if model_cat_name is not None:
+                                    raise Exception(
+                                        f"model category pattern '{model_cat_pattern}' matches multiple model "
+                                        f"categories ('{model_cat_name}' and '{_model_cat_name}'); please specify a "
+                                        "more specific pattern or use an exact name",
+                                    )
+                                model_cat_name = _model_cat_name
+                        if model_cat_name is None:
+                            raise Exception(
+                                f"model category pattern '{model_cat_pattern}' does not match any model category",
+                            )
+
+                    # expand category pattern
+                    cat_names = cls.find_config_objects(
+                        names=cat_pattern,
+                        container=config_insts,
+                        object_cls=od.Category,
+                        groups_str="category_groups",
+                        multi_strategy="intersection",
+                    )
+
+                    # fill the map
+                    for cat_name in cat_names:
+                        if model_cat_name is None and cat_name not in full_category_map:
+                            raise Exception(
+                                f"category '{cat_name}' is not defined in the inference model; using the syntax "
+                                "'CATEGORY:MODEL_CATEGORY', as MODEL_CATEGORY, specify any of "
+                                f"{','.join(full_catogory_map_rev)}",
+                            )
+                        category_map[cat_name] = model_cat_name or full_category_map[cat_name]
+            else:
+                category_map.update(full_category_map)
+            params["categories"] = tuple(sorted(category_map.keys()))
+            params["category_map"] = {cat_name: category_map[cat_name] for cat_name in params["categories"]}
+
+        return params
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # constraint: since the plotting requires actual process instances with labels, etc, it is currently not
+        # supported for the inference model to use the same config process multiple times within the same config object
+        # to compose different model processes, e.g.
+        #   proc obj a
+        #     -> config x
+        #       -> process tt
+        #   proc obj b
+        #     -> config x
+        #       -> process tt
+        for category in self.categories:
+            cat_obj = self.inference_model_inst.get_category(self.category_map[category])
+            config_processes = collections.defaultdict(lambda: collections.defaultdict(set))
+            for proc_obj in cat_obj.processes:
+                for config_name, proc_data in proc_obj.config_data.items():
+                    config_processes[config_name][proc_data.process].add(proc_obj.name)
+            for config_name, proc_map in config_processes.items():
+                for proc_name, proc_obj_names in proc_map.items():
+                    if len(proc_obj_names) > 1:
+                        raise Exception(
+                            f"in category '{category}' (model category '{self.cartegory_map[category]}') for config "
+                            f"'{config_name}', process '{proc_name}' is used by multiple model processes "
+                            f"({','.join(proc_obj_names)}); this is currently not supported for plotting",
+                        )
+
+    @property
+    def processes_repr(self) -> str:
+        return DatasetsProcessesMixin._processes_repr(self.processes)
+
+    @property
+    def datasets_repr(self) -> str:
+        return DatasetsProcessesMixin._datasets_repr(self.datasets)
+
+    @classmethod
+    def _nuisances_repr(cls, nuisances: set[str]) -> str:
+        return cls._multi_sequence_repr(nuisances, sort=True)
+
+    @property
+    def nuisances_repr(self) -> str:
+        return (
+            self._nuisances_repr(self.nuisance_map[self.branch_data.category])
+            if self.is_branch()
+            else self._nuisances_repr(set.union(*self.nuisance_map.values()))
+        )
+
+    @law.workflow_property(cache=True)
+    def processes(self) -> tuple[tuple[str]]:
+        config_data = self.combined_config_data
+        exclude = pattern_matcher(self.skip_processes) if self.skip_processes else (lambda proc_name: False)
+        include = lambda proc_name: not exclude(proc_name)
+        return tuple(
+            tuple(filter(include, set.union(*(mc_data.proc_names for mc_data in config_data.mc_datasets.values()))))
+            for config_inst, config_data in config_data.items()
+        )
+
+    @law.workflow_property(cache=True)
+    def nuisance_map(self) -> dict[str, set[str]]:
+        # collect list of all nuisance parameters that need to be accounted for, mapped to categories
+        # (merely for filtering and constructing requirements)
+        nuisance_map = {cat_name: set() for cat_name in self.categories}
+
+        # collect all nuisances from the model
+        category_map_rev = dict(zip(self.category_map.values(), self.category_map.keys()))
+        supported_parameter_types = {ParameterType.rate_gauss, ParameterType.rate_uniform, ParameterType.shape}
+        for cat_obj_name, _, param_obj in self.inference_model_inst.iter_parameters(category=self.category_map.values()):
+            # consider only specific parameter types
+            if param_obj.type in supported_parameter_types:
+                nuisance_map[category_map_rev[cat_obj_name]].add(param_obj.name)
+            else:
+                self.logger.warning(
+                    f"parameter '{param_obj.name}' has unsupported type '{param_obj.type}', skipping it for nuisance "
+                    f"parameter selection; supported types are {supported_parameter_types}",
+                )
+
+        # per category, filter with inclusion and exclusion lists
+        if self.nuisances or self.skip_nuisances:
+            for cat_name, nuisances in nuisance_map.items():
+                if self.nuisances:
+                    include = pattern_matcher(self.nuisances)
+                    nuisances = set(filter(include, nuisances))
+                if self.skip_nuisances:
+                    exclude = pattern_matcher(self.skip_nuisances)
+                    not_exclude = lambda n: not exclude(n)
+                    nuisances = set(filter(not_exclude, nuisances))
+                nuisance_map[cat_name] = nuisances
+
+        # raise on empty nuisance sets
+        for cat_name, nuisances in nuisance_map.items():
+            if not nuisances:
+                raise Exception(f"no nuisance parameters found for category '{cat_name}'")
+
+        return nuisance_map
+
+    @law.workflow_property(cache=True)
+    def shift_sources(self) -> dict[od.Config, dict[str, str]]:
+        # determine shift sources to request per config, mapping from nuisance name to source name
+        shift_sources = {config_inst: {} for config_inst in self.config_insts}
+
+        # get all shift sources
+        config_map = {config_inst.name: config_inst for config_inst in self.config_insts}
+        for cat_name, nuisances in self.nuisance_map.items():
+            for _, _, param_obj in self.inference_model_inst.iter_parameters(category=self.category_map[cat_name]):
+                # skip if parameter is not in the nuisances for that category
+                if param_obj.name not in self.nuisance_map[cat_name]:
+                    continue
+                # skip if no shift is required to model the parameter effect
+                from_shift = (
+                    (param_obj.type.is_shape and not param_obj.transformations.any_from_rate) or
+                    (param_obj.type.is_rate and param_obj.transformations.any_from_shape)
+                )
+                if not from_shift:
+                    continue
+                # add to shift sources
+                for config_name, config_data in param_obj.config_data.items():
+                    shift_sources[config_map[config_name]][param_obj.name] = config_data.shift_source
+
+        return shift_sources
+
+    @law.workflow_property(cache=True)
+    def datasets(self) -> list[list[str]]:
+        # define which datasets are required per config, potentially filtered by selected processes to show
+        # (not a dict, same order as config_insts as per structural design of parent classes)
+        all_datasets = []
+        for (config_inst, config_data), processes in zip(self.combined_config_data.items(), self.processes):
+            datasets = []
+
+            # add mc datasets
+            proc_insts = set(map(config_inst.get_process, processes))
+            procs_match = lambda p1, p2: p1 == p2 or p1.has_process(p2) or p2.has_process(p1)
+            for dataset_name in config_data.mc_datasets:
+                dataset_proc_inst = config_inst.get_dataset(dataset_name).processes.get_first()
+                if any(procs_match(dataset_proc_inst, proc_inst) for proc_inst in proc_insts):
+                    datasets.append(dataset_name)
+
+            # add data datasets
+            datasets.extend(list(config_data.data_datasets))
+            all_datasets.append(datasets)
+
+        return all_datasets
+
+    def create_branch_map(self) -> list[DotDict]:
+        branch_data = super().create_branch_map()
+
+        if self.split_nuisances:
+            branch_data = [
+                DotDict({**d, "nuisance": nuisance})
+                for d in branch_data
+                for nuisance in sorted(self.nuisance_map[d["category"]])
+            ]
+
+        return branch_data
+
+    def req_workflow(self, **kwargs) -> PlotVariablesBaseShiftsFromModel:
+        kwargs["categories"] = tuple(":".join(pair) for pair in self.category_map.items())
+        return super().req_workflow(**kwargs)
+
+    def req_branch(self, branch: int, **kwargs) -> PlotVariablesBaseShiftsFromModel:
+        kwargs["categories"] = tuple(":".join(pair) for pair in self.category_map.items())
+        return super().req_branch(branch, **kwargs)
+
+    def requires_histograms(self, config_inst: od.Config, dataset_name: str, **kwargs) -> Any:
+        dataset_is_mc = config_inst.get_dataset(dataset_name).is_mc
+        kwargs |= {
+            "config": config_inst.name,
+            "dataset": dataset_name,
+            "shift_sources": ("nominal", *(self.shift_sources[config_inst].values() if dataset_is_mc else ())),
+        }
+        return self.reqs.MergeShiftedHistograms.req_different_branching(self, **kwargs)
+
+    def plot_parts(self) -> law.util.InsertableDict:
+        parts = super().plot_parts()
+
+        # nuisance(s)
+        nuisance_repr = ""
+        if self.split_nuisances:
+            nuisance_repr = f"nparam_{self.branch_data.nuisance}"
+        elif (nuisances_repr := self.nuisances_repr):
+            nuisance_repr = f"nparams_{nuisances_repr}"
+        if nuisance_repr:
+            parts.insert_before("hook", "nuisance", nuisance_repr)
+
+        return parts
+
+    def get_plot_parameters(self) -> dict[str, Any]:
+        params = super().get_plot_parameters()
+
+        # add nuisance parameter name if split_nuisances is enabled
+        if self.split_nuisances and self.is_branch():
+            params["syst_error_label"] = f"{self.branch_data.nuisance} unc."
+
+        return params
+
+    def get_plot_shifts(self) -> list[od.Shift]:
+        # only to be called by branch tasks
+        if self.is_workflow():
+            raise Exception("calls to get_plots_shifts are forbidden for workflow tasks")
+
+        # gather all actual shifts and expand to up/down shifts
+        shifts = [self.config_insts[0].shifts.n.nominal]
+        seen = set()
+        for config_inst, source_map in self.shift_sources.items():
+            if not self.split_nuisances:
+                _shift_names = expand_shift_sources(source_map.values())
+            elif self.branch_data.nuisance in source_map:
+                _shift_names = expand_shift_sources(source_map[self.branch_data.nuisance])
+            else:
+                continue
+            for _shift in map(functools.partial(get_shift_from_configs, [config_inst]), _shift_names):
+                if _shift.name not in seen:
+                    shifts.append(_shift)
+                    seen.add(_shift.name)
+
+        return shifts
+
+    def update_hists_before_config_merging(
+        self,
+        hists: ConfigHists,
+        category_name: str,
+        variable_name: str,
+    ) -> ConfigHists:
+        import hist
+
+        # determine which nuisances to consider for this category
+        nuisances = {self.branch_data.nuisance} if self.split_nuisances else self.nuisance_map[category_name]
+
+        # build mapping "proc name -> config name -> arameter objects"
+        param_map = collections.defaultdict(dict)
+        for proc_objs in self.inference_model_inst.get_processes(category=self.category_map[category_name]).values():
+            for proc_obj in proc_objs:
+                for config_name, config_data in proc_obj.config_data.items():
+                    param_map[config_data.process][config_name] = [
+                        param_obj
+                        for param_obj in proc_obj.parameters
+                        if param_obj.name in nuisances
+                    ]
+
+        # create a shape transformer helper, for now with defaults
+        transformer = ShapeTransformer(**(self.shape_transformer_kwargs or {}))
+
+        for config_inst, proc_hists in hists.items():
+            for proc_inst, h_all in proc_hists.items():
+                # pick the nominal histogram only, but keep the shift axis which is extended below
+                h = h_all[{"shift": [hist.loc("nominal")]}]
+
+                # check which nuisances should be added through parameter objects as shifts
+                param_objs = param_map.get(proc_inst.name, {})[config_inst.name]
+                if param_objs:
+                    # ensure that the shift axis contains all parameters
+                    h = ensure_bin_exists(h, "shift", expand_shift_sources(param_obj.name for param_obj in param_objs))
+
+                    # prepare nominal and varied histograms for the transformer
+                    h_nom = h[{"shift": hist.loc("nominal")}]
+                    h_varied = {}
+                    for param_obj in param_objs:
+                        if param_obj.config_data and config_inst.name in param_obj.config_data:
+                            source = param_obj.config_data[config_inst.name].shift_source
+                            down_up_hists = []
+                            for shift in expand_shift_sources(source, down_first=True):
+                                if shift not in h_all.axes["shift"]:
+                                    raise Exception(
+                                        f"histogram for process '{proc_inst.name}' in config '{config_inst.name}' does "
+                                        f"not contain shift '{shift}' as required for parameter '{param_obj.name}'",
+                                    )
+                                down_up_hists.append(h_all[{"shift": hist.loc(shift)}])
+                            h_varied[param_obj.name] = tuple(down_up_hists)
+                        else:
+                            h_varied[param_obj.name] = None
+
+                    # perform transformations
+                    output = transformer.apply_parameters(
+                        param_objs=param_objs,
+                        h_nom=h_nom,
+                        h_varied=h_varied,
+                        output_type=ShapeTransformer.OutputType.convert_to_shapes,
+                    )
+
+                    # when the nominal hist was updated, inject it's values back into h
+                    # (can happen in certain circumstances depending on some transformations)
+                    if output.nominal_changed:
+                        insert_axis_values(h, "shift", "nominal", output.h_nom)
+
+                    # insert varied shapes into full hist
+                    for param_name, (h_down, h_up) in output.h_varied.items():
+                        insert_axis_values(h, "shift", f"{param_name}_{od.Shift.UP}", h_up)
+                        insert_axis_values(h, "shift", f"{param_name}_{od.Shift.DOWN}", h_down)
+
+                # store the updated histogram
+                proc_hists[proc_inst] = h
+
+        return hists
+
+    def update_shifts_before_plotting(self, shifts: list[od.Shift], hists: MergedHistDicts) -> list[od.Shift]:
+        # hists has only one entry, so unpack values
+        proc_hists = next(iter(hists.values()))
+
+        # collect all shifts from histograms (they were introduced in update_hists_before_config_merging and resemble
+        # nuisance parameters rather than actual shifts that exist in the config)
+        shift_names = set.union(*(set(h.axes["shift"]) for h in proc_hists.values()))
+
+        # create fake shift objects with nominal id 0, even up and odd down ids
+        shift_names = ["nominal"] + sorted(shift_names - {"nominal"})[::-1]
+        shifts = [od.Shift(name=shift_name, id=i) for i, shift_name in enumerate(shift_names)]
+
+        return shifts
+
+
+class PlotShiftedVariablesFromModel1D(
+    PlotBase1DWithErrorBands,
+    PlotVariablesBaseShiftsFromModel,
+):
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.plot_functions_1d.plot_variable_stack",
+        add_default_to_description=True,
+    )

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -33,7 +33,7 @@ from columnflow.inference.transformation import ShapeTransformer
 from columnflow.plotting import check_multi_variable_support, check_multi_category_support
 from columnflow.util import DotDict, dev_sandbox, maybe_import, pattern_matcher
 from columnflow.hist_util import (
-    add_missing_shifts, sum_hists, select_category_bins, insert_axis_values, ensure_bin_exists,
+    add_missing_shifts, sum_hists, sum_hists_shift_aware, select_category_bins, insert_axis_values, ensure_bin_exists,
 )
 from columnflow.config_util import get_shift_from_configs, expand_shift_sources
 from columnflow.types import TYPE_CHECKING, TypeAlias, Any
@@ -363,18 +363,17 @@ class PlotVariablesBase(_PlotVariablesBase):
 
                         # loop and extract one histogram per process
                         for process_inst, process_info in config_process_map[config_inst].items():
-                            if dataset_inst not in process_info["dataset_proc_name_map"].keys():
+                            # get subprocess names to merge
+                            if not (subproc_names := process_info["dataset_proc_name_map"].get(dataset_inst)):
                                 continue
 
-                            # select processes and reduce axis
+                            # select and merge processes
                             h = h_in[{
                                 "process": [
                                     hist.loc(proc_name)
-                                    for proc_name in process_info["dataset_proc_name_map"][dataset_inst]
-                                    if proc_name in h_in.axes["process"]
+                                    for proc_name in set(subproc_names) & set(h_in.axes["process"])
                                 ],
-                            }]
-                            h = h[{"process": sum}]
+                            }][{"process": sum}]
 
                             # skip empty histograms right away
                             if h.empty():
@@ -786,6 +785,13 @@ class PlotVariablesBaseShiftsFromModel(
         "empty",
         brace_expand=True,
     )
+    merge_processes = law.CSVParameter(
+        default=(),
+        brace_expand=True,
+        description="names or patterns of processes to select from the inference model and optionally merge; if empty, "
+        "all processes defined by the model will be used unchanged; can also be the key of a mapping defined in the "
+        "'process_groups' auxiliary data of the config; default: empty",
+    )
     skip_processes = law.CSVParameter(
         default=(),
         brace_expand=True,
@@ -909,12 +915,42 @@ class PlotVariablesBaseShiftsFromModel(
             params["categories"] = tuple(sorted(category_map.keys()))
             params["category_map"] = {cat_name: category_map[cat_name] for cat_name in params["categories"]}
 
+            # expand merge processes
+            if (merge_processes := params.get("merge_processes")):
+                merge_processes = cls.find_config_objects(
+                    names=merge_processes,
+                    container=config_insts,
+                    object_cls=od.Process,
+                    groups_str="process_groups",
+                    multi_strategy="intersection",
+                )
+                params["merge_processes"] = tuple(merge_processes)
+
         return params
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    @property
+    def processes_repr(self) -> str:
+        return DatasetsProcessesMixin._processes_repr(self.merge_processes or self.processes)
 
-        # constraint: since the plotting requires actual process instances with labels, etc, it is currently not
+    @property
+    def datasets_repr(self) -> str:
+        return DatasetsProcessesMixin._datasets_repr(self.datasets)
+
+    @classmethod
+    def _nuisances_repr(cls, nuisances: set[str]) -> str:
+        return cls._multi_sequence_repr(nuisances, sort=True)
+
+    @property
+    def nuisances_repr(self) -> str:
+        return (
+            self._nuisances_repr(self.nuisance_map[self.branch_data.category])
+            if self.is_branch()
+            else self._nuisances_repr(set.union(*self.nuisance_map.values()))
+        )
+
+    @law.workflow_property(cache=True)
+    def processes(self) -> tuple[tuple[str]]:
+        # validation: since the plotting requires actual process instances with labels, etc, it is currently not
         # supported for the inference model to use the same config process multiple times within the same config object
         # to compose different model processes, e.g.
         #   proc obj a
@@ -938,33 +974,32 @@ class PlotVariablesBaseShiftsFromModel(
                             f"({','.join(proc_obj_names)}); this is currently not supported for plotting",
                         )
 
-    @property
-    def processes_repr(self) -> str:
-        return DatasetsProcessesMixin._processes_repr(self.processes)
-
-    @property
-    def datasets_repr(self) -> str:
-        return DatasetsProcessesMixin._datasets_repr(self.datasets)
-
-    @classmethod
-    def _nuisances_repr(cls, nuisances: set[str]) -> str:
-        return cls._multi_sequence_repr(nuisances, sort=True)
-
-    @property
-    def nuisances_repr(self) -> str:
-        return (
-            self._nuisances_repr(self.nuisance_map[self.branch_data.category])
-            if self.is_branch()
-            else self._nuisances_repr(set.union(*self.nuisance_map.values()))
-        )
-
-    @law.workflow_property(cache=True)
-    def processes(self) -> tuple[tuple[str]]:
+        # extract all processes from model that are required and not explicitly skipped
         config_data = self.combined_config_data
-        exclude = pattern_matcher(self.skip_processes) if self.skip_processes else (lambda proc_name: False)
-        include = lambda proc_name: not exclude(proc_name)
+        merge_proc_insts = {
+            config_inst: [config_inst.get_process(proc_name) for proc_name in self.merge_processes]
+            for config_inst in config_data
+        }
+        exclude_matcher = pattern_matcher(self.skip_processes) if self.skip_processes else (lambda proc_name: False)
+        def needed(config_inst: od.Config, proc_name: str) -> bool:
+            if exclude_matcher(proc_name):
+                return False
+            if self.merge_processes:
+                _proc_inst = config_inst.get_process(proc_name)
+                in_merge_processes = any(
+                    proc_inst == _proc_inst or proc_inst.has_process(_proc_inst, deep=True)
+                    for proc_inst in merge_proc_insts[config_inst]
+                )
+                if not in_merge_processes:
+                    return False
+            return True
+
         return tuple(
-            tuple(filter(include, set.union(*(mc_data.proc_names for mc_data in config_data.mc_datasets.values()))))
+            tuple(
+                proc_name
+                for proc_name in set.union(*(mc_data.proc_names for mc_data in config_data.mc_datasets.values()))
+                if needed(config_inst, proc_name)
+            )
             for config_inst, config_data in config_data.items()
         )
 
@@ -1133,12 +1168,19 @@ class PlotVariablesBaseShiftsFromModel(
         category_name: str,
         variable_name: str,
     ) -> ConfigHists:
+        """
+        Hook that uses all read histograms to
+        - insert missing nuisance parameters through bins on the "shift" axis,
+        - apply all parameter transformations to histograms, and
+        - optionally merge processes.
+        """
         import hist
 
         # determine which nuisances to consider for this category
         nuisances = {self.branch_data.nuisance} if self.split_nuisances else self.nuisance_map[category_name]
 
-        # build mapping "proc name -> config name -> arameter objects"
+        # build mapping "proc name -> config name -> parameter objects"
+        # (the latter are filtered by selected nuisances)
         param_map = collections.defaultdict(dict)
         for proc_objs in self.inference_model_inst.get_processes(category=self.category_map[category_name]).values():
             for proc_obj in proc_objs:
@@ -1152,6 +1194,7 @@ class PlotVariablesBaseShiftsFromModel(
         # create a shape transformer helper, for now with defaults
         transformer = ShapeTransformer(**(self.shape_transformer_kwargs or {}))
 
+        # go through all histograms and apply the parameter transformations to them, injecting the resulting shapes back
         for config_inst, proc_hists in hists.items():
             for proc_inst, h_all in proc_hists.items():
                 # pick the nominal histogram only, but keep the shift axis which is extended below
@@ -1181,7 +1224,7 @@ class PlotVariablesBaseShiftsFromModel(
                         else:
                             h_varied[param_obj.name] = None
 
-                    # perform transformations
+                    # perform transformations, force creation of shapes regardless of parameter type (rate or shape)
                     output = transformer.apply_parameters(
                         param_objs=param_objs,
                         h_nom=h_nom,
@@ -1202,9 +1245,32 @@ class PlotVariablesBaseShiftsFromModel(
                 # store the updated histogram
                 proc_hists[proc_inst] = h
 
+            # optional merging
+            if self.merge_processes:
+                orig_hists = proc_hists.copy()
+                proc_hists.clear()
+                for proc_name in self.merge_processes:
+                    proc_inst = config_inst.get_process(proc_name)
+                    _hists = []
+                    for _proc_inst, h in list(orig_hists.items()):
+                        if _proc_inst == proc_inst or proc_inst.has_process(_proc_inst, deep=True):
+                            orig_hists.pop(_proc_inst)
+                            _hists.append(h)
+                    if hists:
+                        proc_hists[proc_inst] = sum_hists_shift_aware(_hists)
+                    else:
+                        self.logger.warning(
+                            f"no processes histograms found to merge into process histogram '{proc_name}'; existing "
+                            f"processes were {','.join(p.name for p in orig_hists)}",
+                        )
+
         return hists
 
     def update_shifts_before_plotting(self, shifts: list[od.Shift], hists: MergedHistDicts) -> list[od.Shift]:
+        """
+        Hook used to extend list of shifts considered for plotting by those found in histograms (as per
+        :py:meth:`update_hists_before_config_merging`).
+        """
         # hists has only one entry, so unpack values
         proc_hists = next(iter(hists.values()))
 


### PR DESCRIPTION
This PR is rather extensive, but I try to keep the description short.

## Changes

- Added `PlotVariablesBaseShiftsFromModel` (base) and `PlotShiftedVariablesFromModel1D` (our usual, user-exposed 1D-implementation) tasks. (features below)
- The uncertainties that make up the syst. error band are taken directly from the model's per-category-per-process nuisance parameters. **For correct plotting, all transformations must be applied, just as for writing datacards**.
- The previous point required to externalize the shape/rate transformations which - so far - were hard-coded into the `DatacardWriter`. Now, there is a `ShapeTransformer` helper, which can be passed any sequence of parameters and transformations, plus the associated histograms on which their effects are propagated in order. This is also helpful for exporting statistical models in different serialization formats (e.g. hs3).
- The newly introduced `ShapeTransformer` is also used by the `DatacardWriter` now, which in turn lost a lot of boiler-plate code related to transformations. 🚀

## New features

`PlotShiftedVariablesFromModel1D` provides various plotting options:

- `--inference-model MODEL` → the underlying model to use
- `--variables VARS,...` → variables to plot; defaults to the model variables, but any variable selection is possible
- `--categories CATS,...` → categories to plot; **note** that the inference model might define different uses for its own model categories; if the matching between requested (config) categories and model categories is **not straight forward**, each category in the sequence should be passed as `CONFIG_CAT:MODEL_CAT`, which provides the matching and thus, the assignment of nuisances to the requested category.
- `--nuisances NAME,...` → A list of nuisance names (patterns supported) to select from the model.
- `--skip-nuisances NAME,...` → A list of nuisance names (patterns supported) to **not** select from the model.
- `--split-nuisances` → When defined, one plot per nuisances is created.
- `--merge-processes` → When defined, processes extracted from the inference model are merging according to this comma-separated list of (parent) processes with pattern and group support. Other plotting tasks use `--processes` for the same purposes, however, due to the interactions with the inference model and parameter transformation that need to act *before* merging, the same mechanism cannot be used. 

## Potentially breaking changes

Not really a change, but a bug-fix in relation to how the transformations `effect_from_{rate,shape,shape_if_flat}` were implemented.

Before, `effect_from_rate` (`effect_from_shape*`) could only be assigned to a parameter object, whose type was `shape` (`rate`), thereby requiring users to foreshadow the potential type change. This becomes an issue with `effect_from_shape_if_flat`, which **may** or **may not** change the type from `shape` to `rate`.

Therefore, the `type` field of parameter objects is now to be seen as the "initial" type, and the sequence of transformations can alter that to result in the "actual" type. This is also the reason why all high-level methods of the `ShapeTransformer` return structured objects, which allow an exact tracking of what changed during the sequential application of transformations (including the evaluated type).

tidbit: With that, to identify whether an actual shift source must be requested from upstream workflows becomes as easy as checking `type.is_shape`, rather than having to check for potential type-changing transformations as before.

tl;dr: If you did not use `effect_from_{rate,shape,shape_if_flat}`, you are not affected. If you did, then flip the parameter type from `rate` to `shape` and vice-versa in these cases. There will be a verbose exception if you don't flip the types, rather than some silent unknown behavior 👍

@mafrahm @Lara813 @LennertGriesing @aalvesan @wolfmor 
feel free to review