### PR TITLE
Include multi-version, stack fraction for 1D plotting

### DIFF
--- a/columnflow/plotting/__init__.py
+++ b/columnflow/plotting/__init__.py
@@ -44,3 +44,11 @@ def check_multi_category_support(plot_func: Callable) -> bool:
     Helper to check if a plot function supports multi-category plotting.
     """
     return "multi_category" in _get_plot_features(plot_func)
+
+def supports_multi_version(plot_func: Callable) -> Callable:
+    _add_plot_feature(plot_func, "multi_version")
+    return plot_func
+
+
+def check_multi_version_support(plot_func: Callable) -> bool:
+    return "multi_version" in _get_plot_features(plot_func)

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -53,6 +53,7 @@ def plot_variable_stack(
     process_settings: dict | None = None,
     variable_settings: dict | None = None,
     print_yields: bool = True,
+    ratio_mode: str = "data_mc",
     **kwargs,
 ) -> plt.Figure:
     variable_inst = variable_insts[0]
@@ -104,6 +105,7 @@ def plot_variable_stack(
         shape_norm=shape_norm,
         shift_insts=shift_insts,
         density=density,
+        ratio_mode=ratio_mode,
         **kwargs,
     )
 
@@ -119,6 +121,13 @@ def plot_variable_stack(
     # additional, plot function specific changes
     if shape_norm:
         default_style_config["ax_cfg"]["ylabel"] = "Normalized entries"
+    # stack fraction
+    if ratio_mode == "stack_fraction":
+        default_style_config["rax_cfg"].update({
+            "ylabel": "Process fraction",
+            "ylim": (0.0, 1.0),
+            "yscale": "linear",
+        })
     style_config = law.util.merge_dicts(
         default_style_config,
         process_style_config,
@@ -126,6 +135,7 @@ def plot_variable_stack(
         style_config,
         deep=True,
     )
+    
 
     return plot_all(plot_config, style_config, **kwargs)
 

--- a/columnflow/plotting/plot_functions_1d.py
+++ b/columnflow/plotting/plot_functions_1d.py
@@ -191,7 +191,7 @@ def plot_variable_variants(
     hists = remove_residual_axis(hists, "shift")
 
     variable_inst = variable_insts[0]
-    hists = apply_variable_settings(hists, variable_insts, variable_settings)
+    hists, variable_style_config = apply_variable_settings(hists, variable_insts, variable_settings)
     if kwargs.get("remove_negative", None):
         hists = remove_negative_contributions(hists)
     if density:
@@ -203,6 +203,7 @@ def plot_variable_variants(
     selector_step_labels = config_inst.x("selector_step_labels", {})
 
     # add hists
+    
     for label, h in hists.items():
         norm = sum(h.values()) if shape_norm else 1
         plot_config[f"hist_{label}"] = plot_cfg = {

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -535,6 +535,7 @@ def prepare_stack_plot_config(
     syst_error_label: str = "MC syst. unc.",
     combined_error_label: str = "MC syst. + stat. unc.",
     density: bool = False,
+    ratio_mode: Literal["data_mc", "stack_fraction"] = "data_mc",
     **kwargs,
 ) -> OrderedDict:
     """
@@ -543,7 +544,11 @@ def prepare_stack_plot_config(
     data entrys with errorbars.
     """
     import hist
-
+    if ratio_mode not in {"data_mc", "stack_fraction"}:
+        raise ValueError(
+            f"unknown ratio mode '{ratio_mode}', expected one of "
+            "'data_mc' or 'stack_fraction'",
+        )
     # separate histograms into stack, lines and data hists
     mc_hists, mc_colors, mc_edgecolors, mc_labels = [], [], [], []
     mc_syst_hists = []
@@ -573,6 +578,21 @@ def prepare_stack_plot_config(
             mc_labels.append(process_inst.label)
             if "shift" in h.axes.name and h.axes["shift"].size > 1:
                 mc_syst_hists.append(h)
+    
+# Warn about negative bins before constructing the fractional stack.
+    if ratio_mode == "stack_fraction":
+        negative_processes = [
+            label
+            for label, h in zip(mc_labels, mc_hists)
+            if np.any(h.values() < 0)
+        ]
+
+        if negative_processes:
+            logger.warning(
+                "stack-fraction panel contains negative bins for processes "
+                f"{negative_processes}; fractions can be negative or exceed one. "
+                "Consider enabling 'remove_negative'",
+            )
 
     h_data, h_mc, h_mc_stack = None, None, None
     if data_hists:
@@ -600,6 +620,39 @@ def prepare_stack_plot_config(
                 "linewidth": [(0 if c is None else 1) for c in mc_colors],
             },
         }
+        if ratio_mode == "stack_fraction":
+            denominator = h_mc.values()
+
+            # A fractional composition is undefined when the total
+            # stacked yield is zero or non-finite. Such bins are drawn
+            # with zero-height components.
+            denominator = np.where(
+                np.isfinite(denominator) & (denominator != 0),
+                denominator,
+                np.inf,
+            )
+
+            # draw_stack distinguishes:
+            #
+            #   norm.shape == (n_hists, n_bins):
+            #       one denominator array per histogram
+            #
+            # Passing the explicit 2D array also avoids ambiguity when
+            # n_hists happens to equal n_bins.
+            fraction_norm = np.broadcast_to(
+                denominator,
+                (len(h_mc_stack), *denominator.shape),
+            )
+
+            plot_config["mc_stack"]["ratio_kwargs"] = {
+                "norm": fraction_norm,
+                "color": mc_colors,
+                "edgecolor": mc_edgecolors,
+                "linewidth": [
+                    0 if color is None else 1
+                    for color in mc_colors
+                ],
+            }
 
     # draw lines
     for i, h in enumerate(line_hists):
@@ -629,19 +682,20 @@ def prepare_stack_plot_config(
     draw_stat_errors = bool(not hide_stat_errors and h_mc_stack is not None)
     if draw_stat_errors and not merge_stat_errors:
         mc_norm = shape_norm_func(h_mc, shape_norm)
-        plot_config["mc_stat_unc"] = {
-            "method": "draw_stat_error_bands",
-            "hist": h_mc,
-            "kwargs": {
-                "norm": mc_norm,
-                "label": stat_error_label,
-                "hatch_style": "black",
-            },
-            "ratio_kwargs": {
-                "norm": h_mc.values(),
-                "hatch_style": "black",
-            },
-        }
+        if ratio_mode == "data_mc":
+            plot_config["mc_stat_unc"] = {
+                "method": "draw_stat_error_bands",
+                "hist": h_mc,
+                "kwargs": {
+                    "norm": mc_norm,
+                    "label": stat_error_label,
+                    "hatch_style": "black",
+                },
+                "ratio_kwargs": {
+                    "norm": h_mc.values(),
+                    "hatch_style": "black",
+                },
+            }
 
     # draw systematic error for stack
     draw_syst_errors = bool(mc_syst_hists and h_mc_stack is not None)
@@ -669,24 +723,25 @@ def prepare_stack_plot_config(
             label = combined_error_label
             hatch_style = "black"
         # add plot config
-        plot_config["mc_syst_unc"] = {
-            "method": "draw_syst_error_bands",
-            "hist": h_mc,
-            "kwargs": {
-                "syst_hists": _mc_syst_hists,
-                "shift_insts": _shift_insts,
-                "norm": mc_norm,
-                "label": label,
-                "hatch_style": hatch_style,
-                "show_rate_change": show_syst_rate_change,
-            },
-            "ratio_kwargs": {
-                "syst_hists": _mc_syst_hists,
-                "shift_insts": _shift_insts,
-                "norm": h_mc.values(),
-                "hatch_style": hatch_style,
-            },
-        }
+        if ratio_mode == "data_mc":
+            plot_config["mc_syst_unc"] = {
+                "method": "draw_syst_error_bands",
+                "hist": h_mc,
+                "kwargs": {
+                    "syst_hists": _mc_syst_hists,
+                    "shift_insts": _shift_insts,
+                    "norm": mc_norm,
+                    "label": label,
+                    "hatch_style": hatch_style,
+                    "show_rate_change": show_syst_rate_change,
+                },
+                "ratio_kwargs": {
+                    "syst_hists": _mc_syst_hists,
+                    "shift_insts": _shift_insts,
+                    "norm": h_mc.values(),
+                    "hatch_style": hatch_style,
+                },
+            }
 
     # draw data
     if data_hists:
@@ -702,7 +757,7 @@ def prepare_stack_plot_config(
             },
         }
 
-        if h_mc is not None:
+        if h_mc is not None and ratio_mode == "data_mc":
             plot_config["data"]["ratio_kwargs"] = {
                 "norm": h_mc.values() * data_norm / mc_norm,
                 "error_type": "poisson_unweighted",

--- a/columnflow/tasks/cutflow.py
+++ b/columnflow/tasks/cutflow.py
@@ -687,7 +687,7 @@ class PlotCutflowVariables1D(_PlotCutflowVariables1D):
         "--per-plot parameter",
         allow_empty=True,
     )
-    plot_function_processes = "columnflow.plotting.plot_functions_1d.plot_variable_per_process"
+    plot_function_processes = "columnflow.plotting.plot_functions_1d.plot_variable_stack"
     plot_function_steps = "columnflow.plotting.plot_functions_1d.plot_variable_variants"
 
     per_plot = luigi.ChoiceParameter(

--- a/columnflow/tasks/framework/plotting.py
+++ b/columnflow/tasks/framework/plotting.py
@@ -81,6 +81,17 @@ class PlotBase(ConfigTask):
         "exceeds a certain threshold; defaults to the `default_blinding_threshold` aux field of "
         "the config",
     )
+    ratio_mode = luigi.ChoiceParameter(
+        choices=("data_mc", "stack_fraction"),
+        default="data_mc",
+        significant=False,
+        description=(
+            "content shown in the lower panel; 'data_mc' draws the "
+            "usual Data/MC ratio and 'stack_fraction' draws the "
+            "fractional composition of the stacked processes; "
+            "default: data_mc"
+        ),
+    )
 
     exclude_params_remote_workflow = {"debug_plot"}
     exclude_params_hash = {"general_settings"}
@@ -122,6 +133,7 @@ class PlotBase(ConfigTask):
         dict_add_strict(params, "cms_label", None if self.cms_label == law.NO_STR else self.cms_label)
         dict_add_strict(params, "general_settings", self.general_settings)
         dict_add_strict(params, "custom_style_config", self.custom_style_config)
+        dict_add_strict(params, "ratio_mode", self.ratio_mode)
         dict_add_strict(
             params,
             "blinding_threshold",

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -499,30 +499,9 @@ class PlotVariablesBase(_PlotVariablesBase):
                 else:
                     hists[hist_key] = hists[hist_key][self.config_inst]
 
-                # axis selections and reductions
-                _hists = OrderedDict()
-                for process_inst in hists[hist_key].keys():
-                    h = hists[hist_key][process_inst]
-
-                    # determine expected shifts from intersection of requested shifts and those known for the process
-                    process_shifts = (
-                        process_shift_map[process_inst.name]
-                        if process_inst.name in process_shift_map
-                        else {"nominal"}
-                    )
-                    expected_shifts = (process_shifts & plot_shift_names) or (process_shifts & {"nominal"})
-                    if not expected_shifts:
-                        raise Exception(f"no shifts to plot found for process {process_inst.name}")
-
-                    # select shifts
-                    h = h[{"shift": [hist.loc(s_name) for s_name in expected_shifts if s_name in h.axes["shift"]]}]
-
-                    # select and reduce categories
-                    h = select_category_bins(h, category_inst, use_leaves=True, prefer_parents=True, reduce=True)
-
-                    # store
-                    _hists[process_inst] = h
-                hists[hist_key] = _hists
+                # update histograms and shifts before being passed to plot function
+                hists = self.update_hists_before_plotting(hists)
+                plot_shifts = self.update_shifts_before_plotting(plot_shifts, hists)
 
             # copy process instances once so that their auxiliary data fields can be used as a storage for
             # process-specific plot parameters later on in plot scripts without affecting the original instances

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -27,8 +27,8 @@ from columnflow.tasks.framework.plotting import (
 from columnflow.tasks.framework.decorators import view_output_plots
 from columnflow.tasks.framework.remote import RemoteWorkflow
 from columnflow.tasks.histograms import MergeHistograms, MergeShiftedHistograms
-from columnflow.plotting import check_multi_variable_support, check_multi_category_support
-from columnflow.util import DotDict, dev_sandbox, maybe_import
+from columnflow.plotting import check_multi_variable_support, check_multi_category_support,check_multi_version_support
+from columnflow.util import DotDict, dev_sandbox, dict_add_strict
 from columnflow.hist_util import add_missing_shifts, sum_hists, select_category_bins
 from columnflow.config_util import get_shift_from_configs, expand_shift_sources
 from columnflow.types import TYPE_CHECKING, TypeAlias, Any
@@ -86,10 +86,26 @@ class PlotVariablesBase(_PlotVariablesBase):
         "function is decorated with '@columnflow.plotting.supports_multi_category' and accepts a list of categories "
         "for the 'category_inst' argument; cannot be used in conjunction with --multi-variable; default: False",
     )
+    # NEW
+    multi_version = luigi.BoolParameter(
+        default=False,
+        description="whether a single plot combining histograms produced under multiple upstream task "
+        "'--version' values should be created; requires '--hist-versions' to be set and the plot function to be "
+        "decorated with '@columnflow.plotting.supports_multi_version'; can be combined with --multi-category or "
+        "--multi-variable (but not both); default: False",
+    )
+    # NEW
+    hist_versions = law.CSVParameter(
+        default=(),
+        description="comma-separated list of upstream task versions (e.g. of MergeHistograms) to compare when "
+          "--multi-version is set; ignored otherwise",
+    )
+
     bypass_branch_requirements = luigi.BoolParameter(
         default=False,
         description="whether to skip branch requirements and only use that of the workflow; default: False",
     )
+    
 
     single_config = False
 
@@ -106,7 +122,7 @@ class PlotVariablesBase(_PlotVariablesBase):
 
         # check multi flags
         self._check_multi_flags()
-
+       
         # the plot function support for multi-flags
         plot_func = self.get_plot_func(self.plot_function)
         if self.multi_variable and not check_multi_variable_support(plot_func):
@@ -121,10 +137,20 @@ class PlotVariablesBase(_PlotVariablesBase):
                 "plot function or, if it actually has multi-category support, decorate it with "
                 "@columnflow.plotting.supports_multi_category",
             )
+        # resolve default hist_versions to this task's own version when not explicitly given
+        if self.multi_version and not check_multi_version_support(plot_func):
+            raise Exception(
+                f"plot function '{self.plot_function}' does not support multi-version plotting; please change the "
+                "plot function or, if it actually has multi-version support, decorate it with "
+                "@columnflow.plotting.supports_multi_version",
+            )
+
 
     def _check_multi_flags(self) -> None:
         if self.multi_variable and self.multi_category:
             raise Exception("cannot use --multi-variable and --multi-category at the same time")
+        if self.multi_version and not self.hist_versions:
+            raise Exception("--multi-version requires --hist-versions to be set")
 
     def create_branch_map(self):
         self._check_multi_flags()
@@ -144,22 +170,24 @@ class PlotVariablesBase(_PlotVariablesBase):
 
     def requires(self):
         reqs = {}
-
         if self.is_branch() and self.bypass_branch_requirements:
             return reqs
-
+        hist_versions = list(self.hist_versions) if self.multi_version else [self.version]
         for config_inst, datasets in zip(self.config_insts, self.datasets):
             reqs[config_inst.name] = {
-                d: self.requires_histograms(
-                    config_inst=config_inst,
-                    dataset_name=d,
-                    branch=-1,
-                    _prefer_cli={"variables"},
-                )
-                for d in datasets
-                if d in config_inst.datasets
+                hv: {  # NEW: nest by hist_version, unconditionally
+                    d: self.requires_histograms(
+                        config_inst=config_inst,
+                        dataset_name=d,
+                        branch=-1,
+                        version=hv,  # NEW: override the upstream requirement's version
+                        _prefer_cli={"variables"},
+                    )
+                    for d in datasets
+                    if d in config_inst.datasets
+                }
+                for hv in hist_versions  # NEW
             }
-
         return reqs
 
     def workflow_requires(self):
@@ -197,6 +225,8 @@ class PlotVariablesBase(_PlotVariablesBase):
             parts["variables"] = f"vars_{self.variables_repr}"
         else:
             parts["variable"] = f"var_{self.branch_data.variable}"
+        if self.multi_version:
+            parts["hist_versions"] = f"hvers_{'_'.join(self.hist_versions)}"
 
         hooks_repr = self.hist_hooks_repr
         if hooks_repr:
@@ -262,6 +292,7 @@ class PlotVariablesBase(_PlotVariablesBase):
             mapping process names to the shifts to be considered.
         """
         reqs = self.requires() or self.as_workflow().requires().merged_hists
+        hist_versions = list(self.hist_versions) if self.multi_version else [self.version]
 
         config_process_map = {config_inst: {} for config_inst in self.config_insts}
         process_shift_map = collections.defaultdict(set)
@@ -272,20 +303,23 @@ class PlotVariablesBase(_PlotVariablesBase):
 
             requested_shifts_per_dataset: dict[od.Dataset, list[str]] = {}
             for dataset_inst in dataset_insts:
-                _req = reqs[config_inst.name][dataset_inst.name]
-                if isinstance(_req, ShiftTask) and _req.shift:
-                    # when a shift is found, use it
-                    requested_shifts = [_req.shift]
-                elif isinstance(_req, ShiftSourcesMixin):
-                    # when no shift is found, check for shift sources and expand to up/down variations
-                    requested_shifts = expand_shift_sources(_req.shift_sources)
-                else:
-                    raise Exception(
-                        f"no shift or shift source found in requirements for dataset {dataset_inst.name} "
-                        f"of config {config_inst.name}",
-                    )
-
-                requested_shifts_per_dataset[dataset_inst] = requested_shifts
+                # NEW: gather shifts across all compared hist_versions; shift structure is assumed
+                # consistent across versions, so use the first one
+                shifts_per_version = []
+                for hv in hist_versions:
+                    _req = reqs[config_inst.name][hv][dataset_inst.name]
+                    if isinstance(_req, ShiftTask) and _req.shift:
+                        # when a shift is found, use it
+                        shifts_per_version.append([_req.shift])
+                    elif isinstance(_req, ShiftSourcesMixin):
+                        # when no shift is found, check for shift sources and expand to up/down variations
+                        shifts_per_version.append(expand_shift_sources(_req.shift_sources))
+                    else:
+                        raise Exception(
+                            f"no shift or shift source found in requirements for dataset {dataset_inst.name} "
+                            f"of config {config_inst.name}",
+                        )
+                requested_shifts_per_dataset[dataset_inst] = shifts_per_version[0]
 
             for process_inst in process_insts:
                 sub_process_insts = [sub for sub, _, _ in process_inst.walk_processes(include_self=True)]
@@ -307,6 +341,7 @@ class PlotVariablesBase(_PlotVariablesBase):
                         for shift in requested_shifts_per_dataset[dataset_inst]
                     },
                 }
+
                 process_shift_map[process_inst.name].update(process_info["config_shifts"])
                 config_process_map[config_inst][process_inst] = process_info
 
@@ -328,7 +363,8 @@ class PlotVariablesBase(_PlotVariablesBase):
         # prepare other config objects
         categories = list(self.categories) if self.multi_category else [self.branch_data.category]
         variables = list(self.variables) if self.multi_variable else [self.branch_data.variable]
-        category_variable_combis = list(itertools.product(categories, variables))
+        hist_versions = list(self.hist_versions) if self.multi_version else [self.version]
+        combis = list(itertools.product(categories, variables, hist_versions))  # NEW: triple product
         plot_shifts = self.get_plot_shifts()
         plot_shift_names = set(shift_inst.name for shift_inst in plot_shifts) | {"nominal"}
 
@@ -336,17 +372,21 @@ class PlotVariablesBase(_PlotVariablesBase):
         config_process_map, process_shift_map = self.get_config_process_map()
 
         # read histograms per variable name, config and process
-        hists: HistDicts = {tpl: {} for tpl in category_variable_combis}
+        hists: dict[tuple[str, str, str], dict[od.Config, dict[od.Process, hist.Hist]]] = {  # NEW: 3-tuple key
+            tpl: {}
+            for tpl in combis
+        }
         with self.publish_step(f"plotting {','.join(variables)} in {','.join(categories)}"):
             inputs = self.input() or self.workflow_input().merged_hists
-            for cat_name, var_name in category_variable_combis:
-                hist_key: CatVarPair = (cat_name, var_name)
-                for i, (config, dataset_dict) in enumerate(inputs.items()):
+
+            for cat_name, var_name, hv in combis:  # NEW: unpack hv
+                hist_key = (cat_name, var_name, hv)
+                for i, (config, hv_dict) in enumerate(inputs.items()):  # NEW: renamed for clarity
                     config_inst = self.config_insts[i]
                     category_inst = config_inst.get_category(cat_name)
+                    dataset_dict = hv_dict[hv]  # NEW: index through hist_version first
 
                     hists_config = {}
-
                     for dataset, inps in dataset_dict.items():
                         dataset_inst = config_inst.get_dataset(dataset)
 
@@ -397,13 +437,13 @@ class PlotVariablesBase(_PlotVariablesBase):
                         )
                     }
 
-                    # there should be hists to plot
-                    if not hists:
-                        raise Exception(
-                            "no histograms found to plot; possible reasons:\n"
-                            "  - requested variable requires columns that were missing during histogramming\n"
-                            "  - selected --processes did not match any value on the input histogram process axis",
-                        )
+                # there should be hists to plot
+                if not hists:
+                    raise Exception(
+                        "no histograms found to plot; possible reasons:\n"
+                        " - requested variable requires columns that were missing during histogramming\n"
+                        " - selected --processes did not match any value on the input histogram process axis",
+                    )
 
                 # update histograms using custom hooks
                 hists[hist_key] = self.invoke_hist_hooks(
@@ -454,14 +494,35 @@ class PlotVariablesBase(_PlotVariablesBase):
                                 merged_hists[process_inst.id] += h
                             else:
                                 merged_hists[process_inst.id] = h
-                                process_memory[process_inst.id] = process_inst
+                            process_memory[process_inst.id] = process_inst
                     hists[hist_key] = {process_memory[process_id]: h for process_id, h in merged_hists.items()}
                 else:
                     hists[hist_key] = hists[hist_key][self.config_inst]
 
-            # update histograms and shifts before being passed to plot function
-            hists = self.update_hists_before_plotting(hists)
-            plot_shifts = self.update_shifts_before_plotting(plot_shifts, hists)
+                # axis selections and reductions
+                _hists = OrderedDict()
+                for process_inst in hists[hist_key].keys():
+                    h = hists[hist_key][process_inst]
+
+                    # determine expected shifts from intersection of requested shifts and those known for the process
+                    process_shifts = (
+                        process_shift_map[process_inst.name]
+                        if process_inst.name in process_shift_map
+                        else {"nominal"}
+                    )
+                    expected_shifts = (process_shifts & plot_shift_names) or (process_shifts & {"nominal"})
+                    if not expected_shifts:
+                        raise Exception(f"no shifts to plot found for process {process_inst.name}")
+
+                    # select shifts
+                    h = h[{"shift": [hist.loc(s_name) for s_name in expected_shifts if s_name in h.axes["shift"]]}]
+
+                    # select and reduce categories
+                    h = select_category_bins(h, category_inst, use_leaves=True, prefer_parents=True, reduce=True)
+
+                    # store
+                    _hists[process_inst] = h
+                hists[hist_key] = _hists
 
             # copy process instances once so that their auxiliary data fields can be used as a storage for
             # process-specific plot parameters later on in plot scripts without affecting the original instances
@@ -479,21 +540,55 @@ class PlotVariablesBase(_PlotVariablesBase):
             get_var_insts = lambda var_name: list(map(self.config_inst.get_variable, self.variable_tuples[var_name]))
 
             # prepare dynamic plot arguments
-            if self.multi_category:
+            # NEW: multi_version branch, combinable with multi_category / multi_variable
+            if self.multi_version:
+                if self.multi_category:
+                    plot_content = {
+                        "hists": {
+                            hv: {cat_name: hists[(cat_name, variables[0], hv)] for cat_name in categories}
+                            for hv in hist_versions
+                        },
+                        "category_inst": [
+                            self.config_inst.get_category(cat_name).copy_shallow() for cat_name in categories
+                        ],
+                        "variable_insts": get_var_insts(variables[0]),
+                    }
+                elif self.multi_variable:
+                    plot_content = {
+                        "hists": {
+                            hv: {var_name: hists[(categories[0], var_name, hv)] for var_name in variables}
+                            for hv in hist_versions
+                        },
+                        "category_inst": self.config_inst.get_category(categories[0]).copy_shallow(),
+                        "variable_insts": {var_name: get_var_insts(var_name) for var_name in variables},
+                    }
+                else:
+                    plot_content = {
+                        "hists": {hv: hists[(categories[0], variables[0], hv)] for hv in hist_versions},
+                        "category_inst": self.config_inst.get_category(categories[0]).copy_shallow(),
+                        "variable_insts": get_var_insts(variables[0]),
+                    }
+            elif self.multi_category:
                 plot_content = {
-                    "hists": {cat_name: hists[(cat_name, variables[0])] for cat_name in categories},
-                    "category_inst": [self.config_inst.get_category(cat_name).copy_shallow() for cat_name in categories],
+                    "hists": {
+                        cat_name: hists[(cat_name, variables[0], hist_versions[0])] for cat_name in categories
+                    },
+                    "category_inst": [
+                        self.config_inst.get_category(cat_name).copy_shallow() for cat_name in categories
+                    ],
                     "variable_insts": get_var_insts(variables[0]),
                 }
             elif self.multi_variable:
                 plot_content = {
-                    "hists": {var_name: hists[(categories[0], var_name)] for var_name in variables},
+                    "hists": {
+                        var_name: hists[(categories[0], var_name, hist_versions[0])] for var_name in variables
+                    },
                     "category_inst": self.config_inst.get_category(categories[0]).copy_shallow(),
                     "variable_insts": {var_name: get_var_insts(var_name) for var_name in variables},
                 }
             else:
                 plot_content = {
-                    "hists": hists[(categories[0], variables[0])],
+                    "hists": hists[(categories[0], variables[0], hist_versions[0])],
                     "category_inst": self.config_inst.get_category(categories[0]).copy_shallow(),
                     "variable_insts": get_var_insts(variables[0]),
                 }
@@ -503,7 +598,6 @@ class PlotVariablesBase(_PlotVariablesBase):
             if not config_inst.has_aux("lumi_plot_lock"):
                 config_inst.x.lumi_plot_lock = threading.RLock()
             lumi = sum([_config_inst.x.luminosity for _config_inst in self.config_insts])
-
             with law.util.patch_object(config_inst.x, "luminosity", lumi, lock=config_inst.x.lumi_plot_lock):
                 # call the plot function
                 fig, _ = self.call_plot_func(


### PR DESCRIPTION
1. Add multi-version plotting, where the plotting funciton now located in hbt/plotting/multi.py
where  we need to specify hist version from other production
`--multi-version --hist-versions test_invHcat,prod27  --plot-function hbt.plotting.multi.multi_ver_plot`

```
@supports_multi_version
def multi_ver_plot(
    hists: dict[od.Process, hist.Hist] | dict[str, dict[od.Process, hist.Hist]],
    config_inst: od.Config,
    category_inst: od.Category,
    variable_insts: list[od.Variable],
    shift_insts: list[od.Shift],
    style_config: dict | None = None,
    variable_settings: dict[str, Any] | None = None,
    **kwargs,
) -> tuple[plt.Figure, tuple[plt.Axes, ...]]:
    # emulate multi-version input
    if isinstance(list(hists)[0], od.Process):
        hists = {category_inst.name: hists}  # single fake "version" key, label is irrelevant here since len==1

    # prepare objects
    assert len(variable_insts) == 1
    variable_inst = variable_insts[0]

    # remove shift axis
    hists = {ver_name: remove_residual_axis(proc_hists, "shift") for ver_name, proc_hists in hists.items()}

    # unique process instances
    unique_proc_insts = set(sum((list(v.keys()) for v in hists.values()), []))

    # helper to create legend labels
    def create_legend_label(proc_inst: od.Process, ver_name: str) -> str:
        return ver_name if len(unique_proc_insts) == 1 else f"{proc_inst.label}: {ver_name}"

    # create plot instructions for plot_all
    plot_config = {
        **{
            f"multi_ver_plot__{proc_inst.name}__{ver_name}": {
                "method": "draw_hist",
                "hist": move_flow(h, variable_inst),
                "kwargs": dict(
                    label=create_legend_label(proc_inst, ver_name),
                    color=config_inst.x.get_color_from_sequence(i),
                    linestyle=config_inst.x.get_line_style_from_sequence(j),
                    error_type="variance",
                    linewidth=1.5,
                ),
            }
            for i, (ver_name, proc_hists) in enumerate(hists.items())
            for j, (proc_inst, h) in enumerate(proc_hists.items())
        },
    }

    # combine the style config
    style_config = law.util.merge_dicts(
        # inferred from config, category, variable
        prepare_style_config(
            config_inst=config_inst,
            category_inst=category_inst,
            variable_inst=variable_inst,
        ),
        # passed styles
        style_config,
        (variable_settings or {}),
        # overwrite with hardcoded settings
        {
            "cms_label_cfg": {"loc": 0},
            "legend_cfg": {"loc": "upper right", "fontsize": 18},
        },
        deep=True,
    )

    # update kwargs for plot_all
    kwargs = kwargs | {
        "skip_ratio": True,
        "skip_legend": False,
    }

    return plot_all(plot_config, style_config, **kwargs)

```

2. Add stack fraction to ratio panel 
3. also fix function names in cutflow1D plot
