### PR TITLE
Add cf.cms.PlotPostfitFromModel1D task.

### DIFF
--- a/columnflow/cms_util.py
+++ b/columnflow/cms_util.py
@@ -15,14 +15,19 @@ import json
 import base64
 import zlib
 import pathlib
+import functools
 import dataclasses
 import collections
 
-from columnflow.util import maybe_import
+import law
+
+from columnflow.util import maybe_import, expand_path
 from columnflow.types import TYPE_CHECKING, ClassVar, Generator, Literal
 
 if TYPE_CHECKING:
     ak = maybe_import("awkward")
+    uproot = maybe_import("uproot")
+    hist = maybe_import("hist")
 
 
 #: Default root path to CAT metadata.
@@ -352,3 +357,93 @@ def visualize_gen_decay(gen_part: ak.Array, output_type: Literal["text", "link"]
 
     url = f"https://mermaid.live/edit#pako:{encoded}"
     return url
+
+
+@functools.cache
+def _uproot_keys(path: str | pathlib.Path) -> list[str]:
+    import uproot
+
+    path = os.path.abspath(expand_path(path))
+    with uproot.open(path) as f:
+        return list(f.keys())
+
+
+class HarvesterShapes:
+    """
+    Helper class providing access to histograms stored in a category category of a CMS Combine Harvester shape file.
+    """
+
+    @classmethod
+    def read_categories(
+        cls,
+        path: str | pathlib.Path | uproot.reading.ReadOnlyDirectory,
+        prefit: bool = False,
+        return_keys: bool = False,
+    ) -> list[str | tuple[str, str]]:
+        # load keys from uproot file or directory
+        if not callable(getattr(path, "keys", None)):
+            path = os.path.abspath(expand_path(path))
+            keys = _uproot_keys(path)
+        else:
+            keys = list(path.keys())
+
+        # loop through keys, check if they refer to the correct directories
+        categories = {}
+        for key in keys:
+            key = key.split(";", 1)[0]
+            if "/" not in key and key.endswith("_prefit" if prefit else "_postfit"):
+                categories[key.rsplit("_", 1)[0]] = key
+
+        return list(categories.items() if return_keys else categories)
+
+    @classmethod
+    def from_file(cls, path: str | pathlib.Path, prefit: bool = False) -> dict[str, HarvesterShapes]:
+        import uproot
+
+        data: dict[str, HarvesterShapes] = {}
+
+        path = os.path.abspath(expand_path(path))
+        with uproot.open(path) as f:
+            for category, key in cls.read_categories(f, prefit=prefit, return_keys=True):
+                data[category] = HarvesterShapes(category, prefit, f[key])
+
+        return data
+
+    def __init__(self, category: str, prefit: bool, uproot_dir: uproot.reading.ReadOnlyDirectory) -> None:
+        super().__init__()
+
+        # store attributes
+        self.category = category
+        self.prefit = prefit
+        self.uproot_dir = uproot_dir
+
+        # eager inspection
+        self.keys = law.util.make_unique(k.split(";", 1)[0] for k in self.uproot_dir.keys())
+        non_process_keys = {"TotalBkg", "TotalProcs", "TotalSig", "data_obs"}
+        self.processes = [k for k in self.keys if k not in non_process_keys]
+
+        # cache for loaded and converted histograms
+        self._hists: dict[str, hist.Hist] = {}
+
+    def hist(self, key: str) -> hist.Hist:
+        if key not in self.keys:
+            raise KeyError(f"key '{key}' not found in shapes for category '{self.category}'")
+        if key not in self._hists:
+            self._hists[key] = self.uproot_dir[key].to_hist()
+        return self._hists[key]
+
+    @property
+    def data_hist(self) -> hist.Hist:
+        return self.hist("data_obs")
+
+    @property
+    def background_hist(self) -> hist.Hist:
+        return self.hist("TotalBkg")
+
+    @property
+    def signal_hist(self) -> hist.Hist:
+        return self.hist("TotalSig")
+
+    @property
+    def total_hist(self) -> dict[str, hist.Hist]:
+        return self.hist("TotalProcs")

--- a/columnflow/plotting/plot_all.py
+++ b/columnflow/plotting/plot_all.py
@@ -23,7 +23,7 @@ from columnflow.plotting.plot_util import (
     HatchStyles,
     get_hatch_kwargs,
 )
-from columnflow.types import TYPE_CHECKING, Sequence
+from columnflow.types import TYPE_CHECKING, Sequence, Literal
 
 np = maybe_import("numpy")
 if TYPE_CHECKING:
@@ -183,6 +183,65 @@ def draw_syst_error_bands(
             bar_kwargs["label"] += f"__BREAK__{effect_str}"
         else:
             bar_kwargs["label"] = effect_str
+
+    # evaluate label placeholders
+    if "label" in bar_kwargs:
+        bar_kwargs["label"] = remove_label_placeholders(apply_label_placeholders(bar_kwargs["label"]))
+
+    # plot
+    ax.bar(**bar_kwargs)
+
+
+def draw_custom_error_band(
+    ax: plt.Axes,
+    h: hist.Hist,
+    errors: np.ndarray | tuple[np.ndarray, np.ndarray],
+    mode: Literal["abs", "rel"] = "abs",
+    norm: float | Sequence | np.ndarray = 1.0,
+    hatch_style: HatchStyles = "black",
+    **kwargs,
+) -> None:
+    if mode not in (known_modes := {"abs", "rel"}):
+        raise ValueError(f"mode must be one of {known_modes}, not '{mode}'")
+    if len(h.axes) != 1:
+        raise ValueError("draw_custom_error_band only supports 1D histograms")
+
+    # expand errors
+    if isinstance(errors, tuple):
+        if len(errors) != 2:
+            raise ValueError(f"when providing a tuple of errors, it must have length 2, not {len(errors)}")
+        errors_up, errors_down = errors
+    else:
+        errors_up = errors_down = errors
+    # check sizes
+    if len(errors_up) != h.axes[0].size:
+        raise ValueError(f"size of errors_up ({len(errors_up)}) does not match number of bins ({ax.size})")
+    if len(errors_down) != h.axes[0].size:
+        raise ValueError(f"size of errors_down ({len(errors_down)}) does not match number of bins ({ax.size})")
+    # always convert to relative values
+    if mode == "abs":
+        errors_up = errors_up / h.values()
+        errors_down = errors_down / h.values()
+
+    # sanitize
+    errors_up[np.isnan(errors_up)] = 0.0
+    errors_down[np.isnan(errors_down)] = 0.0
+
+    # compute the baseline
+    # fill 1 in places where both numerator and denominator are 0, and 0 for remaining nan's
+    baseline = h.values() / norm
+    baseline[(h.values() == 0) & (norm == 0)] = 1.0
+    baseline[np.isnan(baseline)] = 0.0
+
+    # create bar plot args
+    bar_kwargs = {
+        "x": h.axes[0].centers,
+        "bottom": baseline * (1 - errors_down),
+        "height": baseline * (errors_up + errors_down),
+        "width": h.axes[0].edges[1:] - h.axes[0].edges[:-1],
+        **get_hatch_kwargs(hatch_style),
+        **kwargs,
+    }
 
     # evaluate label placeholders
     if "label" in bar_kwargs:
@@ -482,7 +541,7 @@ def plot_all(
     plot_methods = {
         func.__name__: func
         for func in [
-            draw_stat_error_bands, draw_syst_error_bands, draw_stack, draw_hist, draw_profile,
+            draw_stat_error_bands, draw_syst_error_bands, draw_custom_error_band, draw_stack, draw_hist, draw_profile,
             draw_errorbars,
         ]
     }

--- a/columnflow/plotting/plot_util.py
+++ b/columnflow/plotting/plot_util.py
@@ -537,8 +537,14 @@ def prepare_stack_plot_config(
     show_syst_rate_change: bool = False,
     ratio_mark_out_of_range: bool = True,
     stat_error_label: str = "MC stat. unc.",
+    stat_hatch_style: str = "black",
     syst_error_label: str = "MC syst. unc.",
-    combined_error_label: str = "MC syst. + stat. unc.",
+    syst_hatch_style: str = "green_backwards",
+    combined_error_label: str = "MC unc.",
+    combined_hatch_style: str = "black",
+    custom_errors: np.ndarray | tuple[np.ndarray, np.ndarray] | None = None,  # up/down in asym. case
+    custom_error_label: str = "Custom unc.",
+    custom_hatch_style: str = "black",
     density: bool = False,
     **kwargs,
 ) -> OrderedDict:
@@ -640,11 +646,11 @@ def prepare_stack_plot_config(
             "kwargs": {
                 "norm": mc_norm,
                 "label": stat_error_label,
-                "hatch_style": "black",
+                "hatch_style": stat_hatch_style,
             },
             "ratio_kwargs": {
                 "norm": h_mc.values(),
-                "hatch_style": "black",
+                "hatch_style": stat_hatch_style,
             },
         }
 
@@ -656,7 +662,7 @@ def prepare_stack_plot_config(
         _shift_insts = shift_insts
         _mc_syst_hists = mc_syst_hists
         label = syst_error_label
-        hatch_style = "green_backwards"
+        hatch_style = syst_hatch_style
         if merge_stat_errors:
             _shift_insts = [
                 *shift_insts,
@@ -672,7 +678,7 @@ def prepare_stack_plot_config(
                 insert_axis_values(h, "shift", "mc_stat_down", nom_view.value - stat_err)
                 _mc_syst_hists.append(h)
             label = combined_error_label
-            hatch_style = "black"
+            hatch_style = stat_hatch_style
         # add plot config
         plot_config["mc_syst_unc"] = {
             "method": "draw_syst_error_bands",
@@ -690,6 +696,27 @@ def prepare_stack_plot_config(
                 "shift_insts": _shift_insts,
                 "norm": h_mc.values(),
                 "hatch_style": hatch_style,
+            },
+        }
+
+    # optional additional error band
+    draw_custom_errors = bool(custom_errors is not None and h_mc_stack is not None)
+    if draw_custom_errors:
+        mc_norm = shape_norm_func(h_mc, shape_norm)
+        # add plot config
+        plot_config["mc_syst_unc"] = {
+            "method": "draw_custom_error_band",
+            "hist": h_mc,
+            "kwargs": {
+                "errors": custom_errors,
+                "norm": mc_norm,
+                "label": custom_error_label,
+                "hatch_style": custom_hatch_style,
+            },
+            "ratio_kwargs": {
+                "errors": custom_errors,
+                "norm": h_mc.values(),
+                "hatch_style": custom_hatch_style,
             },
         }
 

--- a/columnflow/tasks/cms/plotting.py
+++ b/columnflow/tasks/cms/plotting.py
@@ -213,16 +213,46 @@ class PlotPostfitFromModel1D(_PlotPostfitFromModel):
             h2.view(flow=True).value[...] = h.view(flow=True).value
             return h2
 
-        # to be consistent to other plotting tasks, create a mapping "process -> hist"
-        proc_hists: ProcHists = {}
+        # create a mapping of process instance to process object in the inference model
+        proc_map: dict[od.Process, DotDict] = {}
         for proc_obj_name in shapes.processes:
             proc_obj = self.inference_model_inst.get_process(process=proc_obj_name, category=cat_obj.name)
-            proc_name = proc_obj.config_data[config_inst.name].process
-            if exclude_matcher(proc_name):
-                continue
-            proc_inst = config_inst.get_process(proc_name)
-            proc_hists[proc_inst] = sanitize_hist(shapes.hist(proc_obj_name))
-        proc_hists[config_inst.get_process("data")] = sanitize_hist(shapes.data_hist)
+            proc_inst = config_inst.get_process(proc_obj.config_data[config_inst.name].process)
+            proc_map[proc_inst] = proc_obj
+
+        # helper to show warnings in case a process is not used but actually contributed to the requested uncertainty
+        def maybe_warn_unused_process(proc_inst: od.Process, skip: bool = False) -> None:
+            # never warn about data
+            if proc_inst.is_data:
+                return
+            # never warn in case "none" uncertainty is requested
+            if self.uncertainty == "none":
+                return
+            # do not warn for signals when only "bkg" uncertainty is requested
+            if self.uncertainty == "bkg" and proc_map[proc_inst].is_signal:
+                return
+            # warn
+            if skip:
+                action = "skipped"
+                extra = ""
+            else:
+                action = "not merged"
+                extra = f"; merge processes: {','.join(self.merge_processes)}"
+            self.logger.warning(
+                f"shape of process '{proc_inst.name}' was {action} for plotting in category '{category_inst.name}', "
+                f"but was likely considered for the computation of the requested uncertainty type '{self.uncertainty}' "
+                f"which is inconsistent and might be misleading{extra}",
+            )
+
+        # to be consistent to other plotting tasks, create a mapping "process -> hist"
+        proc_hists: ProcHists = {}
+        for proc_inst, proc_obj in proc_map.items():
+            if exclude_matcher(proc_inst.name):
+                maybe_warn_unused_process(proc_inst, skip=True)
+            else:
+                proc_hists[proc_inst] = sanitize_hist(shapes.hist(proc_obj.name))
+        if not exclude_matcher("data"):
+            proc_hists[config_inst.get_process("data")] = sanitize_hist(shapes.data_hist)
 
         # optional process merging and selection
         if self.merge_processes:
@@ -239,14 +269,12 @@ class PlotPostfitFromModel1D(_PlotPostfitFromModel):
                     proc_hists[proc_inst] = sum_hists(_hists)
                 else:
                     self.logger.warning(
-                        f"no processes histograms found to merge into process histogram '{proc_name}'; existing "
-                        f"processes were {','.join(p.name for p in orig_hists)}",
+                        f"no process shape found to merge into process histogram '{proc_name}'; existing processes "
+                        f"were {','.join(p.name for p in orig_hists)}",
                     )
-            if orig_hists and self.uncertainty != "none":
-                raise Exception(
-                    "the following processes were not merged into any of the specified merge processes which is "
-                    f"inconsistent when not using '--uncertainty none': {','.join(p.name for p in orig_hists)}",
-                )
+            # potentially warn about unmerged, left-over processes
+            for proc_inst in orig_hists:
+                maybe_warn_unused_process(proc_inst, skip=False)
 
         # update histograms using custom hooks
         proc_hists = self.invoke_hist_hooks(

--- a/columnflow/tasks/cms/plotting.py
+++ b/columnflow/tasks/cms/plotting.py
@@ -1,0 +1,298 @@
+# coding: utf-8
+
+"""
+CMS specific plotting tasks.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import luigi
+import law
+import order as od
+
+from columnflow.tasks.framework.mixins import DatasetsProcessesMixin, HistHookMixin
+from columnflow.tasks.framework.plotting import PlotBase, ProcessPlotSettingMixin, PlotBase1DWithErrorBands
+from columnflow.tasks.framework.inference import InferenceModelUser
+from columnflow.tasks.framework.decorators import view_output_plots
+from columnflow.tasks.plotting import ProcHists, PlotVariablesBaseShiftsFromModel
+from columnflow.hist_util import sum_hists, create_hist_from_variables
+from columnflow.cms_util import HarvesterShapes
+from columnflow.util import maybe_import, expand_path, pattern_matcher, DotDict
+from columnflow.types import TYPE_CHECKING, Any
+
+np = maybe_import("numpy")
+if TYPE_CHECKING:
+    uproot = maybe_import("uproot")
+
+
+class _PlotPostfitFromModel(
+    PlotBase1DWithErrorBands,
+    ProcessPlotSettingMixin,
+    InferenceModelUser,
+    HistHookMixin,
+):
+    """
+    Base classes for :py:class:`PlotPostfitFromModel`.
+    """
+
+
+class PlotPostfitFromModel1D(_PlotPostfitFromModel):
+    """
+    Task to create postfit plots from previously created shapes using combine/harvester. For more info, see
+    https://cms-analysis.github.io/CombineHarvester/post-fit-shapes-ws.html
+    """
+
+    task_namespace = "cf.cms"
+
+    shapes_file = luigi.Parameter(
+        description="path to the shapes file (create by CMS Combine Harvester, see "
+        "https://cms-analysis.github.io/CombineHarvester/post-fit-shapes-ws.html)",
+    )
+    shapes_name = luigi.Parameter(
+        default=law.NO_STR,
+        description="custom name for the --shapes-file that will be written into plot file names; when empty, the "
+        "first 8 characters of the sha1 hash of the file contents will be used; default: empty",
+    )
+    prefit = luigi.BoolParameter(
+        default=False,
+        description="if True, prefit plots will be created rather than postfit plots (provided they exist in "
+        "--shapes-file); default: False",
+    )
+    uncertainty = luigi.ChoiceParameter(
+        default="bkg",
+        choices=["bkg", "all", "none"],
+        description="which uncertainty to show in the ratio plot; choices: bkg,all,none; default: bkg",
+    )
+    plot_function = PlotBase.plot_function.copy(
+        default="columnflow.plotting.plot_functions_1d.plot_variable_stack",
+        add_default_to_description=True,
+    )
+    categories = PlotVariablesBaseShiftsFromModel.categories
+    merge_processes = PlotVariablesBaseShiftsFromModel.merge_processes
+    skip_processes = PlotVariablesBaseShiftsFromModel.skip_processes
+
+    # disable some upstream features
+    resolution_task_cls = law.no_value
+    hide_stat_errors = None
+    merge_stat_errors = None
+    shape_norm = None
+
+    transfer_params_to_inst = {"category_map"}
+
+    @classmethod
+    def resolve_param_values(cls, params: dict[str, Any]) -> dict[str, Any]:
+        params = super().resolve_param_values(params)
+
+        # expand shapes_file path
+        params["shapes_file"] = os.path.abspath(expand_path(params["shapes_file"]))
+
+        # default shapes_name
+        if params["shapes_name"] in {"", None, law.NO_STR}:
+            params["shapes_name"] = law.util.compute_sha1_hash(params["shapes_file"])[:8]
+
+        # expand categories
+        existing_categories = HarvesterShapes.read_categories(params["shapes_file"], prefit=bool(params["prefit"]))
+        category_map = PlotVariablesBaseShiftsFromModel.resolve_model_category_map(
+            inference_model_inst=params["inference_model_inst"],
+            config_insts=params["config_insts"],
+            categories=params["categories"],
+        )
+        category_map = {
+            cat_name: cat_obj_name
+            for cat_name, cat_obj_name in category_map.items()
+            if cat_obj_name in existing_categories
+        }
+        params["categories"] = tuple(sorted(category_map.keys()))
+        params["category_map"] = {cat_name: category_map[cat_name] for cat_name in params["categories"]}
+
+        # expand merge processes
+        if (merge_processes := params.get("merge_processes")):
+            merge_processes = cls.find_config_objects(
+                names=merge_processes,
+                container=params["config_insts"],
+                object_cls=od.Process,
+                groups_str="process_groups",
+                multi_strategy="intersection",
+            )
+            params["merge_processes"] = tuple(merge_processes)
+
+        return params
+
+    @law.workflow_property(cache=True)
+    def shape_data(self) -> dict[str, HarvesterShapes]:
+        return HarvesterShapes.from_file(self.shapes_file, prefit=self.prefit)
+
+    def create_branch_map(self):
+        def get_first_config_variable(cat_name):
+            cat_obj = self.inference_model_inst.get_category(self.category_map[cat_name])
+            return self.config_insts[0].get_variable(cat_obj.config_data[self.config_insts[0].name].variable)
+
+        return [
+            DotDict(
+                category=cat_name,
+                variable=get_first_config_variable(cat_name).name,
+            )
+            for cat_name in self.categories
+        ]
+
+    @property
+    def processes_repr(self) -> str:
+        return DatasetsProcessesMixin._processes_repr(self.merge_processes) if self.merge_processes else ""
+
+    def store_parts(self) -> law.util.InsertableDict:
+        parts = super().store_parts()
+        parts.insert_before("version", "shapes_name", f"shapes_{self.shapes_name}")
+        return parts
+
+    def plot_parts(self) -> law.util.InsertableDict:
+        parts = super().plot_parts()
+
+        parts["category"] = f"cat_{self.branch_data.category}"
+        parts["variable"] = f"var_{self.branch_data.variable}"
+        parts["unc"] = f"unc_{self.uncertainty}"
+
+        if (processes_repr := self.processes_repr):
+            parts["processes"] = f"proc_{processes_repr}"
+
+        hooks_repr = self.hist_hooks_repr
+        if hooks_repr:
+            parts["hook"] = f"hooks_{hooks_repr}"
+
+        return parts
+
+    def output(self):
+        return {
+            "plots": [self.target(name) for name in self.get_plot_names("plot")],
+        }
+
+    def get_plot_parameters(self, *args, **kwargs) -> dict[str, Any]:
+        params = super().get_plot_parameters(*args, **kwargs)
+        params.pop("hide_stat_errors", None)
+        params.pop("merge_stat_errors", None)
+        params.pop("shape_norm", None)
+        return params
+
+    @law.decorator.log
+    @view_output_plots
+    def run(self):
+        import hist
+
+        # prepare config objects, relative to the first config instance
+        config_inst = self.config_insts[0]
+        cat_obj = self.inference_model_inst.get_category(self.category_map[self.branch_data.category])
+        category_inst = config_inst.get_category(self.branch_data.category)
+        variable_inst = config_inst.get_variable(self.branch_data.variable).copy_shallow()
+        shapes = self.shape_data[self.category_map[self.branch_data.category]]
+        exclude_matcher = pattern_matcher(self.skip_processes) if self.skip_processes else (lambda proc_name: False)
+
+        # helper to sanitize histograms coming out of harvester shapes file
+        def sanitize_hist(h: hist.Hist) -> hist.Hist:
+            # check if bin edges align
+            edges_mismatch = (
+                h.axes[0].size != variable_inst.n_bins or
+                not np.allclose(h.axes[0].edges, variable_inst.bin_edges)
+            )
+            if edges_mismatch:
+                raise ValueError(
+                    f"edges of histogram for process '{proc_inst.name}' do not match the binning of variable "
+                    f"'{variable_inst.name}' in category '{category_inst.name}'"
+                    f"\nhistogram: {h.axes[0].edges}\nvariable : {variable_inst.bin_edges}",
+                )
+            # create a copy to
+            # - update variable name and label
+            # - add shift axis and use current values as "nominal" bin
+            # - remove variances that represent syst. uncs. but would be interpreted as stat. uncs. during plotting
+            h2 = create_hist_from_variables(
+                variable_inst,
+                categorical_axes=[("shift", "strcat", ["nominal"])],
+                weight=True,
+            )
+            h2.view(flow=True).value[...] = h.view(flow=True).value
+            return h2
+
+        # to be consistent to other plotting tasks, create a mapping "process -> hist"
+        proc_hists: ProcHists = {}
+        for proc_obj_name in shapes.processes:
+            proc_obj = self.inference_model_inst.get_process(process=proc_obj_name, category=cat_obj.name)
+            proc_name = proc_obj.config_data[config_inst.name].process
+            if exclude_matcher(proc_name):
+                continue
+            proc_inst = config_inst.get_process(proc_name)
+            proc_hists[proc_inst] = sanitize_hist(shapes.hist(proc_obj_name))
+        proc_hists[config_inst.get_process("data")] = sanitize_hist(shapes.data_hist)
+
+        # optional process merging and selection
+        if self.merge_processes:
+            orig_hists = proc_hists.copy()
+            proc_hists.clear()
+            for proc_name in self.merge_processes:
+                proc_inst = config_inst.get_process(proc_name)
+                _hists = []
+                for _proc_inst, h in list(orig_hists.items()):
+                    if _proc_inst == proc_inst or proc_inst.has_process(_proc_inst, deep=True):
+                        orig_hists.pop(_proc_inst)
+                        _hists.append(h)
+                if _hists:
+                    proc_hists[proc_inst] = sum_hists(_hists)
+                else:
+                    self.logger.warning(
+                        f"no processes histograms found to merge into process histogram '{proc_name}'; existing "
+                        f"processes were {','.join(p.name for p in orig_hists)}",
+                    )
+            if orig_hists and self.uncertainty != "none":
+                raise Exception(
+                    "the following processes were not merged into any of the specified merge processes which is "
+                    f"inconsistent when not using '--uncertainty none': {','.join(p.name for p in orig_hists)}",
+                )
+
+        # update histograms using custom hooks
+        proc_hists = self.invoke_hist_hooks(
+            {config_inst: proc_hists},
+            hook_kwargs={"category_name": category_inst.name, "variable_name": variable_inst.name},
+        )[config_inst]
+
+        # prepare error band
+        error_kwargs = {}
+        if self.uncertainty in {"bkg", "all"}:
+            h_unc = shapes.background_hist if self.uncertainty == "bkg" else shapes.total_hist
+            error_kwargs["custom_errors"] = h_unc.view().variance**0.5
+            error_kwargs["custom_error_label"] = "MC unc. (postfit)"
+            error_kwargs["custom_hatch_style"] = "black"
+
+        # copy process instances once so that their auxiliary data fields can be used as a storage for
+        # process-specific plot parameters later on in plot scripts without affecting the original instances
+        fake_root = od.Process(
+            name=f"{hex(id(object()))[2:]}",
+            id="+",
+            processes=list(proc_hists.keys()),
+        ).copy()
+        process_map = {proc_inst.name: proc_inst for proc_inst in fake_root.processes.values()}
+        fake_root.processes.clear()
+        proc_hists = {process_map[proc_inst.name]: h for proc_inst, h in proc_hists.items()}
+
+        # temporarily use a merged luminostiy value, assigned to the first config
+        if not config_inst.has_aux("lumi_plot_lock"):
+            config_inst.x.lumi_plot_lock = threading.RLock()
+        lumi = sum([_config_inst.x.luminosity for _config_inst in self.config_insts])
+
+        with law.util.patch_object(config_inst.x, "luminosity", lumi, lock=config_inst.x.lumi_plot_lock):
+            # call the plot function
+            fig, _ = self.call_plot_func(
+                self.plot_function,
+                hists=proc_hists,
+                category_inst=category_inst,
+                variable_insts=[variable_inst],
+                config_inst=config_inst,
+                shift_insts=[config_inst.get_shift("nominal")],
+                hide_stat_errors=True,
+                merge_stat_errors=False,
+                **error_kwargs,
+                **self.get_plot_parameters(),
+            )
+
+        # save the plot
+        for outp in self.output()["plots"]:
+            outp.dump(fig, formatter="mpl")

--- a/columnflow/tasks/plotting.py
+++ b/columnflow/tasks/plotting.py
@@ -853,65 +853,12 @@ class PlotVariablesBaseShiftsFromModel(
                 )))
             params["variables"] = tuple(variables)
 
-            # before evaluating categories, build a map "model category -> config categories"
-            full_catogory_map_rev = {
-                cat_obj.name: {
-                    config_data.category
-                    for config_name, config_data in cat_obj.config_data.items()
-                    if config_name in params["configs"]
-                }
-                for cat_obj in inference_model_inst.categories
-            }
-            full_category_map = {
-                cat_name: model_cat_name
-                for model_cat_name, cat_names in full_catogory_map_rev.items()
-                for cat_name in cat_names
-            }
-
-            # expand / default categories
-            category_map = {}
-            if (categories := params.get("categories")):
-                for cat_expr in categories:
-                    cat_pattern, model_cat_pattern = cat_expr.split(":", 1) if ":" in cat_expr else (cat_expr, None)
-
-                    # when model cat is a pattern, it should expand to exactly one actual name
-                    model_cat_name = None
-                    if model_cat_pattern:
-                        matcher = pattern_matcher(model_cat_pattern)
-                        for _model_cat_name in full_catogory_map_rev.keys():
-                            if matcher(_model_cat_name):
-                                if model_cat_name is not None:
-                                    raise Exception(
-                                        f"model category pattern '{model_cat_pattern}' matches multiple model "
-                                        f"categories ('{model_cat_name}' and '{_model_cat_name}'); please specify a "
-                                        "more specific pattern or use an exact name",
-                                    )
-                                model_cat_name = _model_cat_name
-                        if model_cat_name is None:
-                            raise Exception(
-                                f"model category pattern '{model_cat_pattern}' does not match any model category",
-                            )
-
-                    # expand category pattern
-                    cat_names = cls.find_config_objects(
-                        names=cat_pattern,
-                        container=config_insts,
-                        object_cls=od.Category,
-                        groups_str="category_groups",
-                        multi_strategy="intersection",
-                    )
-
-                    # fill the map
-                    for cat_name in cat_names:
-                        if model_cat_name is None and cat_name not in full_category_map:
-                            raise Exception(
-                                f"category '{cat_name}' is not defined in the inference model; using the syntax "
-                                "'CATEGORY:MODEL_CATEGORY', as MODEL_CATEGORY, specify any of "
-                                f"{','.join(full_catogory_map_rev)}",
-                            )
-                        category_map[cat_name] = model_cat_name or full_category_map[cat_name]
-            else:
-                category_map.update(full_category_map)
+            # expand categories
+            category_map = cls.resolve_model_category_map(
+                inference_model_inst=inference_model_inst,
+                config_insts=config_insts,
+                categories=params.get("categories"),
+            )
             params["categories"] = tuple(sorted(category_map.keys()))
             params["category_map"] = {cat_name: category_map[cat_name] for cat_name in params["categories"]}
 
@@ -927,6 +874,71 @@ class PlotVariablesBaseShiftsFromModel(
                 params["merge_processes"] = tuple(merge_processes)
 
         return params
+
+    @classmethod
+    def resolve_model_category_map(cls, inference_model_inst, config_insts, categories) -> dict[str, str]:
+        # before evaluating categories, build a map "model category -> config categories"
+        config_names = {config_inst.name for config_inst in config_insts}
+        full_catogory_map_rev = {
+            cat_obj.name: {
+                config_data.category
+                for config_name, config_data in cat_obj.config_data.items()
+                if config_name in config_names
+            }
+            for cat_obj in inference_model_inst.categories
+        }
+        full_category_map = {
+            cat_name: model_cat_name
+            for model_cat_name, cat_names in full_catogory_map_rev.items()
+            for cat_name in cat_names
+        }
+
+        # expand / default categories
+        category_map = {}
+        if categories:
+            for cat_expr in categories:
+                cat_pattern, model_cat_pattern = cat_expr.split(":", 1) if ":" in cat_expr else (cat_expr, None)
+
+                # when model cat is a pattern, it should expand to exactly one actual name
+                model_cat_name = None
+                if model_cat_pattern:
+                    matcher = pattern_matcher(model_cat_pattern)
+                    for _model_cat_name in full_catogory_map_rev.keys():
+                        if matcher(_model_cat_name):
+                            if model_cat_name is not None:
+                                raise Exception(
+                                    f"model category pattern '{model_cat_pattern}' matches multiple model "
+                                    f"categories ('{model_cat_name}' and '{_model_cat_name}'); please specify a "
+                                    "more specific pattern or use an exact name",
+                                )
+                            model_cat_name = _model_cat_name
+                    if model_cat_name is None:
+                        raise Exception(
+                            f"model category pattern '{model_cat_pattern}' does not match any model category",
+                        )
+
+                # expand category pattern
+                cat_names = cls.find_config_objects(
+                    names=cat_pattern,
+                    container=config_insts,
+                    object_cls=od.Category,
+                    groups_str="category_groups",
+                    multi_strategy="intersection",
+                )
+
+                # fill the map
+                for cat_name in cat_names:
+                    if model_cat_name is None and cat_name not in full_category_map:
+                        raise Exception(
+                            f"category '{cat_name}' is not defined in the inference model; using the syntax "
+                            "'CATEGORY:MODEL_CATEGORY', as MODEL_CATEGORY, specify any of "
+                            f"{','.join(full_catogory_map_rev)}",
+                        )
+                    category_map[cat_name] = model_cat_name or full_category_map[cat_name]
+        else:
+            category_map.update(full_category_map)
+
+        return category_map
 
     @property
     def processes_repr(self) -> str:


### PR DESCRIPTION
This PR adds a `cf.cms.PlotPostfitFromModel1D` task that - [given a shapes file produced by the combine harvester](https://cms-analysis.github.io/CombineHarvester/post-fit-shapes-ws.html) - produces postfit plots through common plot functions.

The task itself has no upstream requirements (as its input is solely extracted from combine harvester outputs) and provides various plotting options:

- `--shapes-file` → The shapes file produced by combine harvester.
- `--inference-model MODEL` → The underlying model to use.
- `--categories CATS,...` → Categories to plot; **note** that the inference model might define different uses for its own model categories; if the matching between requested (config) categories and model categories is **not straight forward**, each category in the sequence should be passed as `CONFIG_CAT:MODEL_CAT`, which provides the matching and thus, the assignment of nuisances to the requested category.
- `--uncertainty` → The type of combined uncertainty to show. Choices are "bkg" (default), "all" (background + signal), and "none".
- `--merge-processes` → When defined, processes extracted from the inference model are merged according to this comma-separated list of (parent) processes with pattern and group support.

@mafrahm @Lara813 @LennertGriesing @aalvesan @wolfmor @jomatthi 
feel free to review